### PR TITLE
프리픽스 기본값 LND 처리 및 문서 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ mvn -Pprod package    # 운영 환경 빌드
 ```
 
 각 프로필은 해당 환경의 `globals-<프로필>.properties` 파일을 사용하여 `globals.properties`를 생성합니다.
+
+배치 잡 실행 시 `sourceSystem` 파라미터를 생략하면 `LND` 프리픽스로 ESNTL_ID가 생성됩니다.

--- a/src/main/java/egovframework/bat/domain/insa/EmployeeInfoProcessor.java
+++ b/src/main/java/egovframework/bat/domain/insa/EmployeeInfoProcessor.java
@@ -29,6 +29,10 @@ public class EmployeeInfoProcessor implements ItemProcessor<EmployeeInfo, Employ
 
         // 원천 시스템에 해당하는 프리픽스를 조회
         String prefix = SourceSystemPrefix.getPrefix(sourceSystem);
+        // 프리픽스가 비어있으면 기본값 LND 사용
+        if (prefix.isEmpty()) {
+            prefix = "LND";
+        }
         // 프리픽스로 ESNTL_ID 생성
         item.setEsntlId(esntlIdGenerator.generate(prefix));
 

--- a/src/main/java/egovframework/bat/domain/insa/SourceSystemPrefix.java
+++ b/src/main/java/egovframework/bat/domain/insa/SourceSystemPrefix.java
@@ -22,16 +22,16 @@ public enum SourceSystemPrefix {
      * 소스 시스템에 해당하는 프리픽스를 반환한다.
      *
      * @param system 소스 시스템 값
-     * @return 매핑된 프리픽스, 없으면 빈 문자열
+     * @return 매핑된 프리픽스, 없으면 "LND"
      */
     public static String getPrefix(String system) {
         if (system == null) {
-            return "";
+            return "LND";
         }
         return Arrays.stream(values())
             .filter(v -> v.system.equalsIgnoreCase(system))
             .map(SourceSystemPrefix::getPrefix)
             .findFirst()
-            .orElse("");
+            .orElse("LND");
     }
 }


### PR DESCRIPTION
## 요약
- 프리픽스가 비어있을 때 기본값 LND 사용하도록 Processor 수정
- SourceSystemPrefix에서 기본 프리픽스를 LND로 반환하도록 변경
- sourceSystem 파라미터를 생략하면 LND 프리픽스를 사용한다는 설명 추가

## 테스트
- `mvn -q test` (네트워크 문제로 실패)


------
https://chatgpt.com/codex/tasks/task_e_68a519fc91f0832ab86910b065180be3