### PR TITLE
DB To File 관련 배치 job 제거

### DIFF
--- a/src/main/java/com/springboot/main/EgovBootApplication.java
+++ b/src/main/java/com/springboot/main/EgovBootApplication.java
@@ -50,15 +50,9 @@ public class EgovBootApplication implements CommandLineRunner {
 		
 		List<String> jobPaths = new ArrayList<String>();
 
-		/*
-		 * 1. DB 실행 예제(DB To File)에서 사용 할 Batch Job이 기술 된 xml파일 경로들(jobPaths)
-		 */
-		jobPaths.add("/egovframework/batch/job/mybatisToDelimitedJob.xml");
-		jobPaths.add("/egovframework/batch/job/mybatisToFixedLengthJob.xml");
-		
-		/*
-		 * 2. DB 실행 예제(DB To DB)에서 사용 할 Batch Job이 기술 된 xml파일 경로들(jobPaths)
-		 */
+                /*
+                 * 2. DB 실행 예제(DB To DB)에서 사용 할 Batch Job이 기술 된 xml파일 경로들(jobPaths)
+                 */
 		jobPaths.add("/egovframework/batch/job/mybatisToMybatisJob.xml");
 		jobPaths.add("/egovframework/batch/job/jdbcToJdbcJob.xml");
 


### PR DESCRIPTION
## 요약
- DB To File 배치 작업 예제 주석과 관련 jobPaths 제거

## 테스트
- `mvn -q test` *(실패: parent POM을 내려받지 못함)*

------
https://chatgpt.com/codex/tasks/task_e_68946d8d1720832a96a3567bb389865d