### PR TITLE
스테이징 데이터 로컬 적재 배치 추가

### DIFF
--- a/src/main/java/egovframework/bat/domain/insa/EmployeeInfo.java
+++ b/src/main/java/egovframework/bat/domain/insa/EmployeeInfo.java
@@ -10,16 +10,19 @@ import lombok.Data;
 @Data
 public class EmployeeInfo {
 
-    private String emplyrId;		/** 업무사용자ID */
-    private String orgnztId;		/** 조직ID */
-    private String userNm;			/** 사용자명 */
-    private String sexdstnCode;		/** 성별코드 */
-    private String brthdy;			/** 생일 */
-    private String mbtlnum;			/** 이동전화번호 */
-    private String emailAdres;		/** 이메일주소 */
-    private String ofcpsNm;			/** 직위명 */
-    private String emplyrSttusCode;	/** 사용자상태코드 */
-    private Date regDttm;			/** 등록일자 */
-    private Date modDttm;			/** 수정일자 */
+    private String esntlId;            /** 고유ID */
+    private String sourceSystem;       /** 원천시스템 */
+    private String emplyrId;           /** 업무사용자ID */
+    private String orgnztId;           /** 조직ID */
+    private String userNm;             /** 사용자명 */
+    private String sexdstnCode;        /** 성별코드 */
+    private String brthdy;             /** 생일 */
+    private String mbtlnum;            /** 이동전화번호 */
+    private String emailAdres;         /** 이메일주소 */
+    private String ofcpsNm;            /** 직위명 */
+    private String emplyrSttusCode;    /** 사용자상태코드 */
+    private Date regDttm;              /** 등록일자 */
+    private Date modDttm;              /** 수정일자 */
 
 }
+

--- a/src/main/java/egovframework/bat/domain/insa/EmployeeInfoProcessor.java
+++ b/src/main/java/egovframework/bat/domain/insa/EmployeeInfoProcessor.java
@@ -1,0 +1,21 @@
+package egovframework.bat.domain.insa;
+
+import java.util.UUID;
+
+import org.springframework.batch.item.ItemProcessor;
+
+/**
+ * ESNTL_ID와 SOURCE_SYSTEM 값을 세팅하는 프로세서
+ */
+public class EmployeeInfoProcessor implements ItemProcessor<EmployeeInfo, EmployeeInfo> {
+
+    @Override
+    public EmployeeInfo process(EmployeeInfo item) throws Exception {
+        // 고유ID를 UUID로 생성
+        item.setEsntlId(UUID.randomUUID().toString());
+        // 원천시스템 값을 STG로 설정
+        item.setSourceSystem("STG");
+        return item;
+    }
+}
+

--- a/src/main/resources/egovframework/batch/job/stgToLocalJob.xml
+++ b/src/main/resources/egovframework/batch/job/stgToLocalJob.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+        http://www.springframework.org/schema/batch D:\\DEV\\xsd\\spring-batch-3.0.xsd">
+        <!-- http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-3.0.xsd -->
+
+    <import resource="abstract/eGovBase.xml" />
+
+    <!-- commit-interval 값은 일반적으로 500~1000으로 설정함 -->
+    <job id="stgToLocalJob" parent="eGovBaseJob" xmlns="http://www.springframework.org/schema/batch">
+        <!-- 조직 정보를 먼저 복사한 후 사원 정보를 복사 -->
+        <step id="stgToLocalOrgnztStep" parent="eGovBaseStep" next="stgToLocalStep">
+            <tasklet>
+                <chunk reader="stgToLocalJob.stgToLocalOrgnztStep.mybatisItemReader"
+                       writer="stgToLocalJob.stgToLocalOrgnztStep.mybatisItemWriter"
+                       commit-interval="500" />
+            </tasklet>
+        </step>
+        <step id="stgToLocalStep" parent="eGovBaseStep">
+            <tasklet>
+                <chunk reader="stgToLocalJob.stgToLocalStep.mybatisItemReader"
+                       processor="stgToLocalJob.stgToLocalStep.itemProcessor"
+                       writer="stgToLocalJob.stgToLocalStep.mybatisItemWriter"
+                       commit-interval="500" />
+            </tasklet>
+        </step>
+    </job>
+
+    <bean id="stgToLocalJob.stgToLocalOrgnztStep.mybatisItemReader" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader" scope="step">
+        <!-- 스테이징 DB에서 조직 정보 목록을 조회 -->
+        <property name="sqlSessionFactory" ref="sqlSessionFactory-stg" />
+        <property name="queryId" value="Employee.selectOrgnztList" />
+        <property name="pageSize" value="#{100}" />
+    </bean>
+
+    <bean id="stgToLocalJob.stgToLocalOrgnztStep.mybatisItemWriter" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter">
+        <!-- 로컬 DB에 조직 정보 적재 -->
+        <property name="sqlSessionFactory" ref="sqlSessionFactory-local" />
+        <property name="statementId" value="Employee.insertOrganization" />
+    </bean>
+
+    <bean id="stgToLocalJob.stgToLocalStep.mybatisItemReader" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader" scope="step">
+        <!-- 스테이징 DB 읽기를 위해 stg SqlSessionFactory 사용 -->
+        <property name="sqlSessionFactory" ref="sqlSessionFactory-stg" />
+        <property name="queryId" value="Employee.selectEmployeeList" />
+        <property name="pageSize" value="#{100}" />
+    </bean>
+
+    <bean id="stgToLocalJob.stgToLocalStep.mybatisItemWriter" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter">
+        <!-- 로컬 DB 적재를 위해 local SqlSessionFactory 사용 -->
+        <property name="sqlSessionFactory" ref="sqlSessionFactory-local" />
+        <property name="statementId" value="Employee.insertEmployee" />
+    </bean>
+
+    <bean id="stgToLocalJob.stgToLocalStep.itemProcessor" class="egovframework.bat.domain.insa.EmployeeInfoProcessor" />
+
+</beans>
+

--- a/src/main/resources/egovframework/mapper/bat/Insa_SQL.xml
+++ b/src/main/resources/egovframework/mapper/bat/Insa_SQL.xml
@@ -35,22 +35,23 @@
 				ORGNZT_DC = VALUES(ORGNZT_DC)
 	</insert>
 
-	<insert id="insertEmployee" parameterType="egovframework.bat.domain.insa.EmployeeInfo">
-		INSERT INTO COMTNEMPLYRINFO
-			(EMPLYR_ID, ORGNZT_ID, USER_NM, SEXDSTN_CODE, BRTHDY, MBTLNUM, EMAIL_ADRES, OFCPS_NM, EMPLYR_STTUS_CODE, REG_DTTM, MOD_DTTM)
-		VALUES
-			(#{emplyrId}, #{orgnztId}, #{userNm}, #{sexdstnCode}, #{brthdy}, #{mbtlnum}, #{emailAdres}, #{ofcpsNm}, #{emplyrSttusCode}, #{regDttm}, #{modDttm})
-		ON DUPLICATE KEY UPDATE
-			ORGNZT_ID = VALUES(ORGNZT_ID),
-			USER_NM = VALUES(USER_NM),
-			SEXDSTN_CODE = VALUES(SEXDSTN_CODE),
-			BRTHDY = VALUES(BRTHDY),
-			MBTLNUM = VALUES(MBTLNUM),
-			EMAIL_ADRES = VALUES(EMAIL_ADRES),
-			OFCPS_NM = VALUES(OFCPS_NM),
-			EMPLYR_STTUS_CODE = VALUES(EMPLYR_STTUS_CODE),
-			REG_DTTM = VALUES(REG_DTTM),
-			MOD_DTTM = VALUES(MOD_DTTM)
-	</insert>
+        <insert id="insertEmployee" parameterType="egovframework.bat.domain.insa.EmployeeInfo">
+                INSERT INTO COMTNEMPLYRINFO
+                        (ESNTL_ID, SOURCE_SYSTEM, EMPLYR_ID, ORGNZT_ID, USER_NM, SEXDSTN_CODE, BRTHDY, MBTLNUM, EMAIL_ADRES, OFCPS_NM, EMPLYR_STTUS_CODE, REG_DTTM, MOD_DTTM)
+                VALUES
+                        (#{esntlId}, #{sourceSystem}, #{emplyrId}, #{orgnztId}, #{userNm}, #{sexdstnCode}, #{brthdy}, #{mbtlnum}, #{emailAdres}, #{ofcpsNm}, #{emplyrSttusCode}, #{regDttm}, #{modDttm})
+                ON DUPLICATE KEY UPDATE
+                        ORGNZT_ID = VALUES(ORGNZT_ID),
+                        USER_NM = VALUES(USER_NM),
+                        SEXDSTN_CODE = VALUES(SEXDSTN_CODE),
+                        BRTHDY = VALUES(BRTHDY),
+                        MBTLNUM = VALUES(MBTLNUM),
+                        EMAIL_ADRES = VALUES(EMAIL_ADRES),
+                        OFCPS_NM = VALUES(OFCPS_NM),
+                        EMPLYR_STTUS_CODE = VALUES(EMPLYR_STTUS_CODE),
+                        SOURCE_SYSTEM = VALUES(SOURCE_SYSTEM),
+                        REG_DTTM = VALUES(REG_DTTM),
+                        MOD_DTTM = VALUES(MOD_DTTM)
+        </insert>
 
 </mapper>


### PR DESCRIPTION
## 요약
- 스테이징 DB 데이터를 로컬 DB로 적재하는 `stgToLocalJob` 배치 구성
- 직원 이관 시 ESNTL_ID와 SOURCE_SYSTEM을 채우는 `EmployeeInfoProcessor` 추가
- MyBatis 매퍼에 신규 컬럼 매핑 및 VO 필드 확장

## 테스트
- `mvn -q -e test` *(네트워크 문제로 parent POM을 받을 수 없어 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68a28521ad3c832a9f8628921523be4f