### PR TITLE
배치 Job의 eGovBase import 경로 수정

### DIFF
--- a/src/main/resources/egovframework/batch/job/insa/remote1ToStgJob.xml
+++ b/src/main/resources/egovframework/batch/job/insa/remote1ToStgJob.xml
@@ -4,7 +4,7 @@
         http://www.springframework.org/schema/batch D:\DEV\xsd\spring-batch-3.0.xsd">
         <!-- http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-3.0.xsd"> -->
 
-    <import resource="abstract/eGovBase.xml" />
+    <import resource="../abstract/eGovBase.xml" />
 
     <!-- commit-interval 값은 일반적으로 500~1000으로 설정함 -->
     <job id="remote1ToStgJob" parent="eGovBaseJob" xmlns="http://www.springframework.org/schema/batch">

--- a/src/main/resources/egovframework/batch/job/insa/stgToLocalJob.xml
+++ b/src/main/resources/egovframework/batch/job/insa/stgToLocalJob.xml
@@ -4,7 +4,7 @@
         http://www.springframework.org/schema/batch D:\\DEV\\xsd\\spring-batch-3.0.xsd">
         <!-- http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-3.0.xsd -->
 
-    <import resource="abstract/eGovBase.xml" />
+    <import resource="../abstract/eGovBase.xml" />
 
     <!-- commit-interval 값은 일반적으로 500~1000으로 설정함 -->
     <job id="stgToLocalJob" parent="eGovBaseJob" xmlns="http://www.springframework.org/schema/batch">


### PR DESCRIPTION
## 요약
- remote1ToStgJob과 stgToLocalJob의 eGovBase import 경로를 상위 폴더로 수정

## 테스트
- `mvn -q test` (네트워크 문제로 실패)

------
https://chatgpt.com/codex/tasks/task_e_68a54de2b57c832aa84f40a44c0fe4a6