### PR TITLE
테스트용 CRM 더미 API 정보 추가

### DIFF
--- a/src/test/java/egovframework/bat/crm/api/DummyCrmApiInfo.java
+++ b/src/test/java/egovframework/bat/crm/api/DummyCrmApiInfo.java
@@ -1,0 +1,21 @@
+package egovframework.bat.crm.api;
+
+/**
+ * 개발 중 CRM REST API 호출 테스트에 사용하는 더미 정보.
+ * 실제 서비스와 혼동되지 않도록 더미임을 명확히 표시한다.
+ */
+public final class DummyCrmApiInfo {
+    private DummyCrmApiInfo() {}
+
+    /** 더미 CRM REST API 엔드포인트 */
+    public static final String DUMMY_ENDPOINT =
+        "https://dummy-crm.example.com/api/v1/customers";
+
+    /** 더미 응답 JSON (테스트용) */
+    public static final String DUMMY_RESPONSE = "{\\n"
+        + "  \\\"id\\\": \\\"DUMMY-CUSTOMER-0001\\\",\\n"
+        + "  \\\"name\\\": \\\"테스트 더미 고객\\\",\\n"
+        + "  \\\"email\\\": \\\"dummy-customer@example.com\\\",\\n"
+        + "  \\\"created_at\\\": \\\"2024-05-10T09:00:00Z\\\"\\n"
+        + "}";
+}

--- a/src/test/resources/dummy-crm-response.json
+++ b/src/test/resources/dummy-crm-response.json
@@ -1,0 +1,6 @@
+{
+  "id": "DUMMY-CUSTOMER-0001",
+  "name": "테스트 더미 고객",
+  "email": "dummy-customer@example.com",
+  "created_at": "2024-05-10T09:00:00Z"
+}


### PR DESCRIPTION
## 요약
- CRM REST API 호출 테스트에 사용할 `DummyCrmApiInfo` 클래스와 더미 응답 JSON 추가
- 더미 응답 JSON 파일을 테스트 리소스로 저장하여 활용 가능하게 함

## 테스트
- `mvn -q test` *(네트워크 문제로 의존성 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cf9a0f8c832a841a047973ba8e51