### PR TITLE
EsntlIdGenerator를 util 패키지로 이동

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Spring Batch는 두 가지 대표적인 Step 구현 방식을 제공합니다.
 - 도메인 및 유틸 클래스:
   - `src/main/java/egovframework/bat/insa/domain/SourceSystemPrefix.java`: 시스템 구분을 위한 접두어 상수 정의 클래스
   - `src/main/java/egovframework/bat/insa/domain/EmployeeInfoProcessor.java`: 직원 정보를 처리하는 배치 프로세서
-  - `src/main/java/egovframework/bat/insa/domain/EsntlIdGenerator.java`: ESNTL_ID를 생성하는 유틸리티 클래스
+  - `src/main/java/egovframework/bat/insa/util/EsntlIdGenerator.java`: ESNTL_ID를 생성하는 유틸리티 클래스
   - `src/main/java/egovframework/bat/insa/domain/EmployeeInfo.java`: 직원 정보를 담는 도메인 클래스
   - `src/main/java/egovframework/bat/insa/domain/Orgnztinfo.java`: 조직 정보를 표현하는 도메인 클래스
 - 테스트 코드:

--- a/src/main/java/egovframework/bat/insa/domain/EmployeeInfoProcessor.java
+++ b/src/main/java/egovframework/bat/insa/domain/EmployeeInfoProcessor.java
@@ -5,6 +5,8 @@ import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import egovframework.bat.insa.util.EsntlIdGenerator;
+
 import lombok.RequiredArgsConstructor;
 
 /**

--- a/src/main/java/egovframework/bat/insa/util/EsntlIdGenerator.java
+++ b/src/main/java/egovframework/bat/insa/util/EsntlIdGenerator.java
@@ -1,4 +1,4 @@
-package egovframework.bat.insa.domain;
+package egovframework.bat.insa.util;
 
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/src/test/java/egovframework/bat/insa/domain/EsntlIdGeneratorTest.java
+++ b/src/test/java/egovframework/bat/insa/domain/EsntlIdGeneratorTest.java
@@ -13,6 +13,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
+import egovframework.bat.insa.util.EsntlIdGenerator;
+
 /**
  * ESNTL_ID 생성기가 각 레코드마다 고유한 값을 부여하는지 검증하는 테스트
  */


### PR DESCRIPTION
## 요약
- EsntlIdGenerator를 util 패키지로 이동
- 관련 import 및 문서 경로를 신규 패키지에 맞게 수정

## 테스트
- `mvn -q test` *(네트워크 문제로 실패: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a6839ec400832ab0f3eb1125ecaa1a