### PR TITLE
원격·STG·로컬 이관 매퍼 분리

### DIFF
--- a/src/main/resources/egovframework/batch/context-batch-mapper.xml
+++ b/src/main/resources/egovframework/batch/context-batch-mapper.xml
@@ -1,47 +1,56 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
 
     <!-- 실행환경에서 빈이름 참조(EgovAbstractDAO) -->
-        <bean id="egov.lobHandler" class="org.springframework.jdbc.support.lob.DefaultLobHandler" lazy-init="true" />
+    <bean id="egov.lobHandler" class="org.springframework.jdbc.support.lob.DefaultLobHandler" lazy-init="true" />
 
-        <!-- 원격 DB용 SqlSessionFactory -->
-        <bean id="sqlSessionFactory-remote" class="org.mybatis.spring.SqlSessionFactoryBean">
-                <property name="dataSource" ref="dataSource-remote"/>
-                <property name="configLocation" value="classpath:/egovframework/mapper/config/mapper-config.xml" />
-	
-	        <property name="mapperLocations">
-	            <list>
-	                <value>classpath:/egovframework/mapper/example/bat/Egov_Example_SQL.xml</value>
-	                <value>classpath:/egovframework/mapper/bat/Insa_SQL.xml</value>
-	            </list>
-	        </property>
-        </bean>
+    <!-- 원격 DB용 SqlSessionFactory -->
+    <bean id="sqlSessionFactory-remote" class="org.mybatis.spring.SqlSessionFactoryBean">
+        <property name="dataSource" ref="dataSource-remote"/>
+        <property name="configLocation" value="classpath:/egovframework/mapper/config/mapper-config.xml" />
+        <property name="mapperLocations">
+            <list>
+                <value>classpath:/egovframework/mapper/example/bat/Egov_Example_SQL.xml</value>
+                <value>classpath:/egovframework/mapper/bat/insa_remote_to_stg.xml</value>
+            </list>
+        </property>
+    </bean>
 
-        <!-- 스테이징 DB용 SqlSessionFactory -->
-        <bean id="sqlSessionFactory-stg" class="org.mybatis.spring.SqlSessionFactoryBean">
-                <property name="dataSource" ref="dataSource-stg"/>
-                <property name="configLocation" value="classpath:/egovframework/mapper/config/mapper-config.xml" />
+    <!-- STG DB용 SqlSessionFactory (원격->STG 이관) -->
+    <bean id="sqlSessionFactory-stg-remote" class="org.mybatis.spring.SqlSessionFactoryBean">
+        <property name="dataSource" ref="dataSource-stg"/>
+        <property name="configLocation" value="classpath:/egovframework/mapper/config/mapper-config.xml" />
+        <property name="mapperLocations">
+            <list>
+                <value>classpath:/egovframework/mapper/example/bat/Egov_Example_SQL.xml</value>
+                <value>classpath:/egovframework/mapper/bat/insa_remote_to_stg.xml</value>
+            </list>
+        </property>
+    </bean>
 
-                <property name="mapperLocations">
-                    <list>
-                        <value>classpath:/egovframework/mapper/example/bat/Egov_Example_SQL.xml</value>
-                        <value>classpath:/egovframework/mapper/bat/Insa_SQL.xml</value>
-                    </list>
-                </property>
-        </bean>
+    <!-- STG DB용 SqlSessionFactory (STG->Local 이관) -->
+    <bean id="sqlSessionFactory-stg-local" class="org.mybatis.spring.SqlSessionFactoryBean">
+        <property name="dataSource" ref="dataSource-stg"/>
+        <property name="configLocation" value="classpath:/egovframework/mapper/config/mapper-config.xml" />
+        <property name="mapperLocations">
+            <list>
+                <value>classpath:/egovframework/mapper/example/bat/Egov_Example_SQL.xml</value>
+                <value>classpath:/egovframework/mapper/bat/insa_stg_to_local.xml</value>
+            </list>
+        </property>
+    </bean>
 
-        <!-- 로컬 DB용 SqlSessionFactory -->
-        <bean id="sqlSessionFactory-local" class="org.mybatis.spring.SqlSessionFactoryBean">
-	        <property name="dataSource" ref="dataSource-local"/>
-	        <property name="configLocation" value="classpath:/egovframework/mapper/config/mapper-config.xml" />
-	
-	        <property name="mapperLocations">
-	            <list>
-	                <value>classpath:/egovframework/mapper/example/bat/Egov_Example_SQL.xml</value>
-	                <value>classpath:/egovframework/mapper/bat/Insa_SQL.xml</value>
-	            </list>
-	        </property>
-        </bean>
+    <!-- 로컬 DB용 SqlSessionFactory -->
+    <bean id="sqlSessionFactory-local" class="org.mybatis.spring.SqlSessionFactoryBean">
+        <property name="dataSource" ref="dataSource-local"/>
+        <property name="configLocation" value="classpath:/egovframework/mapper/config/mapper-config.xml" />
+        <property name="mapperLocations">
+            <list>
+                <value>classpath:/egovframework/mapper/example/bat/Egov_Example_SQL.xml</value>
+                <value>classpath:/egovframework/mapper/bat/insa_stg_to_local.xml</value>
+            </list>
+        </property>
+    </bean>
 
 </beans>

--- a/src/main/resources/egovframework/batch/job/remoteToStgJob.xml
+++ b/src/main/resources/egovframework/batch/job/remoteToStgJob.xml
@@ -34,7 +34,7 @@
 
     <bean id="remoteToStgJob.remoteToStgOrgnztStep.mybatisItemWriter" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter">
         <!-- STG DB에 조직 정보 적재 -->
-        <property name="sqlSessionFactory" ref="sqlSessionFactory-stg" />
+        <property name="sqlSessionFactory" ref="sqlSessionFactory-stg-remote" />
         <property name="statementId" value="Employee.insertOrganization" />
     </bean>
 
@@ -47,7 +47,7 @@
 
     <bean id="remoteToStgJob.remoteToStgStep.mybatisItemWriter" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter">
         <!-- STG DB 적재를 위해 stg SqlSessionFactory 사용 -->
-        <property name="sqlSessionFactory" ref="sqlSessionFactory-stg" />
+        <property name="sqlSessionFactory" ref="sqlSessionFactory-stg-remote" />
         <property name="statementId" value="Employee.insertEmployeeLegacy" />
     </bean>
 

--- a/src/main/resources/egovframework/batch/job/stgToLocalJob.xml
+++ b/src/main/resources/egovframework/batch/job/stgToLocalJob.xml
@@ -28,7 +28,7 @@
 
     <bean id="stgToLocalJob.stgToLocalOrgnztStep.mybatisItemReader" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader" scope="step">
         <!-- 스테이징 DB에서 조직 정보 목록을 조회 -->
-        <property name="sqlSessionFactory" ref="sqlSessionFactory-stg" />
+        <property name="sqlSessionFactory" ref="sqlSessionFactory-stg-local" />
         <property name="queryId" value="Employee.selectOrgnztList" />
         <property name="pageSize" value="#{100}" />
     </bean>
@@ -41,7 +41,7 @@
 
     <bean id="stgToLocalJob.stgToLocalStep.mybatisItemReader" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader" scope="step">
         <!-- 스테이징 DB에서 ESNTL_ID와 SOURCE_SYSTEM을 포함한 사원 정보를 조회 -->
-        <property name="sqlSessionFactory" ref="sqlSessionFactory-stg" />
+        <property name="sqlSessionFactory" ref="sqlSessionFactory-stg-local" />
         <property name="queryId" value="Employee.selectEmployeeListLocal" />
         <property name="pageSize" value="#{100}" />
     </bean>

--- a/src/main/resources/egovframework/mapper/bat/insa_remote_to_stg.xml
+++ b/src/main/resources/egovframework/mapper/bat/insa_remote_to_stg.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="Employee">
+
+        <!-- 조직 정보 목록 조회 -->
+        <select id="selectOrgnztList" resultType="egovframework.bat.domain.insa.Orgnztinfo">
+                SELECT
+                         ORGNZT_ID,
+                         ORGNZT_NM,
+                         ORGNZT_DC
+                FROM COMTNORGNZTINFO
+        </select>
+
+        <!-- 원격 DB에서 STG 이관 시 ESNTL_ID와 SOURCE_SYSTEM을 제외하여 조회 -->
+        <select id="selectEmployeeList" resultType="egovframework.bat.domain.insa.EmployeeInfo">
+                SELECT
+                         EMPLYR_ID,
+                         ORGNZT_ID,
+                         USER_NM,
+                         SEXDSTN_CODE,
+                         BRTHDY,
+                         MBTLNUM,
+                         EMAIL_ADRES,
+                         OFCPS_NM,
+                         EMPLYR_STTUS_CODE,
+                         REG_DTTM,
+                         MOD_DTTM
+                FROM COMTNEMPLYRINFO
+        </select>
+
+        <!-- STG DB에 조직 정보 적재 -->
+        <insert id="insertOrganization" parameterType="egovframework.bat.domain.insa.EmployeeInfo">
+                INSERT INTO COMTNORGNZTINFO (ORGNZT_ID, ORGNZT_NM, ORGNZT_DC)
+                                VALUES (#{orgnztId}, #{orgnztNm}, #{orgnztDc})
+                        ON DUPLICATE KEY UPDATE
+                                ORGNZT_NM = VALUES(ORGNZT_NM),
+                                ORGNZT_DC = VALUES(ORGNZT_DC)
+        </insert>
+
+        <!-- 원격 -> STG 이관 시 사용 (ESNTL_ID 제외) -->
+        <insert id="insertEmployeeLegacy" parameterType="egovframework.bat.domain.insa.EmployeeInfo">
+                INSERT INTO COMTNEMPLYRINFO
+                        (EMPLYR_ID, ORGNZT_ID, USER_NM, SEXDSTN_CODE, BRTHDY, MBTLNUM, EMAIL_ADRES, OFCPS_NM, EMPLYR_STTUS_CODE, REG_DTTM, MOD_DTTM)
+                VALUES
+                        (#{emplyrId}, #{orgnztId}, #{userNm}, #{sexdstnCode}, #{brthdy}, #{mbtlnum}, #{emailAdres}, #{ofcpsNm}, #{emplyrSttusCode}, #{regDttm}, #{modDttm})
+                ON DUPLICATE KEY UPDATE
+                        ORGNZT_ID = VALUES(ORGNZT_ID),
+                        USER_NM = VALUES(USER_NM),
+                        SEXDSTN_CODE = VALUES(SEXDSTN_CODE),
+                        BRTHDY = VALUES(BRTHDY),
+                        MBTLNUM = VALUES(MBTLNUM),
+                        EMAIL_ADRES = VALUES(EMAIL_ADRES),
+                        OFCPS_NM = VALUES(OFCPS_NM),
+                        EMPLYR_STTUS_CODE = VALUES(EMPLYR_STTUS_CODE),
+                        REG_DTTM = VALUES(REG_DTTM),
+                        MOD_DTTM = VALUES(MOD_DTTM)
+        </insert>
+
+</mapper>

--- a/src/main/resources/egovframework/mapper/bat/insa_stg_to_local.xml
+++ b/src/main/resources/egovframework/mapper/bat/insa_stg_to_local.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="Employee">
+
+        <!-- 조직 정보 목록 조회 -->
+        <select id="selectOrgnztList" resultType="egovframework.bat.domain.insa.Orgnztinfo">
+                SELECT
+                         ORGNZT_ID,
+                         ORGNZT_NM,
+                         ORGNZT_DC
+                FROM COMTNORGNZTINFO
+        </select>
+
+        <!-- STG DB에서 로컬 DB로 이관할 사원 목록 조회 (ESNTL_ID 포함) -->
+        <select id="selectEmployeeListLocal" resultType="egovframework.bat.domain.insa.EmployeeInfo">
+                SELECT
+                         ESNTL_ID,
+                         EMPLYR_ID,
+                         ORGNZT_ID,
+                         USER_NM,
+                         SEXDSTN_CODE,
+                         BRTHDY,
+                         MBTLNUM,
+                         EMAIL_ADRES,
+                         OFCPS_NM,
+                         EMPLYR_STTUS_CODE,
+                         REG_DTTM,
+                         MOD_DTTM
+                FROM COMTNEMPLYRINFO
+        </select>
+
+        <!-- 로컬 DB에 조직 정보 적재 -->
+        <insert id="insertOrganization" parameterType="egovframework.bat.domain.insa.EmployeeInfo">
+                INSERT INTO COMTNORGNZTINFO (ORGNZT_ID, ORGNZT_NM, ORGNZT_DC)
+                                VALUES (#{orgnztId}, #{orgnztNm}, #{orgnztDc})
+                        ON DUPLICATE KEY UPDATE
+                                ORGNZT_NM = VALUES(ORGNZT_NM),
+                                ORGNZT_DC = VALUES(ORGNZT_DC)
+        </insert>
+
+        <!-- STG -> Local 이관 시 사용 (ESNTL_ID 포함) -->
+        <insert id="insertEmployee" parameterType="egovframework.bat.domain.insa.EmployeeInfo">
+                INSERT INTO COMTNEMPLYRINFO
+                        (ESNTL_ID, EMPLYR_ID, ORGNZT_ID, USER_NM, SEXDSTN_CODE, BRTHDY, MBTLNUM, EMAIL_ADRES, OFCPS_NM, EMPLYR_STTUS_CODE, REG_DTTM, MOD_DTTM)
+                VALUES
+                        (#{esntlId}, #{emplyrId}, #{orgnztId}, #{userNm}, #{sexdstnCode}, #{brthdy}, #{mbtlnum}, #{emailAdres}, #{ofcpsNm}, #{emplyrSttusCode}, #{regDttm}, #{modDttm})
+                ON DUPLICATE KEY UPDATE
+                        ORGNZT_ID = VALUES(ORGNZT_ID),
+                        USER_NM = VALUES(USER_NM),
+                        SEXDSTN_CODE = VALUES(SEXDSTN_CODE),
+                        BRTHDY = VALUES(BRTHDY),
+                        MBTLNUM = VALUES(MBTLNUM),
+                        EMAIL_ADRES = VALUES(EMAIL_ADRES),
+                        OFCPS_NM = VALUES(OFCPS_NM),
+                        EMPLYR_STTUS_CODE = VALUES(EMPLYR_STTUS_CODE),
+                        REG_DTTM = VALUES(REG_DTTM),
+                        MOD_DTTM = VALUES(MOD_DTTM)
+        </insert>
+
+</mapper>


### PR DESCRIPTION
## 요약
- Insa_SQL.xml을 단계별 매퍼로 분리하여 원격→STG, STG→로컬용 쿼리만 포함하도록 구성
- 배치 잡에서 사용할 SqlSessionFactory를 신규 매퍼 파일로 분리하고 각 잡에서 참조하도록 수정
- 컨텍스트 매퍼 설정을 신규 파일과 SqlSessionFactory에 맞게 재정비

## 테스트
- `mvn -q -DskipTests package` (네트워크 단절로 의존성 조회 실패)


------
https://chatgpt.com/codex/tasks/task_e_68a2b65fce60832a8f1cb8de4002dd9b