### PR TITLE
스케줄러 작업 이름을 DB 간 이동용으로 수정

### DIFF
--- a/src/main/resources/egovframework/batch/context-scheduler-job.xml
+++ b/src/main/resources/egovframework/batch/context-scheduler-job.xml
@@ -7,7 +7,8 @@
 		<property name="group" value="quartz-batch" />
 		<property name="jobDataAsMap">
 			<map>
-				<entry key="jobName" value="mybatisToDelimitedJob" />
+                                <!-- DB에서 DB로 데이터 이동을 위한 작업 이름 설정 -->
+                                <entry key="jobName" value="mybatisToMybatisJob" />
 				<entry key="jobLocator" value-ref="jobRegistry" />
 				<entry key="jobLauncher" value-ref="jobLauncher" />
 			</map>


### PR DESCRIPTION
## 요약
- Quartz 스케줄러에서 실행할 배치 작업을 `mybatisToDelimitedJob`에서 `mybatisToMybatisJob`으로 변경
- DB 간 데이터 이동 작업임을 한국어 주석으로 설명

## 테스트
- `mvn -q test` *(네트워크 접근 불가로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68946f0c77d4832aabe310deccd6c86c