### PR TITLE
ESNTL_ID 생성 시 7자리 0패딩 적용

### DIFF
--- a/src/main/java/egovframework/bat/domain/insa/EsntlIdGenerator.java
+++ b/src/main/java/egovframework/bat/domain/insa/EsntlIdGenerator.java
@@ -63,7 +63,9 @@ public class EsntlIdGenerator {
             }
         }
         // ESNTL_ID 숫자 부분을 7자리로 0으로 패딩한다.
-        return String.format("%s%07d", prefix, nextNo);
+        String formattedNumber = String.format("%07d", nextNo);
+        // 프리픽스와 포맷된 숫자를 결합하여 최종 ESNTL_ID를 생성한다.
+        return prefix + formattedNumber;
     }
 }
 


### PR DESCRIPTION
## Summary
- generate 메서드에서 번호를 7자리 0패딩 후 프리픽스와 결합하도록 수정

## Testing
- `mvn -q test` (parent POM 의존성 해결 실패로 테스트 미실행)


------
https://chatgpt.com/codex/tasks/task_e_68a51c3e478c832abd04a3299deae432