### PR TITLE
feat: 로컬 데이터소스용 JdbcTemplate 추가

### DIFF
--- a/src/main/java/egovframework/bat/domain/insa/EsntlIdGenerator.java
+++ b/src/main/java/egovframework/bat/domain/insa/EsntlIdGenerator.java
@@ -1,5 +1,6 @@
 package egovframework.bat.domain.insa;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
@@ -12,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class EsntlIdGenerator {
 
+    /** 로컬 DB 접근용 JdbcTemplate */
+    @Qualifier("jdbcTemplateLocal")
     private final JdbcTemplate jdbcTemplate;
 
     /**

--- a/src/main/resources/egovframework/batch/context-batch-datasource.xml
+++ b/src/main/resources/egovframework/batch/context-batch-datasource.xml
@@ -39,6 +39,11 @@
         <property name="password" value="${Globals.Local.Password}"/>
     </bean>
 
+    <!-- 로컬 데이터소스를 사용하는 JdbcTemplate -->
+    <bean id="jdbcTemplateLocal" class="org.springframework.jdbc.core.JdbcTemplate">
+        <property name="dataSource" ref="dataSource-local" />
+    </bean>
+
     <alias name="dataSource-stg" alias="egov.dataSource"/>
     <alias name="dataSource-stg" alias="dataSource"/>
 


### PR DESCRIPTION
## Summary
- 로컬 데이터소스를 사용하는 `jdbcTemplateLocal` 빈을 추가
- `EsntlIdGenerator`에서 로컬 JDBC 템플릿을 주입받도록 수정

## Testing
- `mvn -q test` *(실패: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4185a1b44832a953b8ab6798c3df6