### PR TITLE
패키지 경로를 egovframework.bat.example.domain으로 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Spring Batch는 두 가지 대표적인 Step 구현 방식을 제공합니다.
 
 - `src/main/resources/egovframework/batch/job/example/mybatisToMybatisJob.xml`: MyBatis 간 데이터 이동을 정의한 배치 Job 설정 파일
 - `src/main/resources/egovframework/mapper/example/Egov_Example_SQL.xml`: 예제 배치를 위한 SQL 매퍼 파일
-- `src/main/java/egovframework/example/domain/trade/CustomerCredit.java`: 고객 신용 정보를 담는 도메인 클래스
-- `src/main/java/egovframework/example/domain/trade/CustomerCreditIncreaseProcessor.java`: 신용 증가 로직을 처리하는 배치 프로세서
+- `src/main/java/egovframework/bat/example/domain/CustomerCredit.java`: 고객 신용 정보를 담는 도메인 클래스
+- `src/main/java/egovframework/bat/example/domain/CustomerCreditIncreaseProcessor.java`: 신용 증가 로직을 처리하는 배치 프로세서
 - `src/main/java/egovframework/scheduler/support/EgovJobLauncherDetails.java`: Quartz 스케줄러에서 배치 Job을 실행하는 지원 클래스
 - `src/main/resources/egovframework/batch/context-batch-mapper.xml`: 예제 SQL 매퍼와 데이터소스가 등록된 설정 파일
 - `src/main/resources/egovframework/batch/context-scheduler-job.xml`: 예제 Job을 스케줄러에 등록하기 위한 설정 파일

--- a/src/main/java/egovframework/bat/example/domain/CustomerCredit.java
+++ b/src/main/java/egovframework/bat/example/domain/CustomerCredit.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package egovframework.example.domain.trade;
+package egovframework.bat.example.domain;
 
 import java.math.BigDecimal;
 

--- a/src/main/java/egovframework/bat/example/domain/CustomerCreditIncreaseProcessor.java
+++ b/src/main/java/egovframework/bat/example/domain/CustomerCreditIncreaseProcessor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package egovframework.example.domain.trade;
+package egovframework.bat.example.domain;
 
 import java.math.BigDecimal;
 

--- a/src/main/resources/egovframework/batch/job/example/mybatisToMybatisJob.xml
+++ b/src/main/resources/egovframework/batch/job/example/mybatisToMybatisJob.xml
@@ -31,6 +31,6 @@
         <property name="statementId" value="Customer.updateCredit" />
     </bean>
 
-	<bean id="mybatisToIbatisJob.mybatisToIbatisStep.itemProcessor" class="egovframework.example.domain.trade.CustomerCreditIncreaseProcessor" />
+	<bean id="mybatisToIbatisJob.mybatisToIbatisStep.itemProcessor" class="egovframework.bat.example.domain.CustomerCreditIncreaseProcessor" />
 
 </beans>

--- a/src/main/resources/egovframework/mapper/example/Egov_Example_SQL.xml
+++ b/src/main/resources/egovframework/mapper/example/Egov_Example_SQL.xml
@@ -3,7 +3,7 @@
 
 <mapper namespace="Customer">
 
-  <resultMap id="result" type="egovframework.example.domain.trade.CustomerCredit">
+  <resultMap id="result" type="egovframework.bat.example.domain.CustomerCredit">
     <result property="name" column="NAME" />
     <result property="credit" column="CREDIT" />
   </resultMap>
@@ -20,7 +20,7 @@
   	select NAME, CREDIT from CUSTOMER where ID = #{value}
   </select>
   
-  <update id="updateCredit" parameterType="egovframework.example.domain.trade.CustomerCredit" >
+  <update id="updateCredit" parameterType="egovframework.bat.example.domain.CustomerCredit" >
   	update CUSTOMER set CREDIT = #{credit} where NAME = #{name}
   </update>
   


### PR DESCRIPTION
## 요약
- 도메인 클래스와 프로세서의 패키지를 `egovframework.bat.example.domain`으로 이동
- 관련 XML 설정과 문서의 패키지 경로 업데이트

## 테스트
- `mvn -q test` *(실패: 원격 저장소에 연결할 수 없어 parent POM을 해석하지 못함)*

------
https://chatgpt.com/codex/tasks/task_e_68a5924340f0832a827c3a9c1534c59a