### PR TITLE
feat: 스캐닝 범위 확장으로 DataSource 등록

### DIFF
--- a/src/main/java/com/springboot/main/EgovBootApplication.java
+++ b/src/main/java/com/springboot/main/EgovBootApplication.java
@@ -11,6 +11,7 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 /**
  * @author 배치실행개발팀
@@ -26,8 +27,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  *  
  *  </pre>
 */
-
 @SpringBootApplication // 스프링 부트 애플리케이션으로 선언
+@ComponentScan(basePackages = {"com.springboot.main", "egovframework.bat"}) // 스캔할 패키지 지정
 public class EgovBootApplication implements CommandLineRunner {
 	
 	private static final Logger LOGGER = LoggerFactory.getLogger(EgovBootApplication.class);


### PR DESCRIPTION
## 요약
- EgovBootApplication에 `@ComponentScan` 추가
- egovframework 배치 패키지까지 스캔하도록 수정

## 테스트
- `mvn -e -ntp package` (네트워크 오류로 실패: spring-boot-starter-parent를 받지 못함)

------
https://chatgpt.com/codex/tasks/task_e_68a7fd4ab918832a90e82c66c2ad3cc2