### PR TITLE
원격-스테이징-로컬 배치 순차 실행 설정

### DIFF
--- a/src/main/resources/egovframework/batch/context-batch-scheduler.xml
+++ b/src/main/resources/egovframework/batch/context-batch-scheduler.xml
@@ -4,21 +4,51 @@
 
         <import resource="context-batch-job-launcher.xml" />
 
+        <!-- 원격 → 스테이징 및 스테이징 → 로컬 작업의 순차 실행을 위한 트리거 정의 -->
+
+        <bean id="remoteToStgCronTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
+            <property name="jobDetail" ref="remoteToStgJobDetail" />
+            <property name="cronExpression" value="0 * * * * ?" />
+        </bean>
+
+        <bean id="stgToLocalCronTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
+            <property name="jobDetail" ref="stgToLocalJobDetail" />
+            <property name="cronExpression" value="0 * * * * ?" />
+        </bean>
+
+        <!-- remoteToStg 작업 완료 후 stgToLocal 작업을 수행하도록 체이닝 -->
+        <bean id="jobChainingJobListener" class="org.quartz.listeners.JobChainingJobListener">
+            <constructor-arg value="jobChainingListener" />
+        </bean>
+        <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+            <property name="targetObject" ref="jobChainingJobListener" />
+            <property name="targetMethod" value="addJobChainLink" />
+            <property name="arguments">
+                <list>
+                    <bean class="org.quartz.JobKey">
+                        <constructor-arg value="remoteToStgJobDetail" />
+                        <constructor-arg value="quartz-batch" />
+                    </bean>
+                    <bean class="org.quartz.JobKey">
+                        <constructor-arg value="stgToLocalJobDetail" />
+                        <constructor-arg value="quartz-batch" />
+                    </bean>
+                </list>
+            </property>
+        </bean>
+
         <bean class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
             <property name="triggers">
                 <list>
-                	<!-- 
-                    <bean id="cronTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
-                        <property name="jobDetail" ref="jobDetail" />
-                        <property name="cronExpression" value="0 * * * * ?" />
-                    </bean>
-                     -->
-                    <bean id="remoteToLocalCronTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
-                        <property name="jobDetail" ref="remoteToLocalJobDetail" />
-                        <property name="cronExpression" value="0 * * * * ?" />
-                    </bean>
+                    <ref bean="remoteToStgCronTrigger" />
+                    <ref bean="stgToLocalCronTrigger" />
                 </list>
-		    </property>
+            </property>
+            <property name="globalJobListeners">
+                <list>
+                    <ref bean="jobChainingJobListener" />
+                </list>
+            </property>
         </bean>
 
 </beans>

--- a/src/main/resources/egovframework/batch/context-scheduler-job.xml
+++ b/src/main/resources/egovframework/batch/context-scheduler-job.xml
@@ -15,17 +15,30 @@
 		</property>
 	</bean>
 	
-    <bean id="remoteToLocalJobDetail" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
-	    <property name="jobClass" value="egovframework.example.bat.scheduler.support.EgovJobLauncherDetails" />
-	    <property name="group" value="quartz-batch" />
-	    <property name="jobDataAsMap">
+    <bean id="remoteToStgJobDetail" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
+        <property name="jobClass" value="egovframework.example.bat.scheduler.support.EgovJobLauncherDetails" />
+        <property name="group" value="quartz-batch" />
+        <property name="jobDataAsMap">
             <map>
-	            <!-- 원격 DB 데이터를 로컬로 적재하기 위한 작업 이름 설정 (가이드) -->
-	            <entry key="jobName" value="remoteToLocalJob" />
-	            <entry key="jobLocator" value-ref="jobRegistry" />
-	            <entry key="jobLauncher" value-ref="jobLauncher" />
+                <!-- 원격 DB 데이터를 스테이징 DB로 적재하기 위한 작업 이름 설정 (가이드) -->
+                <entry key="jobName" value="remoteToStgJob" />
+                <entry key="jobLocator" value-ref="jobRegistry" />
+                <entry key="jobLauncher" value-ref="jobLauncher" />
             </map>
-	    </property>
+        </property>
+    </bean>
+
+    <bean id="stgToLocalJobDetail" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
+        <property name="jobClass" value="egovframework.example.bat.scheduler.support.EgovJobLauncherDetails" />
+        <property name="group" value="quartz-batch" />
+        <property name="jobDataAsMap">
+            <map>
+                <!-- 스테이징 DB 데이터를 로컬로 적재하기 위한 작업 이름 설정 (가이드) -->
+                <entry key="jobName" value="stgToLocalJob" />
+                <entry key="jobLocator" value-ref="jobRegistry" />
+                <entry key="jobLauncher" value-ref="jobLauncher" />
+            </map>
+        </property>
     </bean>
 
 </beans>


### PR DESCRIPTION
## Summary
- stgToLocalJobDetail 빈을 추가하고 기존 원격 작업을 remoteToStg로 정리했습니다.
- Quartz JobChainingJobListener로 remoteToStg 완료 후 stgToLocal 작업이 실행되도록 스케줄러를 구성했습니다.

## Testing
- `mvn -q -e -DskipTests package` *(네트워크 오류로 실패: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a28f821828832aa1d8f2eb251b8245