### PR TITLE
SourceSystemPrefix 공통 패키지 이동 및 문서 경로 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Spring Batch는 두 가지 대표적인 Step 구현 방식을 제공합니다.
   - `src/main/resources/egovframework/batch/mapper/insa/insa_remote1_to_stg.xml`: 원격→스테이징 데이터 이동을 위한 SQL 매퍼
   - `src/main/resources/egovframework/batch/mapper/insa/insa_stg_to_local.xml`: 스테이징→로컬 데이터 이동을 위한 SQL 매퍼
 - 도메인 및 유틸 클래스:
-  - `src/main/java/egovframework/bat/insa/domain/SourceSystemPrefix.java`: 시스템 구분을 위한 접두어 상수 정의 클래스
+  - `src/main/java/egovframework/bat/insa/common/SourceSystemPrefix.java`: 시스템 구분을 위한 접두어 상수 정의 클래스
   - `src/main/java/egovframework/bat/insa/domain/EmployeeInfoProcessor.java`: 직원 정보를 처리하는 배치 프로세서
   - `src/main/java/egovframework/bat/insa/domain/EsntlIdGenerator.java`: ESNTL_ID를 생성하는 유틸리티 클래스
   - `src/main/java/egovframework/bat/insa/domain/EmployeeInfo.java`: 직원 정보를 담는 도메인 클래스
@@ -54,6 +54,7 @@ Spring Batch는 두 가지 대표적인 Step 구현 방식을 제공합니다.
 
 - 설정 파일: `src/main/resources/egovframework/batch/job/insa`에 `<Source>To<Target>Job.xml` 형태로 저장합니다. 파일명은 lowerCamelCase를 사용하며 반드시 `Job.xml`으로 끝납니다.
 - 관련 도메인 클래스: `src/main/java/egovframework/bat/insa/domain` 아래에 작성하고 패키지 구조를 유지합니다.
+- 공통 클래스: `src/main/java/egovframework/bat/insa/common` 아래에 작성하고 패키지 구조를 유지합니다.
 - 테스트 코드: `src/test/java/egovframework/bat/insa/domain`에 동일한 패키지 구조로 작성합니다.
 
 ## 예제 배치 잡 디렉터리(`example`)

--- a/src/main/java/egovframework/bat/insa/common/SourceSystemPrefix.java
+++ b/src/main/java/egovframework/bat/insa/common/SourceSystemPrefix.java
@@ -1,4 +1,4 @@
-package egovframework.bat.insa.domain;
+package egovframework.bat.insa.common;
 
 import java.util.Arrays;
 

--- a/src/main/java/egovframework/bat/insa/domain/EmployeeInfoProcessor.java
+++ b/src/main/java/egovframework/bat/insa/domain/EmployeeInfoProcessor.java
@@ -1,5 +1,6 @@
 package egovframework.bat.insa.domain;
 
+import egovframework.bat.insa.common.SourceSystemPrefix;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Value;


### PR DESCRIPTION
## 변경 내용
- SourceSystemPrefix를 공통 패키지로 이동하고 패키지 선언 수정
- EmployeeInfoProcessor가 새 패키지를 import하도록 수정
- README 경로 예시 업데이트

## 테스트
- `mvn -q test` (네트워크 오류로 실패)


------
https://chatgpt.com/codex/tasks/task_e_68a683a02f74832a8c1553d5f988a642