### PR TITLE
stgToLocalJob itemProcessor에 스텝 스코프 추가

### DIFF
--- a/src/main/resources/egovframework/batch/job/stgToLocalJob.xml
+++ b/src/main/resources/egovframework/batch/job/stgToLocalJob.xml
@@ -52,7 +52,10 @@
         <property name="statementId" value="Employee.insertEmployee" />
     </bean>
 
-    <bean id="stgToLocalJob.stgToLocalStep.itemProcessor" class="egovframework.bat.domain.insa.EmployeeInfoProcessor" />
+    <!-- jobParameters를 사용하기 위해 스텝 스코프로 지정 -->
+    <bean id="stgToLocalJob.stgToLocalStep.itemProcessor"
+          class="egovframework.bat.domain.insa.EmployeeInfoProcessor"
+          scope="step" />
 
 </beans>
 


### PR DESCRIPTION
## Summary
- jobParameters를 사용하기 위해 stgToLocalJob의 itemProcessor 빈에 step 스코프를 적용

## Testing
- `mvn -q test` *(실패: 부모 POM을 받을 수 없음)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d5b24410832abf7e675b5d4ff242