### PR TITLE
환경별 글로벌 속성 파일 경로 변경

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
 			</plugins>
 		</pluginManagement>
 		<plugins>
-			<!-- 환경별 globals-*.properties 파일을 globals.properties로 복사 -->
+                        <!-- 환경별 globals-*.properties 파일을 egovframework/batch/properties에서 globals.properties로 복사 -->
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
 				<version>3.3.1</version>
@@ -237,13 +237,13 @@
 						<configuration>
 							<outputDirectory>${project.build.outputDirectory}</outputDirectory>
 							<resources>
-								<resource>
-									<directory>src/main/resources</directory>
-									<includes>
-										<include>globals-${env}.properties</include>
-									</includes>
-									<filtering>false</filtering>
-								</resource>
+                                                                <resource>
+                                                                        <directory>src/main/resources/egovframework/batch/properties</directory>
+                                                                        <includes>
+                                                                                <include>globals-${env}.properties</include>
+                                                                        </includes>
+                                                                        <filtering>false</filtering>
+                                                                </resource>
 							</resources>
 							<flatten>true</flatten>
 							<overwrite>true</overwrite>

--- a/src/main/resources/globals-dev.properties
+++ b/src/main/resources/globals-dev.properties
@@ -1,5 +1,0 @@
-# 개발 환경용 글로벌 설정
-# 실제 개발 환경 값으로 수정하세요
-db.url=jdbc:example://dev-server:3306/devdb
-db.username=devuser
-db.password=devpass


### PR DESCRIPTION
## 요약
- 빌드 시 globals-*.properties 복사 경로를 `egovframework/batch/properties`로 변경
- 사용되지 않는 `globals-dev.properties` 삭제

## 테스트
- `mvn -q -Denv=dev package` *(네트워크 문제로 의존성 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_689584ed6704832abab8d6ae84889ee1