### PR TITLE
feat: 컨트롤러 API 응답 구조 개선

### DIFF
--- a/src/main/java/egovframework/bat/erp/api/RestToStgJobController.java
+++ b/src/main/java/egovframework/bat/erp/api/RestToStgJobController.java
@@ -9,6 +9,8 @@ import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,10 +35,9 @@ public class RestToStgJobController {
      * ERP REST API 데이터를 STG 테이블로 적재하는 배치 잡을 실행한다.
      *
      * @return 배치 잡 실행 결과 상태
-     * @throws Exception 배치 실행 중 발생한 예외
      */
     @PostMapping("/erp-rest-to-stg")
-    public BatchStatus runErpRestToStgJob() throws Exception {
+    public ResponseEntity<BatchStatus> runErpRestToStgJob() {
         LOGGER.info("ERP REST 배치 실행 요청 수신");
         JobParameters jobParameters = new JobParametersBuilder()
             .addLong("timestamp", System.currentTimeMillis())
@@ -45,10 +46,11 @@ public class RestToStgJobController {
         try {
             JobExecution execution = jobLauncher.run(erpRestToStgJob, jobParameters);
             LOGGER.info("ERP REST 배치 실행 완료: {}", execution.getStatus());
-            return execution.getStatus();
+            return ResponseEntity.ok(execution.getStatus());
         } catch (Exception e) {
             LOGGER.error("ERP REST 배치 실행 실패", e);
-            throw e;
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(BatchStatus.FAILED);
         }
     }
 }

--- a/src/main/java/egovframework/bat/example/api/ExampleJobController.java
+++ b/src/main/java/egovframework/bat/example/api/ExampleJobController.java
@@ -1,12 +1,16 @@
 package egovframework.bat.example.api;
 
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,6 +24,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ExampleJobController {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExampleJobController.class);
+
     // 스프링 배치 잡 실행기
     private final JobLauncher jobLauncher;
 
@@ -31,10 +37,10 @@ public class ExampleJobController {
      *
      * @param userId 사용자를 식별하기 위한 값 (선택)
      * @return 배치 잡 실행 결과 상태
-     * @throws Exception 배치 실행 중 발생한 예외
      */
     @PostMapping("/mybatis")
-    public BatchStatus runMybatisJob(@RequestParam(value = "userId", required = false) String userId) throws Exception {
+    public ResponseEntity<BatchStatus> runMybatisJob(
+        @RequestParam(value = "userId", required = false) String userId) {
         JobParametersBuilder builder = new JobParametersBuilder()
             .addLong("timestamp", System.currentTimeMillis());
 
@@ -43,8 +49,15 @@ public class ExampleJobController {
         }
 
         JobParameters jobParameters = builder.toJobParameters();
-        JobExecution execution = jobLauncher.run(mybatisToMybatisJob, jobParameters);
-        return execution.getStatus();
+
+        try {
+            JobExecution execution = jobLauncher.run(mybatisToMybatisJob, jobParameters);
+            return ResponseEntity.ok(execution.getStatus());
+        } catch (Exception e) {
+            LOGGER.error("마이바티스 배치 실행 실패", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(BatchStatus.FAILED);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- 배치 잡 실행 컨트롤러들이 ResponseEntity<BatchStatus>를 반환하도록 변경
- 예외 발생 시 HTTP 500과 FAILED 상태를 반환하도록 오류 처리 강화

## Testing
- `mvn -q test` *(네트워크 문제로 부모 POM을 받을 수 없어 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ff8e9098832a96eb95269c02df96