### PR TITLE
조직 정보 복사 스텝 추가

### DIFF
--- a/src/main/resources/egovframework/batch/job/remoteToLocalJob.xml
+++ b/src/main/resources/egovframework/batch/job/remoteToLocalJob.xml
@@ -8,6 +8,14 @@
 
     <!-- commit-interval 값은 일반적으로 500~1000으로 설정함 -->
     <job id="remoteToLocalJob" parent="eGovBaseJob" xmlns="http://www.springframework.org/schema/batch">
+        <!-- 조직 정보를 먼저 복사한 후 사원 정보를 복사 -->
+        <step id="remoteToLocalOrgnztStep" parent="eGovBaseStep" next="remoteToLocalStep">
+            <tasklet>
+                <chunk reader="remoteToLocalJob.remoteToLocalOrgnztStep.mybatisItemReader"
+                       writer="remoteToLocalJob.remoteToLocalOrgnztStep.mybatisItemWriter"
+                       commit-interval="500" />
+            </tasklet>
+        </step>
         <step id="remoteToLocalStep" parent="eGovBaseStep">
             <tasklet>
                 <chunk reader="remoteToLocalJob.remoteToLocalStep.mybatisItemReader"
@@ -16,6 +24,19 @@
             </tasklet>
         </step>
     </job>
+
+    <bean id="remoteToLocalJob.remoteToLocalOrgnztStep.mybatisItemReader" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader" scope="step">
+        <!-- 원격 DB에서 조직 정보 목록을 조회 -->
+        <property name="sqlSessionFactory" ref="sqlSessionFactory-remote" />
+        <property name="queryId" value="Employee.selectOrgnztList" />
+        <property name="pageSize" value="#{100}" />
+    </bean>
+
+    <bean id="remoteToLocalJob.remoteToLocalOrgnztStep.mybatisItemWriter" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter">
+        <!-- 로컬 DB에 조직 정보 적재 -->
+        <property name="sqlSessionFactory" ref="sqlSessionFactory-local" />
+        <property name="statementId" value="Employee.insertOrganization" />
+    </bean>
 
     <bean id="remoteToLocalJob.remoteToLocalStep.mybatisItemReader" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader" scope="step">
         <!-- 원격 DB 읽기를 위해 remote SqlSessionFactory 사용 -->


### PR DESCRIPTION
## Summary
- 조직 정보를 먼저 복사하는 `remoteToLocalOrgnztStep` 스텝 추가
- 조직 정보 조회/적재용 MyBatis ItemReader, ItemWriter 빈 정의

## Testing
- `mvn -q test` *(실패: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d62af0b64832a83243ea490a0f273