### PR TITLE
원격·STG 사원 조회 쿼리 정리 및 로컬용 쿼리 추가

### DIFF
--- a/src/main/resources/egovframework/batch/job/remoteToStgJob.xml
+++ b/src/main/resources/egovframework/batch/job/remoteToStgJob.xml
@@ -39,7 +39,7 @@
     </bean>
 
     <bean id="remoteToStgJob.remoteToStgStep.mybatisItemReader" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader" scope="step">
-        <!-- 원격 DB 읽기를 위해 remote SqlSessionFactory 사용 -->
+        <!-- 원격 DB에서 ESNTL_ID와 SOURCE_SYSTEM을 제외한 사원 정보를 조회 -->
         <property name="sqlSessionFactory" ref="sqlSessionFactory-remote" />
         <property name="queryId" value="Employee.selectEmployeeList" />
         <property name="pageSize" value="#{100}" />

--- a/src/main/resources/egovframework/batch/job/stgToLocalJob.xml
+++ b/src/main/resources/egovframework/batch/job/stgToLocalJob.xml
@@ -40,9 +40,9 @@
     </bean>
 
     <bean id="stgToLocalJob.stgToLocalStep.mybatisItemReader" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader" scope="step">
-        <!-- 스테이징 DB 읽기를 위해 stg SqlSessionFactory 사용 -->
+        <!-- 스테이징 DB에서 ESNTL_ID와 SOURCE_SYSTEM을 포함한 사원 정보를 조회 -->
         <property name="sqlSessionFactory" ref="sqlSessionFactory-stg" />
-        <property name="queryId" value="Employee.selectEmployeeList" />
+        <property name="queryId" value="Employee.selectEmployeeListLocal" />
         <property name="pageSize" value="#{100}" />
     </bean>
 

--- a/src/main/resources/egovframework/mapper/bat/Insa_SQL.xml
+++ b/src/main/resources/egovframework/mapper/bat/Insa_SQL.xml
@@ -11,7 +11,25 @@
 		FROM COMTNORGNZTINFO
 	</select>
 
+        <!-- 원격 및 STG 조회 시 사용하며 ESNTL_ID와 SOURCE_SYSTEM을 제외한 쿼리 -->
         <select id="selectEmployeeList" resultType="egovframework.bat.domain.insa.EmployeeInfo">
+                SELECT
+                         EMPLYR_ID,
+                         ORGNZT_ID,
+                         USER_NM,
+                         SEXDSTN_CODE,
+                         BRTHDY,
+                         MBTLNUM,
+                         EMAIL_ADRES,
+                         OFCPS_NM,
+                         EMPLYR_STTUS_CODE,
+                         REG_DTTM,
+                         MOD_DTTM
+                FROM COMTNEMPLYRINFO
+        </select>
+
+        <!-- 로컬 DB 조회 시 사용하며 ESNTL_ID와 SOURCE_SYSTEM을 포함한 쿼리 -->
+        <select id="selectEmployeeListLocal" resultType="egovframework.bat.domain.insa.EmployeeInfo">
                 SELECT
                          ESNTL_ID,
                          SOURCE_SYSTEM,


### PR DESCRIPTION
## Summary
- 원격/스테이징 조회용 selectEmployeeList에서 ESNTL_ID, SOURCE_SYSTEM 제거
- 로컬 조회용 selectEmployeeListLocal 쿼리 추가
- 배치 작업에서 신규 쿼리 ID 사용 및 주석 보강

## Testing
- `mvn -q test` *(실패: 원격 저장소에 접근할 수 없어 parent POM을 해석하지 못함)*

------
https://chatgpt.com/codex/tasks/task_e_68a29245b1e0832a980f787bcbab232b