### PR TITLE
ERP 차량 데이터를 migstg 테이블에 저장하도록 SQL 수정

### DIFF
--- a/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
+++ b/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
@@ -98,20 +98,26 @@ public class FetchErpDataTasklet implements Tasklet {
     }
 
     /**
-     * 조회된 차량 정보를 MIGSTG.ERP_VEHICLE 테이블에 저장한다.
+     * 조회된 차량 정보를 migstg 테이블에 저장한다.
      *
      * @param vehicles 차량 정보 목록
      */
     private void insertVehicles(List<VehicleInfo> vehicles) {
-        String sql = "INSERT INTO MIGSTG.ERP_VEHICLE (vehicle_id, model, manufacturer, price, reg_dttm, mod_dttm) "
+        String sql = "INSERT INTO migstg (vehicle_id, model, manufacturer, price, reg_dttm, mod_dttm) "
                 + "VALUES (?, ?, ?, ?, ?, ?)";
 
         jdbcTemplate.batchUpdate(sql, vehicles, vehicles.size(), (ps, vehicle) -> {
+            // 차량 ID
             ps.setString(1, vehicle.getVehicleId());
+            // 모델명
             ps.setString(2, vehicle.getModel());
+            // 제조사
             ps.setString(3, vehicle.getManufacturer());
+            // 가격
             ps.setBigDecimal(4, vehicle.getPrice());
+            // 등록일시
             ps.setTimestamp(5, vehicle.getRegDttm() == null ? null : new Timestamp(vehicle.getRegDttm().getTime()));
+            // 수정일시
             ps.setTimestamp(6, vehicle.getModDttm() == null ? null : new Timestamp(vehicle.getModDttm().getTime()));
         });
     }


### PR DESCRIPTION
## 요약
- ERP 데이터 적재 SQL을 `migstg` 테이블 대상으로 변경
- 차량 속성에 맞춰 배치 삽입 시 바인딩 필드 명확화 및 주석 추가

## 테스트
- `mvn -q test` (네트워크 문제로 의존성 해결 실패)

------
https://chatgpt.com/codex/tasks/task_e_68a7c0232ea4832aa63eed14a026e9f2