### PR TITLE
STG 데이터소스 및 세션팩토리 추가

### DIFF
--- a/src/main/resources/egovframework/batch/context-batch-datasource.xml
+++ b/src/main/resources/egovframework/batch/context-batch-datasource.xml
@@ -24,6 +24,14 @@
         <property name="password" value="${Globals.Remote.Password}"/>
     </bean>
 
+    <!-- 스테이징 DB 데이터소스 -->
+    <bean id="dataSource-stg" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+        <property name="driverClassName" value="${Globals.Stg.DriverClassName}"/>
+        <property name="url" value="${Globals.Stg.Url}" />
+        <property name="username" value="${Globals.Stg.UserName}"/>
+        <property name="password" value="${Globals.Stg.Password}"/>
+    </bean>
+
     <bean id="dataSource-local" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
         <property name="driverClassName" value="${Globals.Local.DriverClassName}"/>
         <property name="url" value="${Globals.Local.Url}" />

--- a/src/main/resources/egovframework/batch/context-batch-mapper.xml
+++ b/src/main/resources/egovframework/batch/context-batch-mapper.xml
@@ -7,8 +7,8 @@
 
         <!-- 원격 DB용 SqlSessionFactory -->
         <bean id="sqlSessionFactory-remote" class="org.mybatis.spring.SqlSessionFactoryBean">
-	        <property name="dataSource" ref="dataSource-remote"/>
-	        <property name="configLocation" value="classpath:/egovframework/mapper/config/mapper-config.xml" />
+                <property name="dataSource" ref="dataSource-remote"/>
+                <property name="configLocation" value="classpath:/egovframework/mapper/config/mapper-config.xml" />
 	
 	        <property name="mapperLocations">
 	            <list>
@@ -16,6 +16,19 @@
 	                <value>classpath:/egovframework/mapper/bat/Insa_SQL.xml</value>
 	            </list>
 	        </property>
+        </bean>
+
+        <!-- 스테이징 DB용 SqlSessionFactory -->
+        <bean id="sqlSessionFactory-stg" class="org.mybatis.spring.SqlSessionFactoryBean">
+                <property name="dataSource" ref="dataSource-stg"/>
+                <property name="configLocation" value="classpath:/egovframework/mapper/config/mapper-config.xml" />
+
+                <property name="mapperLocations">
+                    <list>
+                        <value>classpath:/egovframework/mapper/example/bat/Egov_Example_SQL.xml</value>
+                        <value>classpath:/egovframework/mapper/bat/Insa_SQL.xml</value>
+                    </list>
+                </property>
         </bean>
 
         <!-- 로컬 DB용 SqlSessionFactory -->

--- a/src/main/resources/egovframework/batch/properties/env/dev/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/env/dev/globals.properties
@@ -29,3 +29,9 @@ Globals.Remote.Url=jdbc:mysql://\uac1c\ubc1c\uc6d0\uaca9IP\uc785\ub825:3306/egov
 Globals.Remote.UserName=readuser
 Globals.Remote.Password=read!1234
 
+# STG DB 접속 정보
+Globals.Stg.DriverClassName=com.mysql.cj.jdbc.Driver
+Globals.Stg.Url=jdbc:mysql://개발STGIP입력:3306/migstg?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+Globals.Stg.UserName=stguser
+Globals.Stg.Password=stg!1234
+

--- a/src/main/resources/egovframework/batch/properties/env/local/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/env/local/globals.properties
@@ -29,3 +29,9 @@ Globals.Remote.Url=jdbc:log4jdbc:mysql://localhost:3306/egovremote1
 Globals.Remote.UserName=readuser
 Globals.Remote.Password=read!1234
 
+# STG DB 접속 정보
+Globals.Stg.DriverClassName=net.sf.log4jdbc.DriverSpy
+Globals.Stg.Url=jdbc:log4jdbc:mysql://localhost:3306/migstg
+Globals.Stg.UserName=stguser
+Globals.Stg.Password=stg!1234
+

--- a/src/main/resources/egovframework/batch/properties/env/prod/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/env/prod/globals.properties
@@ -29,3 +29,9 @@ Globals.Remote.Url=jdbc:mysql://\uc6b4\uc601\uc6d0\uaca9IP\uc785\ub825:3306/egov
 Globals.Remote.UserName=readuser
 Globals.Remote.Password=read!1234
 
+# STG DB 접속 정보
+Globals.Stg.DriverClassName=com.mysql.cj.jdbc.Driver
+Globals.Stg.Url=jdbc:mysql://운영STGIP입력:3306/migstg?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+Globals.Stg.UserName=stguser
+Globals.Stg.Password=stg!1234
+


### PR DESCRIPTION
## 요약
- STG 환경용 `dataSource-stg` 빈과 연결 정보 추가
- STG 환경용 `sqlSessionFactory-stg` 생성 및 데이터소스 연결
- dev/local/prod 환경 `globals.properties`에 STG 접속 정보 정의

## 테스트
- `mvn -q test` (네트워크 미가용으로 부모 POM을 받을 수 없어 실패)

------
https://chatgpt.com/codex/tasks/task_e_68a28440c564832a9d1ae1c0bc9071f6