### PR TITLE
refactor: relocate EsntlIdGenerator to util package

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ Spring Batch는 두 가지 대표적인 Step 구현 방식을 제공합니다.
 - 도메인 및 유틸 클래스:
   - `src/main/java/egovframework/bat/insa/domain/SourceSystemPrefix.java`: 시스템 구분을 위한 접두어 상수 정의 클래스
   - `src/main/java/egovframework/bat/insa/processor/EmployeeInfoProcessor.java`: 직원 정보를 처리하는 배치 프로세서
-  - `src/main/java/egovframework/bat/insa/domain/EsntlIdGenerator.java`: ESNTL_ID를 생성하는 유틸리티 클래스
+  - `src/main/java/egovframework/bat/insa/util/EsntlIdGenerator.java`: ESNTL_ID를 생성하는 유틸리티 클래스
   - `src/main/java/egovframework/bat/insa/domain/EmployeeInfo.java`: 직원 정보를 담는 도메인 클래스
   - `src/main/java/egovframework/bat/insa/domain/Orgnztinfo.java`: 조직 정보를 표현하는 도메인 클래스
 - 테스트 코드:
-  - `src/test/java/egovframework/bat/insa/domain/EsntlIdGeneratorTest.java`: ESNTL_ID 생성 로직을 검증하는 테스트
+  - `src/test/java/egovframework/bat/insa/util/EsntlIdGeneratorTest.java`: ESNTL_ID 생성 로직을 검증하는 테스트
 
 ### 인사 배치 Job 추가시 확인 사항
 

--- a/src/main/java/egovframework/bat/insa/processor/EmployeeInfoProcessor.java
+++ b/src/main/java/egovframework/bat/insa/processor/EmployeeInfoProcessor.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import egovframework.bat.insa.domain.EmployeeInfo;
-import egovframework.bat.insa.domain.EsntlIdGenerator;
+import egovframework.bat.insa.util.EsntlIdGenerator;
 import egovframework.bat.insa.domain.SourceSystemPrefix;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/egovframework/bat/insa/util/EsntlIdGenerator.java
+++ b/src/main/java/egovframework/bat/insa/util/EsntlIdGenerator.java
@@ -1,4 +1,4 @@
-package egovframework.bat.insa.domain;
+package egovframework.bat.insa.util;
 
 import java.sql.Connection;
 import java.sql.SQLException;

--- a/src/test/java/egovframework/bat/insa/util/EsntlIdGeneratorTest.java
+++ b/src/test/java/egovframework/bat/insa/util/EsntlIdGeneratorTest.java
@@ -1,4 +1,4 @@
-package egovframework.bat.insa.domain;
+package egovframework.bat.insa.util;
 
 import static org.junit.Assert.assertEquals;
 
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import egovframework.bat.insa.util.EsntlIdGenerator;
 
 /**
  * ESNTL_ID 생성기가 각 레코드마다 고유한 값을 부여하는지 검증하는 테스트


### PR DESCRIPTION
## Summary
- `EsntlIdGenerator`를 `util` 패키지로 이동하고 패키지명을 수정
- 새 패키지에 맞게 `EmployeeInfoProcessor`와 테스트 코드를 업데이트
- README의 경로 안내를 최신 구조에 맞게 반영

## Testing
- `mvn -q test` *(실패: Non-resolvable parent POM; 네트워크에 접근할 수 없음)*

------
https://chatgpt.com/codex/tasks/task_e_68a686089848832a91a8ae68083397c1