### PR TITLE
CRM 연동 매퍼 및 SqlSessionFactory 추가

### DIFF
--- a/src/main/resources/egovframework/batch/context-batch-mapper.xml
+++ b/src/main/resources/egovframework/batch/context-batch-mapper.xml
@@ -53,4 +53,40 @@
         </property>
     </bean>
 
+    <!-- CRM REST->STG 적재용 SqlSessionFactory -->
+    <bean id="sqlSessionFactory-crm-to-stg" class="org.mybatis.spring.SqlSessionFactoryBean">
+        <property name="dataSource" ref="dataSource-stg"/>
+        <property name="configLocation" value="classpath:/egovframework/batch/mapper/config/mapper-config.xml" />
+        <property name="mapperLocations">
+            <list>
+                <value>classpath:/egovframework/batch/mapper/example/Egov_Example_SQL.xml</value>
+                <value>classpath:/egovframework/batch/mapper/crm/crm_rest_to_stg.xml</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- CRM STG 조회용 SqlSessionFactory -->
+    <bean id="sqlSessionFactory-crm-stg-local" class="org.mybatis.spring.SqlSessionFactoryBean">
+        <property name="dataSource" ref="dataSource-stg"/>
+        <property name="configLocation" value="classpath:/egovframework/batch/mapper/config/mapper-config.xml" />
+        <property name="mapperLocations">
+            <list>
+                <value>classpath:/egovframework/batch/mapper/example/Egov_Example_SQL.xml</value>
+                <value>classpath:/egovframework/batch/mapper/crm/crm_stg_to_local.xml</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- CRM 로컬 적재용 SqlSessionFactory -->
+    <bean id="sqlSessionFactory-crm-local" class="org.mybatis.spring.SqlSessionFactoryBean">
+        <property name="dataSource" ref="dataSource-local"/>
+        <property name="configLocation" value="classpath:/egovframework/batch/mapper/config/mapper-config.xml" />
+        <property name="mapperLocations">
+            <list>
+                <value>classpath:/egovframework/batch/mapper/example/Egov_Example_SQL.xml</value>
+                <value>classpath:/egovframework/batch/mapper/crm/crm_stg_to_local.xml</value>
+            </list>
+        </property>
+    </bean>
+
 </beans>

--- a/src/main/resources/egovframework/batch/mapper/crm/crm_rest_to_stg.xml
+++ b/src/main/resources/egovframework/batch/mapper/crm/crm_rest_to_stg.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="Customer">
+
+    <!-- STG 테이블 초기화 -->
+    <update id="truncateCrmStg">
+        TRUNCATE TABLE MIGSTG.CRM_CUSTOMER
+    </update>
+
+    <!-- REST 데이터 적재 -->
+    <insert id="insertCustomerStg" parameterType="egovframework.bat.crm.domain.CustomerInfo">
+        INSERT INTO MIGSTG.CRM_CUSTOMER
+            (CUSTOMER_ID, NAME, EMAIL, PHONE, REG_DTTM, MOD_DTTM)
+        VALUES
+            (#{customerId}, #{name}, #{email}, #{phone}, #{regDttm}, #{modDttm})
+    </insert>
+
+</mapper>

--- a/src/main/resources/egovframework/batch/mapper/crm/crm_stg_to_local.xml
+++ b/src/main/resources/egovframework/batch/mapper/crm/crm_stg_to_local.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="Customer">
+
+    <!-- STG에서 로컬로 이관할 고객 목록 조회 -->
+    <select id="selectCustomerList" resultType="egovframework.bat.crm.domain.CustomerInfo">
+        SELECT
+            CUSTOMER_ID,
+            NAME,
+            EMAIL,
+            PHONE,
+            REG_DTTM,
+            MOD_DTTM
+        FROM MIGSTG.CRM_CUSTOMER
+    </select>
+
+    <!-- 로컬 DB에 고객 정보 적재 -->
+    <insert id="insertCustomerLocal" parameterType="egovframework.bat.crm.domain.CustomerInfo">
+        INSERT INTO CRM_CUSTOMER
+            (CUSTOMER_ID, NAME, EMAIL, PHONE, REG_DTTM, MOD_DTTM)
+        VALUES
+            (#{customerId}, #{name}, #{email}, #{phone}, #{regDttm}, #{modDttm})
+        ON DUPLICATE KEY UPDATE
+            NAME = VALUES(NAME),
+            EMAIL = VALUES(EMAIL),
+            PHONE = VALUES(PHONE),
+            REG_DTTM = VALUES(REG_DTTM),
+            MOD_DTTM = VALUES(MOD_DTTM)
+    </insert>
+
+</mapper>


### PR DESCRIPTION
## 요약
- CRM REST 데이터를 STG에 적재하는 매퍼 추가
- CRM STG 데이터를 조회해 로컬 DB에 갱신하는 매퍼 추가
- CRM 연동용 SqlSessionFactory 및 매퍼 경로 설정

## 테스트
- `mvn test` (네트워크 문제로 의존성 다운로드 실패)


------
https://chatgpt.com/codex/tasks/task_e_68a6becbe848832abf24497968764909