### PR TITLE
ERP API 실패 로그 테이블 추가

### DIFF
--- a/src/script/mysql/test/3.local_ddl-mysql.sql
+++ b/src/script/mysql/test/3.local_ddl-mysql.sql
@@ -2,6 +2,7 @@
 DROP TABLE IF EXISTS comtnemplyrinfo;
 DROP TABLE IF EXISTS comtnorgnztinfo;
 DROP TABLE IF EXISTS erp_vehicle;
+DROP TABLE IF EXISTS erp_api_fail_log;
 
 -- 조직 테이블
 CREATE TABLE `comtnorgnztinfo` (
@@ -42,3 +43,13 @@ CREATE TABLE `erp_vehicle` (
   PRIMARY KEY (`VEHICLE_ID`),
   UNIQUE KEY `ERP_VEHICLE_PK` (`VEHICLE_ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='ERP 차량 정보';
+
+-- ERP API 실패 로그 테이블
+CREATE TABLE `erp_api_fail_log` (
+  `FAIL_LOG_ID` bigint NOT NULL AUTO_INCREMENT COMMENT '실패 로그 ID',
+  `API_URL` varchar(500) NOT NULL COMMENT 'API URL',
+  `ERROR_MESSAGE` varchar(1000) DEFAULT NULL COMMENT '오류 메시지',
+  `REG_DTTM` datetime NOT NULL COMMENT '등록일시',
+  PRIMARY KEY (`FAIL_LOG_ID`),
+  KEY `ERP_API_FAIL_LOG_i01` (`API_URL`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='ERP API 실패 로그';


### PR DESCRIPTION
## Summary
- 테스트용 MySQL DDL에 ERP API 실패 로그 테이블을 추가했습니다.
- API URL 인덱스와 PK를 정의했습니다.

## Testing
- `mvn -q test` *(실패: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c24792ac832a85a3529b87c53e31