### PR TITLE
차량 정보 필드명 및 매퍼 갱신

### DIFF
--- a/src/main/java/egovframework/bat/erp/domain/VehicleInfo.java
+++ b/src/main/java/egovframework/bat/erp/domain/VehicleInfo.java
@@ -1,6 +1,7 @@
 package egovframework.bat.erp.domain;
 
 import java.util.Date;
+import java.math.BigDecimal;
 
 import lombok.Data;
 
@@ -13,7 +14,7 @@ public class VehicleInfo {
     private String vehicleId;     /** 차량ID (EsntlIdGenerator 등을 통해 생성) */
     private String model;         /** 모델명 */
     private String manufacturer;  /** 제조사 */
-    private String color;         /** 색상 */
+    private BigDecimal price;     /** 가격 */
     private Date regDttm;         /** 등록일시 */
     private Date modDttm;         /** 수정일시 */
 }

--- a/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
+++ b/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
@@ -103,14 +103,14 @@ public class FetchErpDataTasklet implements Tasklet {
      * @param vehicles 차량 정보 목록
      */
     private void insertVehicles(List<VehicleInfo> vehicles) {
-        String sql = "INSERT INTO MIGSTG.ERP_VEHICLE (vehicle_id, model, manufacturer, color, reg_dttm, mod_dttm) "
+        String sql = "INSERT INTO MIGSTG.ERP_VEHICLE (vehicle_id, model, manufacturer, price, reg_dttm, mod_dttm) "
                 + "VALUES (?, ?, ?, ?, ?, ?)";
 
         jdbcTemplate.batchUpdate(sql, vehicles, vehicles.size(), (ps, vehicle) -> {
             ps.setString(1, vehicle.getVehicleId());
             ps.setString(2, vehicle.getModel());
             ps.setString(3, vehicle.getManufacturer());
-            ps.setString(4, vehicle.getColor());
+            ps.setBigDecimal(4, vehicle.getPrice());
             ps.setTimestamp(5, vehicle.getRegDttm() == null ? null : new Timestamp(vehicle.getRegDttm().getTime()));
             ps.setTimestamp(6, vehicle.getModDttm() == null ? null : new Timestamp(vehicle.getModDttm().getTime()));
         });

--- a/src/main/resources/egovframework/batch/mapper/erp/erp_rest_to_stg.xml
+++ b/src/main/resources/egovframework/batch/mapper/erp/erp_rest_to_stg.xml
@@ -11,9 +11,9 @@
     <!-- REST 데이터 적재 -->
     <insert id="insertVehicleStg" parameterType="egovframework.bat.erp.domain.VehicleInfo">
         INSERT INTO MIGSTG.ERP_VEHICLE
-            (VEHICLE_ID, MODEL, MANUFACTURER, COLOR, REG_DTTM, MOD_DTTM)
+            (VEHICLE_ID, MODEL, MANUFACTURER, PRICE, REG_DTTM, MOD_DTTM)
         VALUES
-            (#{vehicleId}, #{model}, #{manufacturer}, #{color}, #{regDttm}, #{modDttm})
+            (#{vehicleId}, #{model}, #{manufacturer}, #{price}, #{regDttm}, #{modDttm})
     </insert>
 
 </mapper>

--- a/src/main/resources/egovframework/batch/mapper/erp/erp_stg_to_local.xml
+++ b/src/main/resources/egovframework/batch/mapper/erp/erp_stg_to_local.xml
@@ -9,7 +9,7 @@
             VEHICLE_ID    AS vehicleId,
             MODEL         AS model,
             MANUFACTURER  AS manufacturer,
-            COLOR         AS color,
+            PRICE         AS price,
             REG_DTTM      AS regDttm,
             MOD_DTTM      AS modDttm
         FROM MIGSTG.ERP_VEHICLE
@@ -18,13 +18,13 @@
     <!-- 로컬 DB에 차량 정보 적재 -->
     <insert id="insertVehicleLocal" parameterType="egovframework.bat.erp.domain.VehicleInfo">
         INSERT INTO ERP_VEHICLE
-            (VEHICLE_ID, MODEL, MANUFACTURER, COLOR, REG_DTTM, MOD_DTTM)
+            (VEHICLE_ID, MODEL, MANUFACTURER, PRICE, REG_DTTM, MOD_DTTM)
         VALUES
-            (#{vehicleId}, #{model}, #{manufacturer}, #{color}, #{regDttm}, #{modDttm})
+            (#{vehicleId}, #{model}, #{manufacturer}, #{price}, #{regDttm}, #{modDttm})
         ON DUPLICATE KEY UPDATE
             MODEL = VALUES(MODEL),
             MANUFACTURER = VALUES(MANUFACTURER),
-            COLOR = VALUES(COLOR),
+            PRICE = VALUES(PRICE),
             REG_DTTM = VALUES(REG_DTTM),
             MOD_DTTM = VALUES(MOD_DTTM)
     </insert>

--- a/src/test/java/egovframework/bat/erp/api/DummyErpApiInfo.java
+++ b/src/test/java/egovframework/bat/erp/api/DummyErpApiInfo.java
@@ -9,13 +9,14 @@ public final class DummyErpApiInfo {
 
     /** 더미 ERP REST API 엔드포인트 */
     public static final String DUMMY_ENDPOINT =
-        "https://dummy-erp.example.com/api/v1/customers";
+        "https://dummy-erp.example.com/api/v1/vehicles";
 
     /** 더미 응답 JSON (테스트용) */
     public static final String DUMMY_RESPONSE = "{\\n"
-        + "  \\\"id\\\": \\\"DUMMY-CUSTOMER-0001\\\",\\n"
-        + "  \\\"name\\\": \\\"테스트 더미 고객\\\",\\n"
-        + "  \\\"email\\\": \\\"dummy-customer@example.com\\\",\\n"
+        + "  \\\"vehicleId\\\": \\\"DUMMY-VEHICLE-0001\\\",\\n"
+        + "  \\\"model\\\": \\\"테스트 더미 차량\\\",\\n"
+        + "  \\\"manufacturer\\\": \\\"더미 제조사\\\",\\n"
+        + "  \\\"price\\\": 1000000,\\n"
         + "  \\\"created_at\\\": \\\"2024-05-10T09:00:00Z\\\"\\n"
         + "}";
 }

--- a/src/test/resources/dummy-crm-response.json
+++ b/src/test/resources/dummy-crm-response.json
@@ -1,6 +1,0 @@
-{
-  "id": "DUMMY-CUSTOMER-0001",
-  "name": "테스트 더미 고객",
-  "email": "dummy-customer@example.com",
-  "created_at": "2024-05-10T09:00:00Z"
-}

--- a/src/test/resources/dummy-vehicle-response.json
+++ b/src/test/resources/dummy-vehicle-response.json
@@ -1,0 +1,7 @@
+{
+  "vehicleId": "DUMMY-VEHICLE-0001",
+  "model": "테스트 더미 차량",
+  "manufacturer": "더미 제조사",
+  "price": 1000000,
+  "created_at": "2024-05-10T09:00:00Z"
+}


### PR DESCRIPTION
## 요약
- VehicleInfo 도메인에 가격 필드 추가 및 관련 주석 수정
- 차량 데이터 적재 로직과 MyBatis 매퍼에서 price 필드 반영
- 더미 ERP API/응답을 차량 중심으로 변경

## 테스트
- `mvn -q test` *(네트워크 문제로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bed921fc832a8184ca4f9c6f8d52