### PR TITLE
fix: 웹 애플리케이션 타입을 SERVLET으로 설정

### DIFF
--- a/src/main/java/com/springboot/main/EgovBootApplication.java
+++ b/src/main/java/com/springboot/main/EgovBootApplication.java
@@ -36,9 +36,9 @@ public class EgovBootApplication implements CommandLineRunner {
 
 		LOGGER.info("##### EgovSampleBootApplication Start #####");
 
-		SpringApplication springApplication = new SpringApplication(EgovBootApplication.class);
-		springApplication.setWebApplicationType(WebApplicationType.NONE);
-		springApplication.setHeadless(false);
+                SpringApplication springApplication = new SpringApplication(EgovBootApplication.class);
+                springApplication.setWebApplicationType(WebApplicationType.SERVLET); // 웹 환경에서 동작하도록 설정
+                springApplication.setHeadless(false);
 		springApplication.setBannerMode(Banner.Mode.CONSOLE);
 		springApplication.run(args);
 		


### PR DESCRIPTION
## Summary
- 웹 애플리케이션 타입을 NONE에서 SERVLET으로 변경하여 Spring Boot 웹 환경 지원

## Testing
- `mvn -q test` *(실패: 상위 POM 다운로드 시 네트워크 연결 불가)*

------
https://chatgpt.com/codex/tasks/task_e_68a698e5d77c832abccaef01d9492608