### PR TITLE
환경별 application.yml 관리 개선

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,7 @@
 				<excludes>
 					<exclude>egovframework/batch/properties/env/**</exclude>
 					<exclude>log4j2/env/**</exclude>
+					<exclude>application/env/**</exclude>
 				</excludes>
 				<filtering>false</filtering>
 			</resource>
@@ -233,6 +234,15 @@
                 <includes>
                     <include>log4j2.xml</include>
                 </includes>
+            </resource>
+            <!-- 환경별 application.yml 복사 -->
+            <resource>
+                <directory>src/main/resources/application/env/${env}</directory>
+                <targetPath>.</targetPath>
+                <includes>
+                    <include>application.yml</include>
+                </includes>
+                <filtering>false</filtering>
             </resource>
         </resources>
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,4 @@
 spring:
-  profiles:
-    active: local
   main:
     # Spring Framework 5.*에서 같은 이름의 빈을 등록할 때 발생하는 BeanDefinitionOverrideException 방지
     allow-bean-definition-overriding: true

--- a/src/main/resources/application/env/dev/application.yml
+++ b/src/main/resources/application/env/dev/application.yml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: dev
   datasource:
     # 개발 서버 MySQL
     egovlocal_mysql:

--- a/src/main/resources/application/env/local/application.yml
+++ b/src/main/resources/application/env/local/application.yml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: local
   datasource:
     # 로컬 개발용 MySQL
     egovlocal_mysql:

--- a/src/main/resources/application/env/prod/application.yml
+++ b/src/main/resources/application/env/prod/application.yml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: prod
   datasource:
     # 운영 서버 MySQL
     egovlocal_mysql:


### PR DESCRIPTION
## 요약
- 환경별 application.yml을 `application/env/<env>` 구조로 분리
- Maven 리소스 설정으로 `${env}` 프로필에 맞는 `application.yml` 복사
- 기본 `application.yml`에서 불필요한 활성 프로파일 제거

## 테스트
- `mvn -Plocal package` (실패: org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 의존성 해석 불가)
- `mvn -Pdev package` (실패: org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 의존성 해석 불가)
- `mvn -Pprod package` (실패: org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 의존성 해석 불가)


------
https://chatgpt.com/codex/tasks/task_e_68a7f7ffa0d0832aae0b61ce8170331b