### PR TITLE
STG 환경에 erp_api_fail_log 테이블 생성 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ mvn -Pprod package    # 운영 환경 빌드
 
 각 프로필은 해당 환경의 `globals-<프로필>.properties` 파일을 사용하여 `globals.properties`를 생성합니다.
 
+## STG 환경용 DDL 스크립트
+
+migstg 데이터베이스 초기화 시 `src/script/mysql/test/2.stg_ddl-mysql.sql`을 실행해 테이블 구조를 생성합니다. STG 연결 정보는 각 환경별 `globals.properties` 파일의 `Globals.Stg.*` 항목을 참고하세요.
+
 배치 잡 실행 시 `sourceSystem` 파라미터를 생략하면 `LND` 프리픽스로 ESNTL_ID가 생성됩니다.
 
 ## Spring Batch 처리 방식: Chunk와 Tasklet

--- a/src/script/mysql/test/2.stg_ddl-mysql.sql
+++ b/src/script/mysql/test/2.stg_ddl-mysql.sql
@@ -2,6 +2,7 @@
 DROP TABLE IF EXISTS comtnemplyrinfo;
 DROP TABLE IF EXISTS comtnorgnztinfo;
 DROP TABLE IF EXISTS erp_vehicle;
+DROP TABLE IF EXISTS erp_api_fail_log;
 
 -- 조직 테이블
 CREATE TABLE `comtnorgnztinfo` (
@@ -41,3 +42,13 @@ CREATE TABLE `erp_vehicle` (
   PRIMARY KEY (`VEHICLE_ID`),
   UNIQUE KEY `ERP_VEHICLE_PK` (`VEHICLE_ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='ERP 차량 정보';
+
+-- ERP API 실패 로그 테이블
+CREATE TABLE `erp_api_fail_log` (
+  `FAIL_LOG_ID` bigint NOT NULL AUTO_INCREMENT COMMENT '실패 로그 ID',
+  `API_URL` varchar(500) NOT NULL COMMENT 'API URL',
+  `ERROR_MESSAGE` varchar(1000) DEFAULT NULL COMMENT '오류 메시지',
+  `REG_DTTM` datetime NOT NULL COMMENT '등록일시',
+  PRIMARY KEY (`FAIL_LOG_ID`),
+  KEY `ERP_API_FAIL_LOG_i01` (`API_URL`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='ERP API 실패 로그';

--- a/src/script/mysql/test/3.local_ddl-mysql.sql
+++ b/src/script/mysql/test/3.local_ddl-mysql.sql
@@ -2,7 +2,6 @@
 DROP TABLE IF EXISTS comtnemplyrinfo;
 DROP TABLE IF EXISTS comtnorgnztinfo;
 DROP TABLE IF EXISTS erp_vehicle;
-DROP TABLE IF EXISTS erp_api_fail_log;
 
 -- 조직 테이블
 CREATE TABLE `comtnorgnztinfo` (
@@ -43,13 +42,3 @@ CREATE TABLE `erp_vehicle` (
   PRIMARY KEY (`VEHICLE_ID`),
   UNIQUE KEY `ERP_VEHICLE_PK` (`VEHICLE_ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='ERP 차량 정보';
-
--- ERP API 실패 로그 테이블
-CREATE TABLE `erp_api_fail_log` (
-  `FAIL_LOG_ID` bigint NOT NULL AUTO_INCREMENT COMMENT '실패 로그 ID',
-  `API_URL` varchar(500) NOT NULL COMMENT 'API URL',
-  `ERROR_MESSAGE` varchar(1000) DEFAULT NULL COMMENT '오류 메시지',
-  `REG_DTTM` datetime NOT NULL COMMENT '등록일시',
-  PRIMARY KEY (`FAIL_LOG_ID`),
-  KEY `ERP_API_FAIL_LOG_i01` (`API_URL`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='ERP API 실패 로그';


### PR DESCRIPTION
## Summary
- STG DDL 스크립트에 `erp_api_fail_log` 테이블 DROP/CREATE 구문 추가
- 로컬 DDL 스크립트에서 `erp_api_fail_log` 관련 구문 제거
- README에 STG용 DDL 실행 안내 문구 추가

## Testing
- `mvn -q test` *(실패: org.springframework.boot:spring-boot-starter-parent 2.7.18 다운로드 실패 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c5c45db0832a9ec0680234e3bca6