### PR TITLE
mybatisToMybatisJob 경로 이동 및 설정 수정

### DIFF
--- a/src/main/java/com/springboot/main/EgovBootApplication.java
+++ b/src/main/java/com/springboot/main/EgovBootApplication.java
@@ -53,7 +53,7 @@ public class EgovBootApplication implements CommandLineRunner {
 		/*
 		 * 2. DB 실행 예제(DB To DB)에서 사용 할 Batch Job이 기술 된 xml파일 경로들(jobPaths)
 		 */
-        jobPaths.add("/egovframework/batch/job/mybatisToMybatisJob.xml");
+        jobPaths.add("/egovframework/batch/job/example/mybatisToMybatisJob.xml");
         // remote1 시스템에서 STG로, 이어서 STG에서 Local로 이관하는 두 배치를 등록
         jobPaths.add("/egovframework/batch/job/remote1ToStgJob.xml");
         jobPaths.add("/egovframework/batch/job/stgToLocalJob.xml");

--- a/src/main/resources/egovframework/batch/job/example/mybatisToMybatisJob.xml
+++ b/src/main/resources/egovframework/batch/job/example/mybatisToMybatisJob.xml
@@ -4,7 +4,7 @@
 		http://www.springframework.org/schema/batch D:\DEV\xsd\spring-batch-3.0.xsd">
 		<!-- http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-3.0.xsd"> -->
 
-	<import resource="abstract/eGovBase.xml" />
+	<import resource="../abstract/eGovBase.xml" />
 
 	<!-- commit-interval 값은 일반적으로 500~1000으로 설정함 -->
 	<job id="mybatisToMybatisJob" parent="eGovBaseJob" xmlns="http://www.springframework.org/schema/batch">


### PR DESCRIPTION
## 요약
- mybatisToMybatisJob.xml을 example 디렉터리로 이동하고 import 경로 수정
- EgovBootApplication에서 mybatisToMybatisJob 경로를 example 디렉터리로 변경
- scheduler 설정에서 mybatisToMybatisJob 등록 상태 확인

## 테스트
- `mvn -q test` (네트워크 문제로 parent POM을 받을 수 없어 실패)

------
https://chatgpt.com/codex/tasks/task_e_68a54a7af640832aa60c96fb0751ff93