### PR TITLE
불필요한 글로벌 DB 계정 속성 제거

### DIFF
--- a/src/main/resources/egovframework/batch/properties/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/globals.properties
@@ -19,10 +19,6 @@ Globals.DbType = mysql
 
 # MySQL \uc124\uc815
 Globals.DriverClassName=net.sf.log4jdbc.DriverSpy
-#Globals.Url=jdbc:mysql://localhost:3306/migstg
-Globals.Url=jdbc:log4jdbc:mysql://localhost:3306/migstg
-Globals.UserName = miguser
-Globals.Password = mig!1234
 
 # 원격 DB 접속 정보
 Globals.Remote.Url=jdbc:log4jdbc:mysql://remotehost:3306/migstg


### PR DESCRIPTION
## 요약
- globals.properties에서 기본 DB 접속 정보를 삭제

## 테스트
- `mvn -q test` (실패: parent POM을 받을 수 없음, 네트워크 문제)

------
https://chatgpt.com/codex/tasks/task_e_6895582d01e4832aadf433ee052bc3ee