### PR TITLE
EmployeeInfoProcessor 패키지 구조 변경 및 설정 경로 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Spring Batch는 두 가지 대표적인 Step 구현 방식을 제공합니다.
   - `src/main/resources/egovframework/batch/mapper/insa/insa_stg_to_local.xml`: 스테이징→로컬 데이터 이동을 위한 SQL 매퍼
 - 도메인 및 유틸 클래스:
   - `src/main/java/egovframework/bat/insa/domain/SourceSystemPrefix.java`: 시스템 구분을 위한 접두어 상수 정의 클래스
-  - `src/main/java/egovframework/bat/insa/domain/EmployeeInfoProcessor.java`: 직원 정보를 처리하는 배치 프로세서
+  - `src/main/java/egovframework/bat/insa/processor/EmployeeInfoProcessor.java`: 직원 정보를 처리하는 배치 프로세서
   - `src/main/java/egovframework/bat/insa/domain/EsntlIdGenerator.java`: ESNTL_ID를 생성하는 유틸리티 클래스
   - `src/main/java/egovframework/bat/insa/domain/EmployeeInfo.java`: 직원 정보를 담는 도메인 클래스
   - `src/main/java/egovframework/bat/insa/domain/Orgnztinfo.java`: 조직 정보를 표현하는 도메인 클래스

--- a/src/main/java/egovframework/bat/insa/processor/EmployeeInfoProcessor.java
+++ b/src/main/java/egovframework/bat/insa/processor/EmployeeInfoProcessor.java
@@ -1,10 +1,13 @@
-package egovframework.bat.insa.domain;
+package egovframework.bat.insa.processor;
 
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import egovframework.bat.insa.domain.EmployeeInfo;
+import egovframework.bat.insa.domain.EsntlIdGenerator;
+import egovframework.bat.insa.domain.SourceSystemPrefix;
 import lombok.RequiredArgsConstructor;
 
 /**

--- a/src/main/resources/egovframework/batch/job/insa/stgToLocalJob.xml
+++ b/src/main/resources/egovframework/batch/job/insa/stgToLocalJob.xml
@@ -54,7 +54,7 @@
 
     <!-- jobParameters를 사용하기 위해 스텝 스코프로 지정 -->
     <bean id="stgToLocalJob.stgToLocalStep.itemProcessor"
-          class="egovframework.bat.insa.domain.EmployeeInfoProcessor"
+          class="egovframework.bat.insa.processor.EmployeeInfoProcessor"
           scope="step" />
 
 </beans>


### PR DESCRIPTION
## Summary
- EmployeeInfoProcessor를 processor 패키지로 이동하고 관련 의존성 import 추가
- stgToLocalJob 설정에서 새 프로세서 경로로 클래스 지정
- README의 EmployeeInfoProcessor 경로 예시를 최신 패키지 구조로 업데이트

## Testing
- `mvn -q test` *(실패: Maven parent POM을 다운로드하지 못함 - 네트워크 문제)*

------
https://chatgpt.com/codex/tasks/task_e_68a6839d1c00832a89aad556ffdb75b6