### PR TITLE
CUBRID URL에 큰따옴표 추가

### DIFF
--- a/src/main/resources/application/env/local/application.yml
+++ b/src/main/resources/application/env/local/application.yml
@@ -19,6 +19,6 @@ spring:
     # 원격1 CUBRID
     egovremote1_cubrid:
       driver-class-name: cubrid.jdbc.driver.CUBRIDDriver
-      url: jdbc:cubrid:192.168.0.10:33000:egovremote1:::
+      url: "jdbc:cubrid:192.168.0.10:33000:egovremote1:::"
       username: readuser
       password: read!1234


### PR DESCRIPTION
## Summary
- CUBRID 데이터소스의 URL을 문자열로 명시

## Testing
- `mvn -q test` *(실패: 네트워크에 연결할 수 없어 부모 POM을 해석하지 못함)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fb47a0e4832aa581f3e6deab8c17