### PR TITLE
test: log generated ESNTL_ID

### DIFF
--- a/src/test/java/egovframework/bat/domain/insa/EsntlIdGeneratorTest.java
+++ b/src/test/java/egovframework/bat/domain/insa/EsntlIdGeneratorTest.java
@@ -8,6 +8,8 @@ import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
@@ -15,6 +17,9 @@ import org.springframework.jdbc.datasource.DriverManagerDataSource;
  * ESNTL_ID 생성기가 각 레코드마다 고유한 값을 부여하는지 검증하는 테스트
  */
 public class EsntlIdGeneratorTest {
+
+    /** 로깅을 위한 로거 */
+    private static final Logger LOGGER = LoggerFactory.getLogger(EsntlIdGeneratorTest.class);
 
     private JdbcTemplate jdbcTemplate;
     private EsntlIdGenerator generator;
@@ -40,7 +45,14 @@ public class EsntlIdGeneratorTest {
         // 12건의 사원 정보를 업서트로 삽입하면서 ESNTL_ID를 생성
         for (int i = 0; i < 12; i++) {
             String esntlId = generator.generate("LND");
-            jdbcTemplate.update("INSERT INTO COMTNEMPLYRINFO (ESNTL_ID, EMPLYR_ID) VALUES (?, ?) ON DUPLICATE KEY UPDATE EMPLYR_ID = VALUES(EMPLYR_ID)", esntlId, "EMP" + i);
+            // 생성된 ESNTL_ID를 로깅 및 출력
+            LOGGER.info("생성된 ESNTL_ID: {}", esntlId);
+            System.out.println("생성된 ESNTL_ID: " + esntlId);
+
+            jdbcTemplate.update(
+                "INSERT INTO COMTNEMPLYRINFO (ESNTL_ID, EMPLYR_ID) VALUES (?, ?) ON DUPLICATE KEY UPDATE EMPLYR_ID = VALUES(EMPLYR_ID)",
+                esntlId,
+                "EMP" + i);
         }
 
         // 삽입된 ESNTL_ID 수와 고유성을 검증


### PR DESCRIPTION
## Summary
- 테스트 반복문에서 생성된 ESNTL_ID를 로깅 및 콘솔 출력하도록 추가

## Testing
- `mvn -q test` *(실패: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a55065de38832aa2c66829a125b686