### PR TITLE
직원 배치에 ESNTL_ID·SOURCE_SYSTEM 지원 추가

### DIFF
--- a/src/main/resources/egovframework/batch/job/remoteToLocalJob.xml
+++ b/src/main/resources/egovframework/batch/job/remoteToLocalJob.xml
@@ -19,6 +19,7 @@
         <step id="remoteToLocalStep" parent="eGovBaseStep">
             <tasklet>
                 <chunk reader="remoteToLocalJob.remoteToLocalStep.mybatisItemReader"
+                       processor="employeeInfoProcessor"
                        writer="remoteToLocalJob.remoteToLocalStep.mybatisItemWriter"
                        commit-interval="500" />
             </tasklet>
@@ -50,5 +51,8 @@
         <property name="sqlSessionFactory" ref="sqlSessionFactory-local" />
         <property name="statementId" value="Employee.insertEmployee" />
     </bean>
+
+    <!-- ESNTL_ID와 SOURCE_SYSTEM을 세팅하는 프로세서 -->
+    <bean id="employeeInfoProcessor" class="egovframework.bat.domain.insa.EmployeeInfoProcessor" />
 
 </beans>

--- a/src/main/resources/egovframework/mapper/bat/Insa_SQL.xml
+++ b/src/main/resources/egovframework/mapper/bat/Insa_SQL.xml
@@ -11,21 +11,23 @@
 		FROM COMTNORGNZTINFO
 	</select>
 
-	<select id="selectEmployeeList" resultType="egovframework.bat.domain.insa.EmployeeInfo">
-		SELECT
-			 EMPLYR_ID,
-			 ORGNZT_ID,
-			 USER_NM,
-			 SEXDSTN_CODE,
-			 BRTHDY,
-			 MBTLNUM,
-			 EMAIL_ADRES,
-			 OFCPS_NM,
-			 EMPLYR_STTUS_CODE,
-			 REG_DTTM,
-			 MOD_DTTM
-		FROM COMTNEMPLYRINFO
-	</select>
+        <select id="selectEmployeeList" resultType="egovframework.bat.domain.insa.EmployeeInfo">
+                SELECT
+                         ESNTL_ID,
+                         SOURCE_SYSTEM,
+                         EMPLYR_ID,
+                         ORGNZT_ID,
+                         USER_NM,
+                         SEXDSTN_CODE,
+                         BRTHDY,
+                         MBTLNUM,
+                         EMAIL_ADRES,
+                         OFCPS_NM,
+                         EMPLYR_STTUS_CODE,
+                         REG_DTTM,
+                         MOD_DTTM
+                FROM COMTNEMPLYRINFO
+        </select>
 
 	<insert id="insertOrganization" parameterType="egovframework.bat.domain.insa.EmployeeInfo">
 		INSERT INTO COMTNORGNZTINFO (ORGNZT_ID, ORGNZT_NM, ORGNZT_DC)
@@ -50,6 +52,25 @@
                         OFCPS_NM = VALUES(OFCPS_NM),
                         EMPLYR_STTUS_CODE = VALUES(EMPLYR_STTUS_CODE),
                         SOURCE_SYSTEM = VALUES(SOURCE_SYSTEM),
+                        REG_DTTM = VALUES(REG_DTTM),
+                        MOD_DTTM = VALUES(MOD_DTTM)
+        </insert>
+
+        <!-- ESNTL_ID와 SOURCE_SYSTEM을 사용하지 않는 구버전용 쿼리 -->
+        <insert id="insertEmployeeLegacy" parameterType="egovframework.bat.domain.insa.EmployeeInfo">
+                INSERT INTO COMTNEMPLYRINFO
+                        (EMPLYR_ID, ORGNZT_ID, USER_NM, SEXDSTN_CODE, BRTHDY, MBTLNUM, EMAIL_ADRES, OFCPS_NM, EMPLYR_STTUS_CODE, REG_DTTM, MOD_DTTM)
+                VALUES
+                        (#{emplyrId}, #{orgnztId}, #{userNm}, #{sexdstnCode}, #{brthdy}, #{mbtlnum}, #{emailAdres}, #{ofcpsNm}, #{emplyrSttusCode}, #{regDttm}, #{modDttm})
+                ON DUPLICATE KEY UPDATE
+                        ORGNZT_ID = VALUES(ORGNZT_ID),
+                        USER_NM = VALUES(USER_NM),
+                        SEXDSTN_CODE = VALUES(SEXDSTN_CODE),
+                        BRTHDY = VALUES(BRTHDY),
+                        MBTLNUM = VALUES(MBTLNUM),
+                        EMAIL_ADRES = VALUES(EMAIL_ADRES),
+                        OFCPS_NM = VALUES(OFCPS_NM),
+                        EMPLYR_STTUS_CODE = VALUES(EMPLYR_STTUS_CODE),
                         REG_DTTM = VALUES(REG_DTTM),
                         MOD_DTTM = VALUES(MOD_DTTM)
         </insert>


### PR DESCRIPTION
## 요약
- 사원 조회 쿼리에 ESNTL_ID와 SOURCE_SYSTEM 컬럼 추가
- 기존 스키마용 insertEmployeeLegacy 쿼리 추가
- 배치 잡에 EmployeeInfoProcessor 연결해 신규 컬럼 세팅

## 테스트
- `mvn -q -e test` (네트워크 문제로 빌드 실패)


------
https://chatgpt.com/codex/tasks/task_e_68a288b2d334832aaf0ba294e338d67d