### PR TITLE
remote1→STG 이관 쿼리 중복 갱신 제거

### DIFF
--- a/src/main/resources/egovframework/mapper/insa/insa_remote1_to_stg.xml
+++ b/src/main/resources/egovframework/mapper/insa/insa_remote1_to_stg.xml
@@ -29,32 +29,18 @@
                 FROM COMTNEMPLYRINFO
         </select>
 
-        <!-- STG DB에 조직 정보 적재 -->
-        <insert id="insertOrganization" parameterType="egovframework.bat.domain.insa.EmployeeInfo">
-                INSERT INTO COMTNORGNZTINFO (ORGNZT_ID, ORGNZT_NM, ORGNZT_DC)
-                                VALUES (#{orgnztId}, #{orgnztNm}, #{orgnztDc})
-                        ON DUPLICATE KEY UPDATE
-                                ORGNZT_NM = VALUES(ORGNZT_NM),
-                                ORGNZT_DC = VALUES(ORGNZT_DC)
-        </insert>
+       <!-- STG DB에 조직 정보 적재 (STG 대상 테이블이 사전 TRUNCATE되므로 중복 갱신 없음) -->
+       <insert id="insertOrganization" parameterType="egovframework.bat.domain.insa.EmployeeInfo">
+               INSERT INTO COMTNORGNZTINFO (ORGNZT_ID, ORGNZT_NM, ORGNZT_DC)
+               VALUES (#{orgnztId}, #{orgnztNm}, #{orgnztDc})
+       </insert>
 
-        <!-- remote1 -> STG 이관 시 사용 (ESNTL_ID 제외) -->
-        <insert id="insertEmployeeLegacy" parameterType="egovframework.bat.domain.insa.EmployeeInfo">
-                INSERT INTO COMTNEMPLYRINFO
-                        (EMPLYR_ID, ORGNZT_ID, USER_NM, SEXDSTN_CODE, BRTHDY, MBTLNUM, EMAIL_ADRES, OFCPS_NM, EMPLYR_STTUS_CODE, REG_DTTM, MOD_DTTM)
-                VALUES
-                        (#{emplyrId}, #{orgnztId}, #{userNm}, #{sexdstnCode}, #{brthdy}, #{mbtlnum}, #{emailAdres}, #{ofcpsNm}, #{emplyrSttusCode}, #{regDttm}, #{modDttm})
-                ON DUPLICATE KEY UPDATE
-                        ORGNZT_ID = VALUES(ORGNZT_ID),
-                        USER_NM = VALUES(USER_NM),
-                        SEXDSTN_CODE = VALUES(SEXDSTN_CODE),
-                        BRTHDY = VALUES(BRTHDY),
-                        MBTLNUM = VALUES(MBTLNUM),
-                        EMAIL_ADRES = VALUES(EMAIL_ADRES),
-                        OFCPS_NM = VALUES(OFCPS_NM),
-                        EMPLYR_STTUS_CODE = VALUES(EMPLYR_STTUS_CODE),
-                        REG_DTTM = VALUES(REG_DTTM),
-                        MOD_DTTM = VALUES(MOD_DTTM)
-        </insert>
+       <!-- remote1 -> STG 이관 시 사용 (ESNTL_ID 제외, STG 대상 테이블이 사전 TRUNCATE되므로 중복 갱신 없음) -->
+       <insert id="insertEmployeeLegacy" parameterType="egovframework.bat.domain.insa.EmployeeInfo">
+               INSERT INTO COMTNEMPLYRINFO
+                       (EMPLYR_ID, ORGNZT_ID, USER_NM, SEXDSTN_CODE, BRTHDY, MBTLNUM, EMAIL_ADRES, OFCPS_NM, EMPLYR_STTUS_CODE, REG_DTTM, MOD_DTTM)
+               VALUES
+                       (#{emplyrId}, #{orgnztId}, #{userNm}, #{sexdstnCode}, #{brthdy}, #{mbtlnum}, #{emailAdres}, #{ofcpsNm}, #{emplyrSttusCode}, #{regDttm}, #{modDttm})
+       </insert>
 
 </mapper>


### PR DESCRIPTION
## Summary
- STG 이관 시 조직·사원 적재 쿼리에서 ON DUPLICATE KEY UPDATE 제거
- STG 대상 테이블이 사전 TRUNCATE됨을 주석으로 명시

## Testing
- `mvn -q test` *(실패: org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 부재)*

------
https://chatgpt.com/codex/tasks/task_e_68a56bb8004c832ab88b495f88881cd2