### PR TITLE
feat: add multi data source configuration

### DIFF
--- a/src/main/java/egovframework/bat/config/MultiDataSourceConfig.java
+++ b/src/main/java/egovframework/bat/config/MultiDataSourceConfig.java
@@ -1,0 +1,54 @@
+package egovframework.bat.config;
+
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+public class MultiDataSourceConfig {
+
+    // Stg MySQL (Primary)
+    @Primary
+    @Bean(name = "migstgDataSource")
+    @ConfigurationProperties("spring.datasource.migstg_mysql")
+    public DataSource migstgDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean(name = "migstgJdbcTemplate")
+    public JdbcTemplate migstgJdbcTemplate(@Qualifier("migstgDataSource") DataSource ds) {
+        return new JdbcTemplate(ds);
+    }
+
+    // 로컬 개발용 MySQL
+    @Bean(name = "egovlocalDataSource")
+    @ConfigurationProperties("spring.datasource.egovlocal_mysql")
+    public DataSource egovlocalDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean(name = "egovlocalJdbcTemplate")
+    public JdbcTemplate egovlocalJdbcTemplate(@Qualifier("egovlocalDataSource") DataSource ds) {
+        return new JdbcTemplate(ds);
+    }
+
+    // Remote1 CUBRID
+    @Bean(name = "egovremote1CubridDataSource")
+    @ConfigurationProperties("spring.datasource.egovremote1_cubrid")
+    public DataSource egovremote1CubridDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean(name = "egovremote1CubridJdbcTemplate")
+    public JdbcTemplate egovremote1CubridJdbcTemplate(
+            @Qualifier("egovremote1CubridDataSource") DataSource ds) {
+        return new JdbcTemplate(ds);
+    }
+}


### PR DESCRIPTION
## Summary
- configure multiple data sources and jdbc templates for staging, local, and remote1

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f774d2e4832a9a9f21e47b3ab6d4