### PR TITLE
환경별 프로퍼티와 Maven 프로필 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# 빌드 가이드
+
+이 프로젝트는 환경별 설정을 Maven 프로필로 관리합니다. 아래 명령을 사용하여 원하는 환경으로 빌드할 수 있습니다.
+
+```bash
+mvn -Plocal package   # 로컬 환경 빌드
+mvn -Pdev package     # 개발 환경 빌드
+mvn -Pprod package    # 운영 환경 빌드
+```
+
+각 프로필은 해당 환경의 `globals-<프로필>.properties` 파일을 사용하여 `globals.properties`를 생성합니다.

--- a/pom.xml
+++ b/pom.xml
@@ -161,15 +161,68 @@
 			<artifactId>cubrid</artifactId>
 			<version>10.2.0</version>
 		</dependency>-->
-	</dependencies>
+        </dependencies>
 
-	<build>
-		<defaultGoal>install</defaultGoal>
-		<directory>${basedir}/target</directory>
-		<finalName>egovframework.example.bat.template.db.scheduler</finalName>
-		<pluginManagement>
-			<plugins>
-				<plugin>
+        <!-- 프로필 정의 -->
+        <profiles>
+                <profile>
+                        <id>local</id>
+                        <properties>
+                                <spring.profiles.active>local</spring.profiles.active>
+                        </properties>
+                        <build>
+                                <filters>
+                                        <filter>src/main/resources/egovframework/batch/properties/globals-local.properties</filter>
+                                </filters>
+                        </build>
+                </profile>
+                <profile>
+                        <id>dev</id>
+                        <properties>
+                                <spring.profiles.active>dev</spring.profiles.active>
+                        </properties>
+                        <build>
+                                <filters>
+                                        <filter>src/main/resources/egovframework/batch/properties/globals-dev.properties</filter>
+                                </filters>
+                        </build>
+                </profile>
+                <profile>
+                        <id>prod</id>
+                        <properties>
+                                <spring.profiles.active>prod</spring.profiles.active>
+                        </properties>
+                        <build>
+                                <filters>
+                                        <filter>src/main/resources/egovframework/batch/properties/globals-prod.properties</filter>
+                                </filters>
+                        </build>
+                </profile>
+        </profiles>
+
+        <build>
+                <defaultGoal>install</defaultGoal>
+                <directory>${basedir}/target</directory>
+                <finalName>egovframework.example.bat.template.db.scheduler</finalName>
+                <resources>
+                        <resource>
+                                <directory>src/main/resources</directory>
+                                <filtering>true</filtering>
+                                <includes>
+                                        <include>egovframework/batch/properties/globals.properties</include>
+                                </includes>
+                        </resource>
+                        <resource>
+                                <directory>src/main/resources</directory>
+                                <filtering>false</filtering>
+                                <excludes>
+                                        <exclude>egovframework/batch/properties/globals.properties</exclude>
+                                </excludes>
+                        </resource>
+                </resources>
+                <pluginManagement>
+                        <plugins>
+                                <plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.13.0</version>

--- a/src/main/resources/egovframework/batch/properties/globals-dev.properties
+++ b/src/main/resources/egovframework/batch/properties/globals-dev.properties
@@ -1,0 +1,8 @@
+# 개발 환경 DB 설정
+# JDBC 드라이버
+db.driver=net.sf.log4jdbc.DriverSpy
+# 접속 URL
+db.url=jdbc:log4jdbc:mysql://dev.example.com:3306/egovdev
+# 계정 정보
+db.username=devuser
+db.password=dev!1234

--- a/src/main/resources/egovframework/batch/properties/globals-local.properties
+++ b/src/main/resources/egovframework/batch/properties/globals-local.properties
@@ -1,0 +1,8 @@
+# 로컬 환경 DB 설정
+# JDBC 드라이버
+db.driver=net.sf.log4jdbc.DriverSpy
+# 접속 URL
+db.url=jdbc:log4jdbc:mysql://localhost:3306/migstg
+# 계정 정보
+db.username=miguser
+db.password=mig!1234

--- a/src/main/resources/egovframework/batch/properties/globals-prod.properties
+++ b/src/main/resources/egovframework/batch/properties/globals-prod.properties
@@ -1,0 +1,8 @@
+# 운영 환경 DB 설정
+# JDBC 드라이버
+db.driver=com.mysql.cj.jdbc.Driver
+# 접속 URL
+db.url=jdbc:mysql://prod.example.com:3306/egovprod?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+# 계정 정보
+db.username=produser
+db.password=prod!1234

--- a/src/main/resources/egovframework/batch/properties/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/globals.properties
@@ -1,35 +1,23 @@
 #-----------------------------------------------------------------------
 #
-#   globals.properties : \uc2dc\uc2a4\ud15c
+#   globals.properties : 시스템 공통 설정
 #
 #-----------------------------------------------------------------------
-#   1.  key = value \uad6c\uc870\uc785\ub2c8\ub2e4.
-#   2.  key\uac12\uc740 \uacf5\ubc31\ubb38\uc790\ub97c \ud3ec\ud568\ubd88\uac00, value\uac12\uc740 \uacf5\ubc31\ubb38\uc790\ub97c \uac00\ub2a5
-#   3.  key\uac12\uc73c\ub85c \ud55c\uae00\uc744 \uc0ac\uc6a9\ubd88\uac00,   value\uac12\uc740 \ud55c\uae00\uc0ac\uc6a9\uc774 \uac00\ub2a5
-#   4.  \uc904\uc744 \ubc14\uafc0 \ud544\uc694\uac00 \uc788\uc73c\uba74 '\'\ub97c \ub77c\uc778\uc758 \ub05d\uc5d0 \ucd94\uac00(\ub9cc\uc57d  '\'\ubb38\uc790\ub97c \uc0ac\uc6a9\ud574\uc57c \ud558\ub294 \uacbd\uc6b0\ub294 '\\'\ub97c \uc0ac\uc6a9)
-#   5.  Windows\uc5d0\uc11c\uc758 \ub514\ub809\ud1a0\ub9ac \ud45c\uc2dc : '\\' or '/'  ('\' \uc0ac\uc6a9\ud558\uba74 \uc548\ub428)
-#   6.  Unix\uc5d0\uc11c\uc758 \ub514\ub809\ud1a0\ub9ac \ud45c\uc2dc : '/'
-#   7.  \uc8fc\uc11d\ubb38 \ucc98\ub9ac\ub294  #\uc0ac\uc6a9
-#   8.  value\uac12 \ub4a4\uc5d0 \uc2a4\ud398\uc774\uc2a4\uac00 \uc874\uc7ac\ud558\ub294 \uacbd\uc6b0 \uc11c\ube14\ub9bf\uc5d0\uc11c \ucc38\uc870\ud560\ub54c\ub294 \uc5d0\ub7ec\ubc1c\uc0dd\ud560 \uc218 \uc788\uc73c\ubbc0\ub85c trim()\ud558\uac70\ub098 \ub9c8\uc9c0\ub9c9 \uacf5\ubc31\uc5c6\uc774 properties \uac12\uc744 \uc124\uc815\ud560\uac83
+#   1.  key = value 구조입니다.
+#   2.  key값은 공백문자를 포함불가, value값은 공백문자 가능
+#   3.  key값으로 한글을 사용불가, value값은 한글사용이 가능
+#   4.  줄을 바꿀 필요가 있으면 '\'를 라인의 끝에 추가(만약  '\'문자를 사용해야 하는 경우는 '\\'를 사용)
+#   5.  Windows에서의 디렉토리 표시 : '\\' or '/'  ('\' 사용하면 안됨)
+#   6.  Unix에서의 디렉토리 표시 : '/'
+#   7.  주석문 처리는  #사용
+#   8.  value값 뒤에 스페이스가 존재하는 경우 서버에서 참조할때는 에러발생할 수 있으므로 trim()하거나 마지막 공백없이 properties 값을 설정할것
 #-----------------------------------------------------------------------
 
-
-# DB\uc11c\ubc84 \ud0c0\uc785(mysql) - datasource \ubc0f sqlMap \ud30c\uc77c \uc9c0\uc815\uc5d0 \uc0ac\uc6a9\ub428
+# DB서버 타입(mysql) - datasource 및 sqlMap 파일 지정에 사용됨
 Globals.DbType = mysql
 
-# \uc6d0\uaca9 DB \uc811\uc18d \uc815\ubcf4
-#Globals.Remote.DriverClassName=com.mysql.cj.jdbc.Driver
-#Globals.Remote.Url=jdbc:mysql://localhost:3306/migstg?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
-Globals.Remote.DriverClassName=net.sf.log4jdbc.DriverSpy
-Globals.Remote.Url=jdbc:log4jdbc:mysql://localhost:3306/egovremote1
-Globals.Remote.UserName=miguser
-Globals.Remote.Password=mig!1234
-
-# \ub85c\uceec DB \uc811\uc18d \uc815\ubcf4
-#Globals.Local.DriverClassName=com.mysql.cj.jdbc.Driver
-#Globals.Local.Url=jdbc:mysql://localhost:3306/migstg?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
-Globals.Local.DriverClassName=net.sf.log4jdbc.DriverSpy
-Globals.Local.Url=jdbc:log4jdbc:mysql://localhost:3306/migstg
-Globals.Local.UserName=miguser
-Globals.Local.Password=mig!1234
-
+# DB 연결 정보 - 프로필별 필터에서 치환됨
+Globals.DriverClassName=@db.driver@
+Globals.Url=@db.url@
+Globals.UserName=@db.username@
+Globals.Password=@db.password@


### PR DESCRIPTION
## 요약
- DB 접속 정보를 환경별 프로퍼티 파일로 분리
- Maven 프로필과 리소스 필터링으로 `globals.properties` 생성
- 환경별 빌드 방법을 README에 추가

## 테스트
- `mvn -Plocal package` 실행 시 의존성 다운로드 실패로 빌드 불가 (네트워크 문제)


------
https://chatgpt.com/codex/tasks/task_e_6895615dcdf8832a84b0290b9fb3b2c6