### PR TITLE
환경별 데이터소스 설정 파일 추가

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,22 @@
+spring:
+  datasource:
+    # 개발 서버 MySQL
+    egovlocal_mysql:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      url: jdbc:mysql://dev.mysql.example.com:3306/egovdev
+      username: devuser
+      password: devpass
+
+    # 스테이징 MySQL (주 데이터베이스)
+    migstg_mysql:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      url: jdbc:mysql://dev.mysql.example.com:3306/migstg
+      username: migdev
+      password: dev!1234
+
+    # 원격1 CUBRID
+    egovremote1_cubrid:
+      driver-class-name: cubrid.jdbc.driver.CUBRIDDriver
+      url: jdbc:cubrid:192.168.10.10:33000:egovremote1_dev:::
+      username: devread
+      password: devread!1234

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,22 @@
+spring:
+  datasource:
+    # 로컬 개발용 MySQL
+    egovlocal_mysql:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      url: jdbc:mysql://localhost:3306/egovlocal
+      username: localuser
+      password: localpass
+
+    # 스테이징 MySQL (주 데이터베이스)
+    migstg_mysql:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      url: jdbc:mysql://localhost:3306/migstg
+      username: miguser
+      password: mig!1234
+
+    # 원격1 CUBRID
+    egovremote1_cubrid:
+      driver-class-name: cubrid.jdbc.driver.CUBRIDDriver
+      url: jdbc:cubrid:192.168.0.10:33000:egovremote1:::
+      username: readuser
+      password: read!1234

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,22 @@
+spring:
+  datasource:
+    # 운영 서버 MySQL
+    egovlocal_mysql:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      url: jdbc:mysql://prod.mysql.example.com:3306/egovprod
+      username: produser
+      password: prodpass
+
+    # 스테이징 MySQL (주 데이터베이스)
+    migstg_mysql:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      url: jdbc:mysql://prod.mysql.example.com:3306/migstg
+      username: migprod
+      password: prod!1234
+
+    # 원격1 CUBRID
+    egovremote1_cubrid:
+      driver-class-name: cubrid.jdbc.driver.CUBRIDDriver
+      url: jdbc:cubrid:192.168.20.20:33000:egovremote1_prod:::
+      username: prodread
+      password: prodread!1234


### PR DESCRIPTION
## Summary
- 로컬, 개발, 운영 환경별 데이터소스 설정 파일을 추가했습니다.

## Testing
- `mvn -q test` *(실패: 네트워크 문제로 POM 의존성 해결 불가)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f6cc14e4832aa14799107998fee0