### PR TITLE
CRM CustomerInfo를 VehicleInfo로 리네이밍

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ Spring Batch는 두 가지 대표적인 Step 구현 방식을 제공합니다.
   - `src/main/resources/egovframework/batch/mapper/crm/crm_rest_to_stg.xml`: CRM REST 데이터→STG 적재를 위한 SQL 매퍼
   - `src/main/resources/egovframework/batch/mapper/crm/crm_stg_to_local.xml`: STG→로컬 데이터 이동을 위한 SQL 매퍼
 - 공통, 도메인 및 유틸 클래스:
-  - `src/main/java/egovframework/bat/crm/tasklet/FetchCrmDataTasklet.java`: CRM 시스템에서 고객 정보를 조회하여 STG에 적재하는 Tasklet
-  - `src/main/java/egovframework/bat/crm/processor/CustomerInfoProcessor.java`: CRM 고객 정보를 처리하는 배치 프로세서
-  - `src/main/java/egovframework/bat/crm/domain/CustomerInfo.java`: CRM 고객 정보를 담는 도메인 클래스
+  - `src/main/java/egovframework/bat/crm/tasklet/FetchCrmDataTasklet.java`: CRM 시스템에서 차량 정보를 조회하여 STG에 적재하는 Tasklet
+  - `src/main/java/egovframework/bat/crm/processor/VehicleInfoProcessor.java`: CRM 차량 정보를 처리하는 배치 프로세서
+  - `src/main/java/egovframework/bat/crm/domain/VehicleInfo.java`: CRM 차량 정보를 담는 도메인 클래스
   - `src/main/java/egovframework/bat/crm/api/RestToStgJobController.java`: CRM REST 배치를 수동 실행하는 컨트롤러
 
 ## 예제 배치 잡 디렉터리(`example`)

--- a/src/main/java/egovframework/bat/crm/domain/VehicleInfo.java
+++ b/src/main/java/egovframework/bat/crm/domain/VehicleInfo.java
@@ -5,13 +5,13 @@ import java.util.Date;
 import lombok.Data;
 
 /**
- * REST API로 수신한 고객 정보를 담는 VO 클래스
+ * REST API로 수신한 차량 정보를 담는 VO 클래스
  */
 @Data
-public class CustomerInfo {
+public class VehicleInfo {
 
-    private String customerId;    /** 고객ID (EsntlIdGenerator 등을 통해 생성) */
-    private String name;          /** 고객명 */
+    private String customerId;    /** 차량ID (EsntlIdGenerator 등을 통해 생성) */
+    private String name;          /** 차량명 */
     private String email;         /** 이메일 */
     private String phone;         /** 전화번호 */
     private Date regDttm;         /** 등록일시 */

--- a/src/main/java/egovframework/bat/crm/processor/VehicleInfoProcessor.java
+++ b/src/main/java/egovframework/bat/crm/processor/VehicleInfoProcessor.java
@@ -4,18 +4,18 @@ import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.stereotype.Component;
 
-import egovframework.bat.crm.domain.CustomerInfo;
+import egovframework.bat.crm.domain.VehicleInfo;
 
 /**
- * 고객 정보를 후처리하는 프로세서.
+ * 차량 정보를 후처리하는 프로세서.
  * 현재는 입력 데이터를 그대로 반환한다.
  */
 @Component
 @StepScope
-public class CustomerInfoProcessor implements ItemProcessor<CustomerInfo, CustomerInfo> {
+public class VehicleInfoProcessor implements ItemProcessor<VehicleInfo, VehicleInfo> {
 
     @Override
-    public CustomerInfo process(CustomerInfo item) {
+    public VehicleInfo process(VehicleInfo item) {
         // 필요한 추가 가공 로직은 이곳에 구현한다.
         return item;
     }

--- a/src/main/resources/egovframework/batch/job/crm/stgToLocalJob.xml
+++ b/src/main/resources/egovframework/batch/job/crm/stgToLocalJob.xml
@@ -5,7 +5,7 @@
 
     <import resource="../abstract/eGovBase.xml" />
 
-    <!-- STG에 적재된 CRM 고객 정보를 로컬 DB로 이관하는 잡 -->
+    <!-- STG에 적재된 CRM 차량 정보를 로컬 DB로 이관하는 잡 -->
     <job id="crmStgToLocalJob" parent="eGovBaseJob" xmlns="http://www.springframework.org/schema/batch">
         <step id="stgToLocalStep" parent="eGovBaseStep">
             <tasklet>
@@ -18,21 +18,21 @@
     </job>
 
     <bean id="crmStgToLocalJob.stgToLocalStep.mybatisItemReader" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader" scope="step">
-        <!-- STG DB에서 CRM 고객 정보를 조회 -->
+        <!-- STG DB에서 CRM 차량 정보를 조회 -->
         <property name="sqlSessionFactory" ref="sqlSessionFactory-crm-stg-local" />
         <property name="queryId" value="Customer.selectCustomerList" />
         <property name="pageSize" value="#{100}" />
     </bean>
 
     <bean id="crmStgToLocalJob.stgToLocalStep.mybatisItemWriter" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter">
-        <!-- 로컬 DB에 CRM 고객 정보 적재 -->
+        <!-- 로컬 DB에 CRM 차량 정보 적재 -->
         <property name="sqlSessionFactory" ref="sqlSessionFactory-crm-local" />
         <property name="statementId" value="Customer.insertCustomerLocal" />
     </bean>
 
-    <!-- 고객 정보 후처리를 위한 프로세서 -->
+    <!-- 차량 정보 후처리를 위한 프로세서 -->
     <bean id="crmStgToLocalJob.stgToLocalStep.itemProcessor"
-          class="egovframework.bat.crm.processor.CustomerInfoProcessor"
+          class="egovframework.bat.crm.processor.VehicleInfoProcessor"
           scope="step" />
 
 </beans>

--- a/src/main/resources/egovframework/batch/mapper/crm/crm_rest_to_stg.xml
+++ b/src/main/resources/egovframework/batch/mapper/crm/crm_rest_to_stg.xml
@@ -9,7 +9,7 @@
     </update>
 
     <!-- REST 데이터 적재 -->
-    <insert id="insertCustomerStg" parameterType="egovframework.bat.crm.domain.CustomerInfo">
+    <insert id="insertCustomerStg" parameterType="egovframework.bat.crm.domain.VehicleInfo">
         INSERT INTO MIGSTG.CRM_CUSTOMER
             (CUSTOMER_ID, NAME, EMAIL, PHONE, REG_DTTM, MOD_DTTM)
         VALUES

--- a/src/main/resources/egovframework/batch/mapper/crm/crm_stg_to_local.xml
+++ b/src/main/resources/egovframework/batch/mapper/crm/crm_stg_to_local.xml
@@ -4,7 +4,7 @@
 <mapper namespace="Customer">
 
     <!-- STG에서 로컬로 이관할 고객 목록 조회 -->
-    <select id="selectCustomerList" resultType="egovframework.bat.crm.domain.CustomerInfo">
+    <select id="selectCustomerList" resultType="egovframework.bat.crm.domain.VehicleInfo">
         SELECT
             CUSTOMER_ID,
             NAME,
@@ -16,7 +16,7 @@
     </select>
 
     <!-- 로컬 DB에 고객 정보 적재 -->
-    <insert id="insertCustomerLocal" parameterType="egovframework.bat.crm.domain.CustomerInfo">
+    <insert id="insertCustomerLocal" parameterType="egovframework.bat.crm.domain.VehicleInfo">
         INSERT INTO CRM_CUSTOMER
             (CUSTOMER_ID, NAME, EMAIL, PHONE, REG_DTTM, MOD_DTTM)
         VALUES


### PR DESCRIPTION
## 요약
- VehicleInfo 도메인/프로세서/태스크렛으로 리네이밍
- 매퍼와 잡 설정에 VehicleInfo 타입 적용
- README와 문서에서 VehicleInfo 명칭 사용

## 테스트
- `mvn -q test` (실패: org.springframework.boot:spring-boot-starter-parent:pom:2.7.18을(를) 찾을 수 없음)

------
https://chatgpt.com/codex/tasks/task_e_68a7b4e897a0832aa4f17c43419623ea