### PR TITLE
데이터소스 프로퍼티 키 하이픈 적용

### DIFF
--- a/src/main/java/egovframework/bat/config/MultiDataSourceConfig.java
+++ b/src/main/java/egovframework/bat/config/MultiDataSourceConfig.java
@@ -17,7 +17,7 @@ public class MultiDataSourceConfig {
     // 스테이징 MySQL (Primary)
     @Primary
     @Bean(name = "migstgDataSource")
-    @ConfigurationProperties("spring.datasource.migstg_mysql")
+    @ConfigurationProperties("spring.datasource.migstg-mysql")
     public DataSource migstgDataSource() {
         return DataSourceBuilder.create().build();
     }
@@ -29,7 +29,7 @@ public class MultiDataSourceConfig {
 
     // 운영용 MySQL
     @Bean(name = "egovlocalDataSource")
-    @ConfigurationProperties("spring.datasource.egovlocal_mysql")
+    @ConfigurationProperties("spring.datasource.egovlocal-mysql")
     public DataSource egovlocalDataSource() {
         return DataSourceBuilder.create().build();
     }
@@ -41,7 +41,7 @@ public class MultiDataSourceConfig {
 
     // Remote1 CUBRID
     @Bean(name = "egovremote1CubridDataSource")
-    @ConfigurationProperties("spring.datasource.egovremote1_cubrid")
+    @ConfigurationProperties("spring.datasource.egovremote1-cubrid")
     public DataSource egovremote1CubridDataSource() {
         return DataSourceBuilder.create().build();
     }

--- a/src/main/resources/application/env/dev/application.yml
+++ b/src/main/resources/application/env/dev/application.yml
@@ -3,21 +3,21 @@ spring:
     active: dev
   datasource:
     # 개발 서버 MySQL
-    egovlocal_mysql:
+    egovlocal-mysql:
       driver-class-name: com.mysql.cj.jdbc.Driver
       url: jdbc:mysql://dev.mysql.example.com:3306/egovdev
       username: devuser
       password: devpass
 
     # 스테이징 MySQL (주 데이터베이스)
-    migstg_mysql:
+    migstg-mysql:
       driver-class-name: com.mysql.cj.jdbc.Driver
       url: jdbc:mysql://dev.mysql.example.com:3306/migstg
       username: migdev
       password: dev!1234
 
     # 원격1 CUBRID
-    egovremote1_cubrid:
+    egovremote1-cubrid:
       driver-class-name: cubrid.jdbc.driver.CUBRIDDriver
       url: "jdbc:cubrid:192.168.10.10:33000:egovremote1_dev:::"
       username: devread

--- a/src/main/resources/application/env/local/application.yml
+++ b/src/main/resources/application/env/local/application.yml
@@ -3,21 +3,21 @@ spring:
     active: local
   datasource:
     # 로컬 개발용 MySQL
-    egovlocal_mysql:
+    egovlocal-mysql:
       driver-class-name: com.mysql.cj.jdbc.Driver
       url: jdbc:mysql://localhost:3306/egovlocal
       username: localuser
       password: localpass
 
     # 스테이징 MySQL (주 데이터베이스)
-    migstg_mysql:
+    migstg-mysql:
       driver-class-name: com.mysql.cj.jdbc.Driver
       url: jdbc:mysql://localhost:3306/migstg
       username: miguser
       password: mig!1234
 
     # 원격1 CUBRID
-    egovremote1_cubrid:
+    egovremote1-cubrid:
       driver-class-name: cubrid.jdbc.driver.CUBRIDDriver
       url: "jdbc:cubrid:192.168.0.10:33000:egovremote1:::"
       username: readuser

--- a/src/main/resources/application/env/prod/application.yml
+++ b/src/main/resources/application/env/prod/application.yml
@@ -3,21 +3,21 @@ spring:
     active: prod
   datasource:
     # 운영 서버 MySQL
-    egovlocal_mysql:
+    egovlocal-mysql:
       driver-class-name: com.mysql.cj.jdbc.Driver
       url: jdbc:mysql://prod.mysql.example.com:3306/egovprod
       username: produser
       password: prodpass
 
     # 스테이징 MySQL (주 데이터베이스)
-    migstg_mysql:
+    migstg-mysql:
       driver-class-name: com.mysql.cj.jdbc.Driver
       url: jdbc:mysql://prod.mysql.example.com:3306/migstg
       username: migprod
       password: prod!1234
 
     # 원격1 CUBRID
-    egovremote1_cubrid:
+    egovremote1-cubrid:
       driver-class-name: cubrid.jdbc.driver.CUBRIDDriver
       url: "jdbc:cubrid:192.168.20.20:33000:egovremote1_prod:::"
       username: prodread


### PR DESCRIPTION
## 요약
- 환경별 application.yml에서 데이터소스 프로퍼티 키의 밑줄(_)을 하이픈(-)으로 변경
- MultiDataSourceConfig의 `@ConfigurationProperties` 접두사를 새로운 키에 맞게 수정

## 테스트
- `mvn -q test` (네트워크 문제로 부모 POM을 가져오지 못해 실패)

------
https://chatgpt.com/codex/tasks/task_e_68a8009cc450832a88e15ebc904758d8