### PR TITLE
feat: zero-pad ESNTL_ID numbers

### DIFF
--- a/src/main/java/egovframework/bat/domain/insa/EsntlIdGenerator.java
+++ b/src/main/java/egovframework/bat/domain/insa/EsntlIdGenerator.java
@@ -62,7 +62,8 @@ public class EsntlIdGenerator {
                 nextNo = 1L;
             }
         }
-        return prefix + nextNo;
+        // ESNTL_ID 숫자 부분을 7자리로 0으로 패딩한다.
+        return String.format("%s%07d", prefix, nextNo);
     }
 }
 


### PR DESCRIPTION
## Summary
- pad ESNTL_ID numeric part to 7 digits with zeros

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.18)*

------
https://chatgpt.com/codex/tasks/task_e_68a517866140832a826b5ee849402414