### PR TITLE
EgovQuartzJobLauncher로 클래스 이동 및 설정 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Spring Batch는 두 가지 대표적인 Step 구현 방식을 제공합니다.
 - `src/main/resources/egovframework/mapper/example/Egov_Example_SQL.xml`: 예제 배치를 위한 SQL 매퍼 파일
 - `src/main/java/egovframework/bat/example/domain/CustomerCredit.java`: 고객 신용 정보를 담는 도메인 클래스
 - `src/main/java/egovframework/bat/example/domain/CustomerCreditIncreaseProcessor.java`: 신용 증가 로직을 처리하는 배치 프로세서
-- `src/main/java/egovframework/bat/scheduler/support/EgovJobLauncherDetails.java`: Quartz 스케줄러에서 배치 Job을 실행하는 지원 클래스
+- `src/main/java/egovframework/bat/scheduler/EgovQuartzJobLauncher.java`: Quartz 스케줄러에서 배치 Job을 실행하는 클래스
 - `src/main/resources/egovframework/batch/context-batch-mapper.xml`: 예제 SQL 매퍼와 데이터소스가 등록된 설정 파일
 - `src/main/resources/egovframework/batch/context-scheduler-job.xml`: 예제 Job을 스케줄러에 등록하기 위한 설정 파일
 

--- a/src/main/java/egovframework/bat/scheduler/EgovQuartzJobLauncher.java
+++ b/src/main/java/egovframework/bat/scheduler/EgovQuartzJobLauncher.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package egovframework.bat.scheduler.support;
+package egovframework.bat.scheduler;
 
 import java.util.Date;
 import java.util.Map;
@@ -31,6 +31,8 @@ import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.scheduling.quartz.QuartzJobBean;
 
 /**
+ * Quartz 스케줄러에서 Spring Batch Job을 실행하는 클래스입니다.
+ *
  * @author 배치실행개발팀
  * @since 2012. 07.25
  * @version 1.0
@@ -44,14 +46,14 @@ import org.springframework.scheduling.quartz.QuartzJobBean;
  *  </pre>
  */
 
-public class EgovJobLauncherDetails extends QuartzJobBean {
+public class EgovQuartzJobLauncher extends QuartzJobBean {
 
 	/**
 	 * Special key in job data map for the name of a job to run.
 	 */
 	static final String JOB_NAME = "jobName";
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(EgovJobLauncherDetails.class);
+        private static final Logger LOGGER = LoggerFactory.getLogger(EgovQuartzJobLauncher.class);
 
 	private JobLocator jobLocator;
 

--- a/src/main/resources/egovframework/batch/context-scheduler-job.xml
+++ b/src/main/resources/egovframework/batch/context-scheduler-job.xml
@@ -3,7 +3,7 @@
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
 
 	<bean id="jobDetail" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
-		<property name="jobClass" value="egovframework.bat.scheduler.support.EgovJobLauncherDetails" />
+                <property name="jobClass" value="egovframework.bat.scheduler.EgovQuartzJobLauncher" />
 		<property name="group" value="quartz-batch" />
 		<property name="jobDataAsMap">
 			<map>
@@ -16,7 +16,7 @@
 	</bean>
 	
     <bean id="remote1ToStgJobDetail" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
-        <property name="jobClass" value="egovframework.bat.scheduler.support.EgovJobLauncherDetails" />
+        <property name="jobClass" value="egovframework.bat.scheduler.EgovQuartzJobLauncher" />
         <property name="group" value="quartz-batch" />
         <property name="jobDataAsMap">
             <map>
@@ -29,7 +29,7 @@
     </bean>
 
     <bean id="stgToLocalJobDetail" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
-        <property name="jobClass" value="egovframework.bat.scheduler.support.EgovJobLauncherDetails" />
+        <property name="jobClass" value="egovframework.bat.scheduler.EgovQuartzJobLauncher" />
         <property name="group" value="quartz-batch" />
         <property name="jobDataAsMap">
             <map>


### PR DESCRIPTION
## 요약
- EgovJobLauncherDetails를 EgovQuartzJobLauncher로 이동 및 클래스명 변경
- Quartz 설정 파일에서 새로운 런처 클래스로 참조 수정
- README에 변경된 클래스 경로 반영

## 테스트
- `mvn test` (실패: 원격 저장소에 접근할 수 없어 parent POM을 해석하지 못함)


------
https://chatgpt.com/codex/tasks/task_e_68a67242643c832a85a9190e9adec6d9