### PR TITLE
README에 ExampleJobController 코드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,64 @@ Spring Batch는 두 가지 대표적인 Step 구현 방식을 제공합니다.
 - `src/main/resources/egovframework/batch/mapper/example/Egov_Example_SQL.xml`: 예제 배치를 위한 SQL 매퍼 파일
 - `src/main/java/egovframework/bat/example/domain/CustomerCredit.java`: 고객 신용 정보를 담는 도메인 클래스
 - `src/main/java/egovframework/bat/example/processor/CustomerCreditIncreaseProcessor.java`: 신용 증가 로직을 처리하는 배치 프로세서
+- `src/main/java/egovframework/bat/example/api/ExampleJobController.java`: REST API로 예제 배치 잡을 실행하는 컨트롤러
 - `src/main/java/egovframework/bat/scheduler/EgovQuartzJobLauncher.java`: Quartz 스케줄러에서 배치 Job을 실행하는 클래스
 - `src/main/resources/egovframework/batch/context-batch-mapper.xml`: 예제 SQL 매퍼와 데이터소스가 등록된 설정 파일
 - `src/main/resources/egovframework/batch/context-scheduler-job.xml`: 예제 Job을 스케줄러에 등록하기 위한 설정 파일
+
+### ExampleJobController.java
+
+```java
+package egovframework.bat.example.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 마이바티스 예제 배치 잡을 REST API로 실행하기 위한 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api/batch")
+@RequiredArgsConstructor
+public class ExampleJobController {
+
+    // 스프링 배치 잡 실행기
+    private final JobLauncher jobLauncher;
+
+    // MyBatis 데이터를 MyBatis 데이터베이스로 옮기는 배치 잡
+    private final Job mybatisToMybatisJob;
+
+    /**
+     * 마이바티스 배치 잡을 실행한다.
+     *
+     * @param userId 사용자를 식별하기 위한 값 (선택)
+     * @return 배치 잡 실행 결과 상태
+     * @throws Exception 배치 실행 중 발생한 예외
+     */
+    @PostMapping("/mybatis")
+    public BatchStatus runMybatisJob(@RequestParam(value = "userId", required = false) String userId) throws Exception {
+        JobParametersBuilder builder = new JobParametersBuilder()
+            .addLong("timestamp", System.currentTimeMillis());
+
+        if (userId != null) {
+            builder.addString("userId", userId);
+        }
+
+        JobParameters jobParameters = builder.toJobParameters();
+        JobExecution execution = jobLauncher.run(mybatisToMybatisJob, jobParameters);
+        return execution.getStatus();
+    }
+}
+```
 
 ## 완전 새로운 배치 작업 추가시 매뉴얼
 


### PR DESCRIPTION
## 요약
- 예제 배치 잡 섹션에 `ExampleJobController` 경로와 설명 추가
- `ExampleJobController.java` 전체 내용을 README에 코드 블록으로 포함

## 테스트
- `mvn -q test` (네트워크 오류로 실패)

------
https://chatgpt.com/codex/tasks/task_e_68a69c31e060832a877d473e0a0636a9