### PR TITLE
EgovJobLauncherDetails 클래스 패키지 이동

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Spring Batch는 두 가지 대표적인 Step 구현 방식을 제공합니다.
 - `src/main/resources/egovframework/mapper/example/Egov_Example_SQL.xml`: 예제 배치를 위한 SQL 매퍼 파일
 - `src/main/java/egovframework/example/domain/trade/CustomerCredit.java`: 고객 신용 정보를 담는 도메인 클래스
 - `src/main/java/egovframework/example/domain/trade/CustomerCreditIncreaseProcessor.java`: 신용 증가 로직을 처리하는 배치 프로세서
-- `src/main/java/egovframework/example/scheduler/support/EgovJobLauncherDetails.java`: Quartz 스케줄러에서 배치 Job을 실행하는 지원 클래스
+- `src/main/java/egovframework/scheduler/support/EgovJobLauncherDetails.java`: Quartz 스케줄러에서 배치 Job을 실행하는 지원 클래스
 - `src/main/resources/egovframework/batch/context-batch-mapper.xml`: 예제 SQL 매퍼와 데이터소스가 등록된 설정 파일
 - `src/main/resources/egovframework/batch/context-scheduler-job.xml`: 예제 Job을 스케줄러에 등록하기 위한 설정 파일
 

--- a/src/main/java/egovframework/scheduler/support/EgovJobLauncherDetails.java
+++ b/src/main/java/egovframework/scheduler/support/EgovJobLauncherDetails.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package egovframework.example.scheduler.support;
+package egovframework.scheduler.support;
 
 import java.util.Date;
 import java.util.Map;

--- a/src/main/resources/egovframework/batch/context-scheduler-job.xml
+++ b/src/main/resources/egovframework/batch/context-scheduler-job.xml
@@ -3,7 +3,7 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
 
 	<bean id="jobDetail" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
-		<property name="jobClass" value="egovframework.example.scheduler.support.EgovJobLauncherDetails" />
+		<property name="jobClass" value="egovframework.scheduler.support.EgovJobLauncherDetails" />
 		<property name="group" value="quartz-batch" />
 		<property name="jobDataAsMap">
 			<map>
@@ -16,7 +16,7 @@
 	</bean>
 	
     <bean id="remote1ToStgJobDetail" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
-        <property name="jobClass" value="egovframework.example.scheduler.support.EgovJobLauncherDetails" />
+        <property name="jobClass" value="egovframework.scheduler.support.EgovJobLauncherDetails" />
         <property name="group" value="quartz-batch" />
         <property name="jobDataAsMap">
             <map>
@@ -29,7 +29,7 @@
     </bean>
 
     <bean id="stgToLocalJobDetail" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
-        <property name="jobClass" value="egovframework.example.scheduler.support.EgovJobLauncherDetails" />
+        <property name="jobClass" value="egovframework.scheduler.support.EgovJobLauncherDetails" />
         <property name="group" value="quartz-batch" />
         <property name="jobDataAsMap">
             <map>


### PR DESCRIPTION
## 요약
- EgovJobLauncherDetails를 example 패키지 밖으로 이동해 공통 스케줄러 지원 패키지로 정리
- 관련 XML과 README의 경로 수정

## 테스트
- `mvn -q -e test` (네트워크 단절로 부모 POM을 받을 수 없어 실패)

------
https://chatgpt.com/codex/tasks/task_e_68a58f13ffc0832ab6dfc9ab2c6da4aa