### PR TITLE
인사 도메인 패키지 분리 및 매퍼 경로 수정

### DIFF
--- a/src/main/java/egovframework/bat/domain/insa/EmployeeInfo.java
+++ b/src/main/java/egovframework/bat/domain/insa/EmployeeInfo.java
@@ -1,4 +1,4 @@
-package egovframework.example.bat.domain.insa;
+package egovframework.bat.domain.insa;
 
 import java.util.Date;
 

--- a/src/main/java/egovframework/bat/domain/insa/Orgnztinfo.java
+++ b/src/main/java/egovframework/bat/domain/insa/Orgnztinfo.java
@@ -1,4 +1,4 @@
-package egovframework.example.bat.domain.insa;
+package egovframework.bat.domain.insa;
 
 import lombok.Data;
 

--- a/src/main/resources/egovframework/batch/context-batch-mapper.xml
+++ b/src/main/resources/egovframework/batch/context-batch-mapper.xml
@@ -13,7 +13,7 @@
 	        <property name="mapperLocations">
 	            <list>
 	                <value>classpath:/egovframework/mapper/example/bat/Egov_Example_SQL.xml</value>
-	                <value>classpath:/egovframework/mapper/example/bat/Insa_SQL.xml</value>
+	                <value>classpath:/egovframework/mapper/bat/Insa_SQL.xml</value>
 	            </list>
 	        </property>
         </bean>
@@ -26,7 +26,7 @@
 	        <property name="mapperLocations">
 	            <list>
 	                <value>classpath:/egovframework/mapper/example/bat/Egov_Example_SQL.xml</value>
-	                <value>classpath:/egovframework/mapper/example/bat/Insa_SQL.xml</value>
+	                <value>classpath:/egovframework/mapper/bat/Insa_SQL.xml</value>
 	            </list>
 	        </property>
         </bean>

--- a/src/main/resources/egovframework/mapper/bat/Insa_SQL.xml
+++ b/src/main/resources/egovframework/mapper/bat/Insa_SQL.xml
@@ -3,7 +3,7 @@
 
 <mapper namespace="Employee">
 
-	<select id="selectOrgnztList" resultType="egovframework.example.bat.domain.insa.Orgnztinfo">
+	<select id="selectOrgnztList" resultType="egovframework.bat.domain.insa.Orgnztinfo">
 		SELECT
 			 ORGNZT_ID,
 			 ORGNZT_NM,
@@ -11,7 +11,7 @@
 		FROM COMTNORGNZTINFO
 	</select>
 
-	<select id="selectEmployeeList" resultType="egovframework.example.bat.domain.insa.EmployeeInfo">
+	<select id="selectEmployeeList" resultType="egovframework.bat.domain.insa.EmployeeInfo">
 		SELECT
 			 EMPLYR_ID,
 			 ORGNZT_ID,
@@ -27,7 +27,7 @@
 		FROM COMTNEMPLYRINFO
 	</select>
 
-	<insert id="insertOrganization" parameterType="egovframework.example.bat.domain.insa.EmployeeInfo">
+	<insert id="insertOrganization" parameterType="egovframework.bat.domain.insa.EmployeeInfo">
 		INSERT INTO COMTNORGNZTINFO (ORGNZT_ID, ORGNZT_NM, ORGNZT_DC)
 				VALUES (#{orgnztId}, #{orgnztNm}, #{orgnztDc})
 			ON DUPLICATE KEY UPDATE
@@ -35,7 +35,7 @@
 				ORGNZT_DC = VALUES(ORGNZT_DC)
 	</insert>
 
-	<insert id="insertEmployee" parameterType="egovframework.example.bat.domain.insa.EmployeeInfo">
+	<insert id="insertEmployee" parameterType="egovframework.bat.domain.insa.EmployeeInfo">
 		INSERT INTO COMTNEMPLYRINFO
 			(EMPLYR_ID, ORGNZT_ID, USER_NM, SEXDSTN_CODE, BRTHDY, MBTLNUM, EMAIL_ADRES, OFCPS_NM, EMPLYR_STTUS_CODE, REG_DTTM, MOD_DTTM)
 		VALUES


### PR DESCRIPTION
## 요약
- 인사 VO 클래스를 example 패키지에서 분리
- 인사 매퍼 XML을 새 경로로 이동하고 참조 수정

## 테스트
- `mvn -q test` *(네트워크 문제로 부모 POM을 받아오지 못해 실패)*

------
https://chatgpt.com/codex/tasks/task_e_689d67d3ca04832abdd51b9e4325bdb2