### PR TITLE
fix: stg 스키마 명시

### DIFF
--- a/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
+++ b/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
@@ -128,7 +128,7 @@ public class FetchErpDataTasklet implements Tasklet {
      * @param e 발생한 예외
      */
     private void saveFailedCall(Exception e) {
-        String sql = "INSERT INTO erp_api_fail_log (api_url, error_message, reg_dttm) VALUES (?, ?, ?)";
+        String sql = "INSERT INTO migstg.erp_api_fail_log (api_url, error_message, reg_dttm) VALUES (?, ?, ?)";
         jdbcTemplate.update(sql, apiUrl, e.getMessage(), new Timestamp(System.currentTimeMillis()));
     }
 

--- a/src/main/resources/egovframework/batch/mapper/insa/insa_remote1_to_stg.xml
+++ b/src/main/resources/egovframework/batch/mapper/insa/insa_remote1_to_stg.xml
@@ -31,13 +31,13 @@
 
        <!-- STG DB에 조직 정보 적재 (STG 대상 테이블이 사전 TRUNCATE되므로 중복 갱신 없음) -->
        <insert id="insertOrganization" parameterType="egovframework.bat.insa.domain.EmployeeInfo">
-               INSERT INTO COMTNORGNZTINFO (ORGNZT_ID, ORGNZT_NM, ORGNZT_DC)
+               INSERT INTO MIGSTG.COMTNORGNZTINFO (ORGNZT_ID, ORGNZT_NM, ORGNZT_DC)
                VALUES (#{orgnztId}, #{orgnztNm}, #{orgnztDc})
        </insert>
 
        <!-- remote1 -> STG 이관 시 사용 (ESNTL_ID 제외, STG 대상 테이블이 사전 TRUNCATE되므로 중복 갱신 없음) -->
        <insert id="insertEmployeeLegacy" parameterType="egovframework.bat.insa.domain.EmployeeInfo">
-               INSERT INTO COMTNEMPLYRINFO
+               INSERT INTO MIGSTG.COMTNEMPLYRINFO
                        (EMPLYR_ID, ORGNZT_ID, USER_NM, SEXDSTN_CODE, BRTHDY, MBTLNUM, EMAIL_ADRES, OFCPS_NM, EMPLYR_STTUS_CODE, REG_DTTM, MOD_DTTM)
                VALUES
                        (#{emplyrId}, #{orgnztId}, #{userNm}, #{sexdstnCode}, #{brthdy}, #{mbtlnum}, #{emailAdres}, #{ofcpsNm}, #{emplyrSttusCode}, #{regDttm}, #{modDttm})


### PR DESCRIPTION
## Summary
- ERP API 실패 로그를 migstg 스키마로 저장
- remote1→STG 이관 SQL에 migstg 스키마 명시

## Testing
- `mvn test` *(실패: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a805d95aa0832a97b0bf0a717d3ec2