### PR TITLE
JdbcTemplate 생성자 주입과 데이터소스 URL 로그 추가

### DIFF
--- a/src/main/java/egovframework/bat/domain/insa/EsntlIdGenerator.java
+++ b/src/main/java/egovframework/bat/domain/insa/EsntlIdGenerator.java
@@ -1,21 +1,45 @@
 package egovframework.bat.domain.insa;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
-
-import lombok.RequiredArgsConstructor;
 
 /**
  * COMTNEMPLYRINFO 테이블의 최대 ESNTL_ID를 조회하여 새로운 ID를 생성한다.
  */
 @Component
-@RequiredArgsConstructor
 public class EsntlIdGenerator {
 
+    /** 로거 */
+    private static final Logger LOGGER = LoggerFactory.getLogger(EsntlIdGenerator.class);
+
     /** 로컬 DB 접근용 JdbcTemplate */
-    @Qualifier("jdbcTemplateLocal")
     private final JdbcTemplate jdbcTemplate;
+
+    // 생성자 주입 시 Qualifier를 명시
+    public EsntlIdGenerator(@Qualifier("jdbcTemplateLocal") JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /**
+     * 빈 초기화 시 데이터소스 URL 확인용 로그를 출력한다.
+     */
+    @PostConstruct
+    public void logDataSourceUrl() {
+        try (Connection connection = jdbcTemplate.getDataSource().getConnection()) {
+            String url = connection.getMetaData().getURL();
+            LOGGER.info("사용 중인 데이터소스 URL: {}", url);
+        } catch (SQLException e) {
+            LOGGER.error("데이터소스 URL 조회 실패", e);
+        }
+    }
 
     /**
      * 주어진 프리픽스로 시작하는 ESNTL_ID의 최대값을 조회하여 다음 번호를 생성한다.


### PR DESCRIPTION
## Summary
- JdbcTemplate 필드의 @Qualifier 제거 후 생성자에서 직접 지정하여 주입 방식 개선
- 빈 초기화 시 데이터소스 URL을 로그로 출력해 올바른 연결 여부 확인

## Testing
- `mvn -q test` *(실패: org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 다운로드 불가 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a41ec03254832a92d7e3edb6f9e147