### PR TITLE
log4j2 설정 파일 적용 및 YAML 로깅 블록 주석 처리

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,9 +7,12 @@ spring:
       enabled: never   # ANSI 색상 끄기    
 
 logging:
-  level:
-    '[org.egovframe]': DEBUG
-    '[egovframework]': DEBUG
-    '[org.springframework]': DEBUG
-#    root: DEBUG
+  # 기존 로그 레벨 설정을 주석 처리하여 log4j2 설정만 사용하도록 함
+  # level:
+  #   '[org.egovframe]': DEBUG
+  #   '[egovframework]': DEBUG
+  #   '[org.springframework]': DEBUG
+  #   root: DEBUG
+  # 활성 프로파일에 따라 log4j2 설정 파일을 로드
+  config: classpath:log4j2/env/${spring.profiles.active:local}/log4j2.xml
 

--- a/src/main/resources/log4j2/env/dev/log4j2.xml
+++ b/src/main/resources/log4j2/env/dev/log4j2.xml
@@ -14,6 +14,19 @@
     </RollingFile>
   </Appenders>
   <Loggers>
+    <!-- 프레임워크 패키지 로그 레벨 설정 -->
+    <Logger name="egovframework" level="DEBUG" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="File"/>
+    </Logger>
+    <Logger name="org.egovframe" level="DEBUG" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="File"/>
+    </Logger>
+    <Logger name="org.springframework" level="INFO" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="File"/>
+    </Logger>
     <Root level="INFO">
       <AppenderRef ref="Console"/>
       <AppenderRef ref="File"/>

--- a/src/main/resources/log4j2/env/local/log4j2.xml
+++ b/src/main/resources/log4j2/env/local/log4j2.xml
@@ -1,30 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xml>
 <Configuration>
-    <Appenders>
+      <Appenders>
         <Console name="console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d %5p [%c] %m%n" />
+          <PatternLayout pattern="%d %5p [%c] %m%n" />
         </Console>
-    </Appenders>
-    <Loggers>
-        <Logger name="java.sql" level="INFO" additivity="false">
-            <AppenderRef ref="console" />
-        </Logger>
-        <Logger name="egovframework" level="DEBUG" additivity="false">
-            <AppenderRef ref="console" />
-        <Logger name="org.egovframe" level="DEBUG" additivity="false">
-            <AppenderRef ref="console" />
-        </Logger>    
-        </Logger>
-		  <!-- log SQL with timing information, post execution -->
-	    <Logger name="jdbc.sqltiming" level="INFO" additivity="false">
-	        <AppenderRef ref="console" />
-	    </Logger>
-	    <Logger name="org.springframework" level="INFO" additivity="false">
-	        <AppenderRef ref="console" />
-	    </Logger>
-        <Root level="ERROR">
-            <AppenderRef ref="console" />
-        </Root>
-    </Loggers>
-</Configuration>
+      </Appenders>
+      <Loggers>
+          <!-- 프레임워크 패키지 로그 레벨 설정 -->
+          <Logger name="java.sql" level="INFO" additivity="false">
+              <AppenderRef ref="console" />
+          </Logger>
+          <Logger name="egovframework" level="DEBUG" additivity="false">
+              <AppenderRef ref="console" />
+          </Logger>
+          <Logger name="org.egovframe" level="DEBUG" additivity="false">
+              <AppenderRef ref="console" />
+          </Logger>
+          <!-- 실행 후 SQL과 시간 정보를 로그 -->
+          <Logger name="jdbc.sqltiming" level="INFO" additivity="false">
+              <AppenderRef ref="console" />
+          </Logger>
+          <Logger name="org.springframework" level="INFO" additivity="false">
+              <AppenderRef ref="console" />
+          </Logger>
+          <Root level="ERROR">
+              <AppenderRef ref="console" />
+          </Root>
+      </Loggers>
+  </Configuration>

--- a/src/main/resources/log4j2/env/prod/log4j2.xml
+++ b/src/main/resources/log4j2/env/prod/log4j2.xml
@@ -2,17 +2,27 @@
 <!DOCTYPE xml>
 <!-- 운영 환경용 로그 설정 -->
 <Configuration>
-  <Appenders>
+    <Appenders>
     <RollingFile name="File" fileName="/var/log/app/prod.log" filePattern="/var/log/app/prod-%d{yyyy-MM-dd}.log.gz">
       <PatternLayout pattern="%d %-5p [%c{1}] %m%n"/>
       <Policies>
         <TimeBasedTriggeringPolicy interval="1"/>
       </Policies>
     </RollingFile>
-  </Appenders>
-  <Loggers>
-    <Root level="WARN">
-      <AppenderRef ref="File"/>
-    </Root>
-  </Loggers>
-</Configuration>
+    </Appenders>
+    <Loggers>
+      <!-- 프레임워크 패키지 로그 레벨 설정 -->
+      <Logger name="egovframework" level="DEBUG" additivity="false">
+        <AppenderRef ref="File"/>
+      </Logger>
+      <Logger name="org.egovframe" level="DEBUG" additivity="false">
+        <AppenderRef ref="File"/>
+      </Logger>
+      <Logger name="org.springframework" level="INFO" additivity="false">
+        <AppenderRef ref="File"/>
+      </Logger>
+      <Root level="WARN">
+        <AppenderRef ref="File"/>
+      </Root>
+    </Loggers>
+  </Configuration>


### PR DESCRIPTION
## Summary
- application.yml의 기존 로깅 레벨 설정을 주석 처리하고 log4j2 환경별 설정 파일을 로드하도록 수정
- dev/local/prod 환경별 log4j2.xml에 프레임워크 및 스프링 패키지 로그 레벨 정의

## Testing
- `mvn -q test` *(실패: 네트워크 문제로 parent POM을 다운로드하지 못함)*
- `mvn -q spring-boot:run -Dspring.profiles.active=local` *(실패: 위와 동일한 이유)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fc72f198832aa0e2db70468bce81