### PR TITLE
stgToLocalStep 매퍼에서 ESNTL_ID 생성 방식 정비

### DIFF
--- a/src/main/resources/egovframework/batch/job/stgToLocalJob.xml
+++ b/src/main/resources/egovframework/batch/job/stgToLocalJob.xml
@@ -40,7 +40,7 @@
     </bean>
 
     <bean id="stgToLocalJob.stgToLocalStep.mybatisItemReader" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader" scope="step">
-        <!-- 스테이징 DB에서 ESNTL_ID와 SOURCE_SYSTEM을 포함한 사원 정보를 조회 -->
+        <!-- 스테이징 DB에서 사원 정보를 조회 (ESNTL_ID는 로컬 적재 시 생성) -->
         <property name="sqlSessionFactory" ref="sqlSessionFactory-stg-local" />
         <property name="queryId" value="Employee.selectEmployeeListLocal" />
         <property name="pageSize" value="#{100}" />

--- a/src/main/resources/egovframework/mapper/bat/insa_stg_to_local.xml
+++ b/src/main/resources/egovframework/mapper/bat/insa_stg_to_local.xml
@@ -12,10 +12,9 @@
                 FROM COMTNORGNZTINFO
         </select>
 
-        <!-- STG DB에서 로컬 DB로 이관할 사원 목록 조회 (ESNTL_ID 포함) -->
+        <!-- STG DB에서 로컬 DB로 이관할 사원 목록 조회 (ESNTL_ID는 로컬 적재 시 생성) -->
         <select id="selectEmployeeListLocal" resultType="egovframework.bat.domain.insa.EmployeeInfo">
                 SELECT
-                         ESNTL_ID,
                          EMPLYR_ID,
                          ORGNZT_ID,
                          USER_NM,


### PR DESCRIPTION
## Summary
- stg→local 이관 매퍼에서 ESNTL_ID 컬럼 제거 및 주석 정비
- stgToLocalStep 리더 주석에 ESNTL_ID가 로컬에서 생성됨을 명시

## Testing
- `mvn -q -Plocal package` *(실패: org.springframework.boot:spring-boot-starter-parent:pom:2.7.18)

------
https://chatgpt.com/codex/tasks/task_e_68a3f7cc0464832a98bf4a9ac64412e3