### PR TITLE
환경별 globals.properties 리소스 설정 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,10 +179,14 @@
 			</resource>
 
 			<!-- 환경별 리소스: env/${env} 폴더의 globals.properties만 클래스패스에 포함 -->
-			<resource>
-				<directory>src/main/resources/egovframework/batch/properties/env/${env}</directory>
-				<filtering>false</filtering>
-			</resource>
+                        <resource>
+                                <directory>src/main/resources/egovframework/batch/properties/env/${env}</directory>
+                                <targetPath>egovframework/batch/properties</targetPath>
+                                <includes>
+                                        <include>globals.properties</include>
+                                </includes>
+                                <filtering>false</filtering>
+                        </resource>
 		</resources>
 
 		<defaultGoal>install</defaultGoal>


### PR DESCRIPTION
## 변경 내용
- env별 globals.properties만 클래스패스에 포함되도록 pom.xml 리소스 설정 보강

## 테스트
- `mvn -Plocal package` (네트워크 문제로 parent POM을 내려받지 못해 실패)


------
https://chatgpt.com/codex/tasks/task_e_689aa1c8d794832aa52b0623fcd6f8ca