### PR TITLE
ESNTL_ID 생성 로직 개선 및 테스트 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,13 +155,18 @@
 		    <artifactId>cubrid-jdbc</artifactId>
 		    <version>11.0.8.0319</version>
 		</dependency>
-		<dependency>
-		    <groupId>org.projectlombok</groupId>
-		    <artifactId>lombok</artifactId>
-		    <!--<version>1.18.34</version>-->
-		    <scope>provided</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                    <!--<version>1.18.34</version>-->
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.h2database</groupId>
+                    <artifactId>h2</artifactId>
+                    <scope>test</scope>
+                </dependency>
+        </dependencies>
        
     <!-- 환경별 프로필 설정 -->
     <profiles>

--- a/src/test/java/egovframework/bat/domain/insa/EsntlIdGeneratorTest.java
+++ b/src/test/java/egovframework/bat/domain/insa/EsntlIdGeneratorTest.java
@@ -1,0 +1,52 @@
+package egovframework.bat.domain.insa;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+/**
+ * ESNTL_ID 생성기가 각 레코드마다 고유한 값을 부여하는지 검증하는 테스트
+ */
+public class EsntlIdGeneratorTest {
+
+    private JdbcTemplate jdbcTemplate;
+    private EsntlIdGenerator generator;
+
+    @Before
+    public void setUp() {
+        // H2 인메모리 DB 설정 (MySQL 모드 사용)
+        DriverManagerDataSource ds = new DriverManagerDataSource();
+        ds.setDriverClassName("org.h2.Driver");
+        ds.setUrl("jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1");
+        ds.setUsername("sa");
+        ds.setPassword("");
+        jdbcTemplate = new JdbcTemplate(ds);
+
+        // 테스트용 테이블 생성
+        jdbcTemplate.execute("CREATE TABLE COMTNEMPLYRINFO (ESNTL_ID VARCHAR(20) PRIMARY KEY, EMPLYR_ID VARCHAR(20))");
+
+        generator = new EsntlIdGenerator(jdbcTemplate);
+    }
+
+    @Test
+    public void uniqueIdInsertTest() {
+        // 12건의 사원 정보를 업서트로 삽입하면서 ESNTL_ID를 생성
+        for (int i = 0; i < 12; i++) {
+            String esntlId = generator.generate("LND");
+            jdbcTemplate.update("INSERT INTO COMTNEMPLYRINFO (ESNTL_ID, EMPLYR_ID) VALUES (?, ?) ON DUPLICATE KEY UPDATE EMPLYR_ID = VALUES(EMPLYR_ID)", esntlId, "EMP" + i);
+        }
+
+        // 삽입된 ESNTL_ID 수와 고유성을 검증
+        List<String> ids = jdbcTemplate.queryForList("SELECT ESNTL_ID FROM COMTNEMPLYRINFO", String.class);
+        assertEquals(12, ids.size());
+        Set<String> unique = new HashSet<>(ids);
+        assertEquals(12, unique.size());
+    }
+}


### PR DESCRIPTION
## Summary
- ESNTL_ID를 프리픽스별로 메모리에서 증가시키도록 변경해 중복 없이 발급
- H2 기반 단위 테스트 추가로 12건 업서트 시 ESNTL_ID 중복 여부 검증

## Testing
- `mvn -q test` *(네트워크 오류로 parent POM을 가져오지 못해 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68a5433b3bdc832abe4664e8c3954b4e