### PR TITLE
Remove manual RestTemplateBuilder bean

### DIFF
--- a/src/main/resources/egovframework/batch/context-common.xml
+++ b/src/main/resources/egovframework/batch/context-common.xml
@@ -12,8 +12,4 @@
                 <context:include-filter type="annotation" expression="org.springframework.stereotype.Component"/>
                 <context:exclude-filter type="annotation" expression="org.springframework.stereotype.Controller"/>
         </context:component-scan>
-
-    <!-- RestTemplateBuilder 빈 등록 -->
-    <bean id="restTemplateBuilder" class="org.springframework.boot.web.client.RestTemplateBuilder"/>
-
 </beans>


### PR DESCRIPTION
## Summary
- remove explicit RestTemplateBuilder bean configuration

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a81e5841e8832aaf7834d45427ef49