### PR TITLE
통합 CRM API 속성 키 사용

### DIFF
--- a/src/main/java/egovframework/bat/crm/tasklet/FetchCrmDataTasklet.java
+++ b/src/main/java/egovframework/bat/crm/tasklet/FetchCrmDataTasklet.java
@@ -38,7 +38,7 @@ public class FetchCrmDataTasklet implements Tasklet {
     private final List<NotificationSender> notificationSenders;
 
     /** 차량 정보를 조회할 API URL */
-    @Value("${crm.api.url}")
+    @Value("${Globals.Crm.ApiUrl}")
     private String apiUrl;
 
     public FetchCrmDataTasklet(RestTemplateBuilder restTemplateBuilder,

--- a/src/main/resources/egovframework/batch/properties/env/dev/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/env/dev/globals.properties
@@ -35,6 +35,4 @@ Globals.Stg.Password=mig!1234
 # CRM REST API \ud638\ucd9c \uc815\ubcf4
 Globals.Crm.ApiUrl=http://localhost:8080/api/crm
 Globals.Crm.AuthToken=CHANGE_ME
-crm.api.url=${Globals.Crm.ApiUrl}
-crm.api.token=${Globals.Crm.AuthToken}
 

--- a/src/main/resources/egovframework/batch/properties/env/local/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/env/local/globals.properties
@@ -41,6 +41,4 @@ Globals.Stg.Password=mig!1234
 # CRM REST API \ud638\ucd9c \uc815\ubcf4
 Globals.Crm.ApiUrl=http://localhost:8080/api/crm
 Globals.Crm.AuthToken=CHANGE_ME
-crm.api.url=${Globals.Crm.ApiUrl}
-crm.api.token=${Globals.Crm.AuthToken}
 

--- a/src/main/resources/egovframework/batch/properties/env/prod/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/env/prod/globals.properties
@@ -35,6 +35,4 @@ Globals.Stg.Password=mig!1234
 # CRM REST API \ud638\ucd9c \uc815\ubcf4
 Globals.Crm.ApiUrl=http://localhost:8080/api/crm
 Globals.Crm.AuthToken=CHANGE_ME
-crm.api.url=${Globals.Crm.ApiUrl}
-crm.api.token=${Globals.Crm.AuthToken}
 


### PR DESCRIPTION
## 변경 내용
- 환경별 globals.properties에서 crm.api.* 키 제거
- FetchCrmDataTasklet이 Globals.Crm.ApiUrl을 주입하도록 수정

## 테스트
- `mvn test` (실패: org.springframework.boot:spring-boot-starter-parent를 다운로드하지 못함)
- `mvn -DskipTests package` (실패: org.springframework.boot:spring-boot-starter-parent를 다운로드하지 못함)


------
https://chatgpt.com/codex/tasks/task_e_68a7b75757d0832a86b0c1fb778e7123