### PR TITLE
환경별 로그 설정 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,15 +185,23 @@
 			</resource>
 
 			<!-- 환경별 리소스: env/${env} 폴더의 globals.properties만 클래스패스에 포함 -->
-            <resource>
-                <directory>src/main/resources/egovframework/batch/properties/env/${env}</directory>
-                <targetPath>egovframework/batch/properties</targetPath>
-                <includes>
-                    <include>globals.properties</include>
-                </includes>
-                <filtering>false</filtering>
-            </resource>
-		</resources>
+                  <resource>
+                      <directory>src/main/resources/egovframework/batch/properties/env/${env}</directory>
+                      <targetPath>egovframework/batch/properties</targetPath>
+                      <includes>
+                          <include>globals.properties</include>
+                      </includes>
+                      <filtering>false</filtering>
+                  </resource>
+                  <!-- 환경별 log4j2 설정 파일 포함 -->
+                  <resource>
+                      <directory>src/main/resources/log4j2/env/${env}</directory>
+                      <targetPath>.</targetPath>
+                      <includes>
+                          <include>log4j2.xml</include>
+                      </includes>
+                  </resource>
+              </resources>
 
 		<defaultGoal>install</defaultGoal>
 		<directory>${basedir}/target</directory>

--- a/src/main/resources/log4j2/env/dev/log4j2.xml
+++ b/src/main/resources/log4j2/env/dev/log4j2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 개발 환경용 로그 설정 -->
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %-5p [%c{1}] %m%n"/>
+    </Console>
+    <RollingFile name="File" fileName="logs/dev.log" filePattern="logs/dev-%d{yyyy-MM-dd}.log.gz">
+      <PatternLayout pattern="%d %-5p [%c{1}] %m%n"/>
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="1"/>
+      </Policies>
+    </RollingFile>
+  </Appenders>
+  <Loggers>
+    <Root level="INFO">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="File"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/src/main/resources/log4j2/env/local/log4j2.xml
+++ b/src/main/resources/log4j2/env/local/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 로컬 환경용 로그 설정 -->
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d %-5p [%c{1}] %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="DEBUG">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/src/main/resources/log4j2/env/prod/log4j2.xml
+++ b/src/main/resources/log4j2/env/prod/log4j2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 운영 환경용 로그 설정 -->
+<Configuration status="WARN">
+  <Appenders>
+    <RollingFile name="File" fileName="/var/log/app/prod.log" filePattern="/var/log/app/prod-%d{yyyy-MM-dd}.log.gz">
+      <PatternLayout pattern="%d %-5p [%c{1}] %m%n"/>
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="1"/>
+      </Policies>
+    </RollingFile>
+  </Appenders>
+  <Loggers>
+    <Root level="WARN">
+      <AppenderRef ref="File"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
## 요약
- 로컬, 개발, 운영 환경별 log4j2 설정 파일을 추가하여 환경별 로깅 전략을 분리했습니다.
- Maven 빌드 시 활성화된 프로필에 따라 해당 log4j2.xml이 포함되도록 pom.xml을 수정했습니다.

## 테스트
- `mvn -Plocal package` (네트워크 문제로 parent POM을 다운로드하지 못해 실패)
- `mvn -Pdev package` (네트워크 문제로 parent POM을 다운로드하지 못해 실패)
- `mvn -Pprod package` (네트워크 문제로 parent POM을 다운로드하지 못해 실패)


------
https://chatgpt.com/codex/tasks/task_e_68a3dd6ad5cc832aac9cc2f6935bc781