### PR TITLE
Remove HSQL references from globals.properties

### DIFF
--- a/src/main/resources/egovframework/batch/properties/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/globals.properties
@@ -14,42 +14,16 @@
 #-----------------------------------------------------------------------
 
 
-# DB\uc11c\ubc84 \ud0c0\uc785(Hsql,Mysql,Oracle,Altibase,Tibero) - datasource \uc9c0\uc815\uc5d0 \uc0ac\uc6a9\ub428
+# DB\uc11c\ubc84 \ud0c0\uc785(MySQL) - datasource \uc9c0\uc815\uc5d0 \uc0ac\uc6a9\ub428
 
-# DB\uc11c\ubc84 \ud0c0\uc785(hsql, mysql, oracle, altibase, tibero, cubrid) - datasource \ubc0f sqlMap \ud30c\uc77c \uc9c0\uc815\uc5d0 \uc0ac\uc6a9\ub428
-#Globals.DbType = hsql
+# DB\uc11c\ubc84 \ud0c0\uc785(mysql) - datasource \ubc0f sqlMap \ud30c\uc77c \uc9c0\uc815\uc5d0 \uc0ac\uc6a9\ub428
 Globals.DbType = mysql
 
 # \uc704\uc800\ub4dc \uc0ac\uc6a9\uc2dc \ub370\uc774\ud130\ubca0\uc774\uc2a4 \uad00\ub828 \uc124\uc815\uc744 \ubd88\ub7ec\uc634
-#hsql
 
-#mysql
+# MySQL 설정
 Globals.DriverClassName=net.sf.log4jdbc.DriverSpy
-#Globals.Url=jdbc:mysql://localhost:3306/migstg
 Globals.Url=jdbc:log4jdbc:mysql://localhost:3306/migstg
 Globals.UserName = miguser
 Globals.Password = mig!1234
 
-#oracle
-#Globals.DriverClassName=oracle.jdbc.driver.OracleDriver
-#Globals.Url=jdbc:oracle:thin:@127.0.0.1:1521:egovfrm
-#Globals.UserName = 
-#Globals.Password = 
-
-#Altibase
-#Globals.DriverClassName=Altibase.jdbc.driver.AltibaseDriver
-#Globals.Url=jdbc:Altibase://127.0.0.1:1721/egovfrm?encoding=UTF-8
-#Globals.UserName = 
-#Globals.Password = 
-
-#Tibero
-#Globals.DriverClassName=com.tmax.tibero.jdbc.TbDriver
-#Globals.Url=jdbc:tibero:thin:@127.0.0.1:1821:egovfrm
-#Globals.UserName = 
-#Globals.Password = 
-
-#cubrid
-#Globals.DriverClassName=cubrid.jdbc.driver.CUBRIDDriver
-#Globals.Url=jdbc:cubrid:127.0.0.1:33000:egovfrm:::?charset=utf-8
-#Globals.UserName = 
-#Globals.Password = 


### PR DESCRIPTION
## Summary
- remove unused HSQL comments and settings from `globals.properties`
- keep only active MySQL configuration

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689477bfc0f8832a86a6221a1a0d063b