### PR TITLE
feat: add prefix-based ESNTL_ID generation

### DIFF
--- a/src/main/java/egovframework/bat/domain/insa/EsntlIdGenerator.java
+++ b/src/main/java/egovframework/bat/domain/insa/EsntlIdGenerator.java
@@ -15,15 +15,27 @@ public class EsntlIdGenerator {
     private final JdbcTemplate jdbcTemplate;
 
     /**
-     * COMTNEMPLYRINFO에서 최대 ESNTL_ID를 조회하여 1을 더한 값을 반환한다.
+     * 주어진 프리픽스로 시작하는 ESNTL_ID의 최대값을 조회하여 다음 번호를 생성한다.
      *
-     * @return 새로운 ESNTL_ID
+     * @param prefix ESNTL_ID에 붙일 프리픽스
+     * @return 새로 생성된 ESNTL_ID
      */
-    public String generate() {
-        Long nextId = jdbcTemplate.queryForObject(
-            "SELECT COALESCE(MAX(CAST(ESNTL_ID AS UNSIGNED)),0) + 1 FROM COMTNEMPLYRINFO",
-            Long.class);
-        return String.valueOf(nextId);
+    public String generate(String prefix) {
+        String maxId = jdbcTemplate.queryForObject(
+            "SELECT MAX(ESNTL_ID) FROM COMTNEMPLYRINFO WHERE ESNTL_ID LIKE ?",
+            String.class,
+            prefix + "%");
+
+        long nextNo = 1L;
+        if (maxId != null) {
+            String numberPart = maxId.substring(prefix.length());
+            try {
+                nextNo = Long.parseLong(numberPart) + 1;
+            } catch (NumberFormatException e) {
+                nextNo = 1L;
+            }
+        }
+        return prefix + nextNo;
     }
 }
 

--- a/src/main/java/egovframework/bat/domain/insa/SourceSystemPrefix.java
+++ b/src/main/java/egovframework/bat/domain/insa/SourceSystemPrefix.java
@@ -1,0 +1,37 @@
+package egovframework.bat.domain.insa;
+
+import java.util.Arrays;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 소스 시스템별 ESNTL_ID 프리픽스를 관리하는 열거형.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum SourceSystemPrefix {
+
+    REMOTE1("remote1", "LND"),
+    REMOTE2("remote2", "ETC");
+
+    private final String system;
+    private final String prefix;
+
+    /**
+     * 소스 시스템에 해당하는 프리픽스를 반환한다.
+     *
+     * @param system 소스 시스템 값
+     * @return 매핑된 프리픽스, 없으면 빈 문자열
+     */
+    public static String getPrefix(String system) {
+        if (system == null) {
+            return "";
+        }
+        return Arrays.stream(values())
+            .filter(v -> v.system.equalsIgnoreCase(system))
+            .map(SourceSystemPrefix::getPrefix)
+            .findFirst()
+            .orElse("");
+    }
+}

--- a/src/main/java/egovframework/bat/processor/EmployeePostProcessor.java
+++ b/src/main/java/egovframework/bat/processor/EmployeePostProcessor.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 
 import egovframework.bat.domain.insa.EmployeeInfo;
 import egovframework.bat.domain.insa.EsntlIdGenerator;
+import egovframework.bat.domain.insa.SourceSystemPrefix;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -19,7 +20,8 @@ public class EmployeePostProcessor implements ItemProcessor<EmployeeInfo, Employ
 
     @Override
     public EmployeeInfo process(EmployeeInfo item) {
-        item.setEsntlId(esntlIdGenerator.generate());
+        String prefix = SourceSystemPrefix.getPrefix(item.getSourceSystem());
+        item.setEsntlId(esntlIdGenerator.generate(prefix));
         item.setSourceSystem(SOURCE_SYSTEM);
         return item;
     }


### PR DESCRIPTION
## Summary
- generate ESNTL_ID per source system prefix
- map source system to ID prefixes via enum
- create IDs with LND/ETC prefix in EmployeePostProcessor

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a28ae125f0832a8f748523d8e8f9dc