### PR TITLE
로컬 프로파일 기본값 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,10 +1,12 @@
-# Overwrite the bins created from the Spring Framework 5.* - When you try to register bins with the same name - BeanDefinitionOverrideException occurs, setting that eliminates this.
 spring:
+  profiles:
+    active: local
   main:
+    # Spring Framework 5.*에서 같은 이름의 빈을 등록할 때 발생하는 BeanDefinitionOverrideException 방지
     allow-bean-definition-overriding: true
   output:
     ansi:
-      enabled: never   # ANSI 색상 끄기, Eclipse > Preferences > Run/Debug > Console > ANSI Support 에서 Enable ANSI support 체크박스 끄기
+      enabled: never   # ANSI 색상 끄기, Eclipse 콘솔의 ANSI Support 체크박스 끄기
 
 logging:
   # 기존 로그 레벨 설정을 주석 처리하여 log4j2 설정만 사용하도록 함


### PR DESCRIPTION
## Summary
- application.yml에 기본 프로파일을 `local`로 설정
- ANSI 설정 주석을 정리하고 한글로 보완

## Testing
- `mvn test` *(실패: 원격 저장소에 접근 불가로 의존성 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f6183734832a982f07d610914c66