### PR TITLE
feat: import common context for bean scanning

### DIFF
--- a/src/main/resources/egovframework/batch/context-batch-job-launcher.xml
+++ b/src/main/resources/egovframework/batch/context-batch-job-launcher.xml
@@ -5,8 +5,10 @@
 			http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
 			http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-3.0.xsd">
 
-	<import resource="classpath:/egovframework/batch/context-batch-datasource.xml" />
-	<import resource="classpath:/egovframework/batch/context-batch-mapper.xml" />
+        <import resource="classpath:/egovframework/batch/context-batch-datasource.xml" />
+        <import resource="classpath:/egovframework/batch/context-batch-mapper.xml" />
+        <!-- 공통 설정(컴포넌트 스캔 등)을 포함하여 Bean 등록 누락 방지 -->
+        <import resource="classpath:/egovframework/batch/context-common.xml" />
 
 	<bean id="eGovBatchRunner" class="org.egovframe.rte.bat.core.launch.support.EgovBatchRunner">
 		<constructor-arg ref="jobOperator" />


### PR DESCRIPTION
## Summary
- add common context import to register `EsntlIdGenerator`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d36d80ac832aaa8f73727c95a2d2