### PR TITLE
환경별 globals.properties 복사 프로필 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,9 +161,37 @@
 			<artifactId>cubrid</artifactId>
 			<version>10.2.0</version>
 		</dependency>-->
-	</dependencies>
+</dependencies>
 
-	<build>
+        <!-- 환경별 프로필 설정 -->
+        <profiles>
+                <!-- 로컬: 기본 활성화 -->
+                <profile>
+                        <id>local</id>
+                        <activation>
+                                <activeByDefault>true</activeByDefault>
+                        </activation>
+                        <properties>
+                                <env>local</env>
+                        </properties>
+                </profile>
+                <!-- 개발 환경 -->
+                <profile>
+                        <id>dev</id>
+                        <properties>
+                                <env>dev</env>
+                        </properties>
+                </profile>
+                <!-- 운영 환경 -->
+                <profile>
+                        <id>prod</id>
+                        <properties>
+                                <env>prod</env>
+                        </properties>
+                </profile>
+        </profiles>
+
+        <build>
 		<defaultGoal>install</defaultGoal>
 		<directory>${basedir}/target</directory>
 		<finalName>egovframework.example.bat.template.db.scheduler</finalName>
@@ -193,9 +221,43 @@
 					<version>3.23.0</version>
 				</plugin>
 			</plugins>
-		</pluginManagement>
-		<plugins>
-			<!-- EMMA -->
+                </pluginManagement>
+                <plugins>
+                        <!-- 환경별 globals-*.properties 파일을 globals.properties로 복사 -->
+                        <plugin>
+                                <artifactId>maven-resources-plugin</artifactId>
+                                <version>3.3.1</version>
+                                <executions>
+                                        <execution>
+                                                <id>copy-globals</id>
+                                                <phase>process-resources</phase>
+                                                <goals>
+                                                        <goal>copy-resources</goal>
+                                                </goals>
+                                                <configuration>
+                                                        <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                                                        <resources>
+                                                                <resource>
+                                                                        <directory>src/main/resources</directory>
+                                                                        <includes>
+                                                                                <include>globals-${env}.properties</include>
+                                                                        </includes>
+                                                                        <filtering>false</filtering>
+                                                                </resource>
+                                                        </resources>
+                                                        <flatten>true</flatten>
+                                                        <overwrite>true</overwrite>
+                                                        <transformers>
+                                                                <transformer implementation="org.apache.maven.plugins.resources.transformer.RenameRegExpTransformer">
+                                                                        <regExp>globals-${env}.properties</regExp>
+                                                                        <replacement>globals.properties</replacement>
+                                                                </transformer>
+                                                        </transformers>
+                                                </configuration>
+                                        </execution>
+                                </executions>
+                        </plugin>
+                        <!-- EMMA -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/resources/globals-dev.properties
+++ b/src/main/resources/globals-dev.properties
@@ -1,0 +1,5 @@
+# 개발 환경용 글로벌 설정
+# 실제 개발 환경 값으로 수정하세요
+db.url=jdbc:example://dev-server:3306/devdb
+db.username=devuser
+db.password=devpass

--- a/src/main/resources/globals-local.properties
+++ b/src/main/resources/globals-local.properties
@@ -1,0 +1,5 @@
+# 로컬 환경용 글로벌 설정
+# 실제 로컬 환경 값으로 수정하세요
+db.url=jdbc:example://localhost:3306/localdb
+db.username=localuser
+db.password=localpass

--- a/src/main/resources/globals-prod.properties
+++ b/src/main/resources/globals-prod.properties
@@ -1,0 +1,5 @@
+# 운영 환경용 글로벌 설정
+# 실제 운영 환경 값으로 수정하세요
+db.url=jdbc:example://prod-server:3306/proddb
+db.username=produser
+db.password=prodpass


### PR DESCRIPTION
### 요약
- Maven 프로필을 추가하여 실행 환경별 globals-*.properties를 자동으로 globals.properties로 복사하도록 설정
- 로컬/개발/운영 환경에 대한 예시 globals-*.properties 파일 추가

### 테스트
- `mvn -q package` (부모 POM을 다운로드하지 못해 실패)

------
https://chatgpt.com/codex/tasks/task_e_68957a976d44832a9ea0d995c26a6ea9