### PR TITLE
MySQL 연결 설정 최신화

### DIFF
--- a/src/main/resources/application/env/dev/application.yml
+++ b/src/main/resources/application/env/dev/application.yml
@@ -5,14 +5,14 @@ spring:
     # 개발 서버 MySQL
     egovlocal-mysql:
       driver-class-name: com.mysql.cj.jdbc.Driver
-      url: jdbc:mysql://dev.mysql.example.com:3306/egovdev
+      url: jdbc:mysql://dev.mysql.example.com:3306/egovdev?useSSL=false&serverTimezone=UTC
       username: devuser
       password: devpass
 
     # 스테이징 MySQL (주 데이터베이스)
     migstg-mysql:
       driver-class-name: com.mysql.cj.jdbc.Driver
-      url: jdbc:mysql://dev.mysql.example.com:3306/migstg
+      url: jdbc:mysql://dev.mysql.example.com:3306/migstg?useSSL=false&serverTimezone=UTC
       username: migdev
       password: dev!1234
 

--- a/src/main/resources/application/env/local/application.yml
+++ b/src/main/resources/application/env/local/application.yml
@@ -5,14 +5,14 @@ spring:
     # 로컬 개발용 MySQL
     egovlocal-mysql:
       driver-class-name: com.mysql.cj.jdbc.Driver
-      url: jdbc:mysql://localhost:3306/egovlocal
+      url: jdbc:mysql://localhost:3306/egovlocal?useSSL=false&serverTimezone=UTC
       username: localuser
       password: localpass
 
     # 스테이징 MySQL (주 데이터베이스)
     migstg-mysql:
       driver-class-name: com.mysql.cj.jdbc.Driver
-      url: jdbc:mysql://localhost:3306/migstg
+      url: jdbc:mysql://localhost:3306/migstg?useSSL=false&serverTimezone=UTC
       username: miguser
       password: mig!1234
 

--- a/src/main/resources/application/env/prod/application.yml
+++ b/src/main/resources/application/env/prod/application.yml
@@ -5,14 +5,14 @@ spring:
     # 운영 서버 MySQL
     egovlocal-mysql:
       driver-class-name: com.mysql.cj.jdbc.Driver
-      url: jdbc:mysql://prod.mysql.example.com:3306/egovprod
+      url: jdbc:mysql://prod.mysql.example.com:3306/egovprod?useSSL=false&serverTimezone=UTC
       username: produser
       password: prodpass
 
     # 스테이징 MySQL (주 데이터베이스)
     migstg-mysql:
       driver-class-name: com.mysql.cj.jdbc.Driver
-      url: jdbc:mysql://prod.mysql.example.com:3306/migstg
+      url: jdbc:mysql://prod.mysql.example.com:3306/migstg?useSSL=false&serverTimezone=UTC
       username: migprod
       password: prod!1234
 

--- a/src/main/resources/egovframework/batch/properties/env/dev/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/env/dev/globals.properties
@@ -16,13 +16,13 @@
 
 # \ub85c\uceec DB \uc811\uc18d \uc815\ubcf4
 Globals.Local.DriverClassName=com.mysql.cj.jdbc.Driver
-Globals.Local.Url=jdbc:mysql://\uac1c\ubc1c\ub85c\uceecIP\uc785\ub825:3306/egovlocal?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+Globals.Local.Url=jdbc:mysql://\uac1c\ubc1c\ub85c\uceecIP\uc785\ub825:3306/egovlocal?characterEncoding=UTF-8&useSSL=false&serverTimezone=UTC
 Globals.Local.UserName=miguser
 Globals.Local.Password=mig!1234
 
 # remote1 DB \uc811\uc18d \uc815\ubcf4(mysql\uc6a9)
 #Globals.Remote1.DriverClassName=com.mysql.cj.jdbc.Driver
-#Globals.Remote1.Url=jdbc:mysql://\uac1c\ubc1c\uc6d0\uaca9IP\uc785\ub825:3306/egovremote1?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+#Globals.Remote1.Url=jdbc:mysql://\uac1c\ubc1c\uc6d0\uaca9IP\uc785\ub825:3306/egovremote1?characterEncoding=UTF-8&useSSL=false&serverTimezone=UTC
 #Globals.Remote1.UserName=readuser
 #Globals.Remote1.Password=read!1234
 
@@ -34,7 +34,7 @@ Globals.Remote1.Password=read!1234
 
 # STG DB \uc811\uc18d \uc815\ubcf4
 Globals.Stg.DriverClassName=com.mysql.cj.jdbc.Driver
-Globals.Stg.Url=jdbc:mysql://\uac1c\ubc1cSTGIP\uc785\ub825:3306/migstg?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+Globals.Stg.Url=jdbc:mysql://\uac1c\ubc1cSTGIP\uc785\ub825:3306/migstg?characterEncoding=UTF-8&useSSL=false&serverTimezone=UTC
 Globals.Stg.UserName=miguser
 Globals.Stg.Password=mig!1234
 

--- a/src/main/resources/egovframework/batch/properties/env/local/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/env/local/globals.properties
@@ -16,17 +16,17 @@
 
 # \ub85c\uceec DB \uc811\uc18d \uc815\ubcf4
 Globals.Local.DriverClassName=net.sf.log4jdbc.DriverSpy
-Globals.Local.Url=jdbc:log4jdbc:mysql://localhost:3306/egovlocal
+Globals.Local.Url=jdbc:log4jdbc:mysql://localhost:3306/egovlocal?useSSL=false&serverTimezone=UTC
 #Globals.Local.DriverClassName=com.mysql.cj.jdbc.Driver
-#Globals.Local.Url=jdbc:mysql://localhost:3306/egovlocal
+#Globals.Local.Url=jdbc:mysql://localhost:3306/egovlocal?useSSL=false&serverTimezone=UTC
 Globals.Local.UserName=miguser
 Globals.Local.Password=mig!1234
 
 # remote1 DB \uc811\uc18d \uc815\ubcf4(mysql\uc6a9)
 #Globals.Remote1.DriverClassName=net.sf.log4jdbc.DriverSpy
-#Globals.Remote1.Url=jdbc:log4jdbc:mysql://localhost:3306/egovremote1
+#Globals.Remote1.Url=jdbc:log4jdbc:mysql://localhost:3306/egovremote1?useSSL=false&serverTimezone=UTC
 #Globals.Remote1.DriverClassName=com.mysql.cj.jdbc.Driver
-#Globals.Remote1.Url=jdbc:mysql://localhost:3306/egovremote1
+#Globals.Remote1.Url=jdbc:mysql://localhost:3306/egovremote1?useSSL=false&serverTimezone=UTC
 #Globals.Remote1.UserName=readuser
 #Globals.Remote1.Password=read!1234
 
@@ -38,9 +38,9 @@ Globals.Remote1.Password=read!1234
 
 # STG DB \uc811\uc18d \uc815\ubcf4
 #Globals.Stg.DriverClassName=net.sf.log4jdbc.DriverSpy
-#Globals.Stg.Url=jdbc:log4jdbc:mysql://localhost:3306/migstg
+#Globals.Stg.Url=jdbc:log4jdbc:mysql://localhost:3306/migstg?useSSL=false&serverTimezone=UTC
 Globals.Stg.DriverClassName=com.mysql.cj.jdbc.Driver
-Globals.Stg.Url=jdbc:mysql://localhost:3306/migstg
+Globals.Stg.Url=jdbc:mysql://localhost:3306/migstg?useSSL=false&serverTimezone=UTC
 Globals.Stg.UserName=miguser
 Globals.Stg.Password=mig!1234
 

--- a/src/main/resources/egovframework/batch/properties/env/prod/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/env/prod/globals.properties
@@ -16,13 +16,13 @@
 
 # \ub85c\uceec DB \uc811\uc18d \uc815\ubcf4
 Globals.Local.DriverClassName=com.mysql.cj.jdbc.Driver
-Globals.Local.Url=jdbc:mysql://\uc6b4\uc601\ub85c\uceecIP\uc785\ub825:3306/egovlocal?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+Globals.Local.Url=jdbc:mysql://\uc6b4\uc601\ub85c\uceecIP\uc785\ub825:3306/egovlocal?characterEncoding=UTF-8&useSSL=false&serverTimezone=UTC
 Globals.Local.UserName=miguser
 Globals.Local.Password=mig!1234
 
 # remote1 DB \uc811\uc18d \uc815\ubcf4(mysql\uc6a9)
 #Globals.Remote1.DriverClassName=com.mysql.cj.jdbc.Driver
-#Globals.Remote1.Url=jdbc:mysql://\uc6b4\uc601\uc6d0\uaca9IP\uc785\ub825:3306/egovremote1?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+#Globals.Remote1.Url=jdbc:mysql://\uc6b4\uc601\uc6d0\uaca9IP\uc785\ub825:3306/egovremote1?characterEncoding=UTF-8&useSSL=false&serverTimezone=UTC
 #Globals.Remote1.UserName=readuser
 #Globals.Remote1.Password=read!1234
 
@@ -34,7 +34,7 @@ Globals.Remote1.Password=read!1234
 
 # STG DB \uc811\uc18d \uc815\ubcf4
 Globals.Stg.DriverClassName=com.mysql.cj.jdbc.Driver
-Globals.Stg.Url=jdbc:mysql://\uc6b4\uc601STGIP\uc785\ub825:3306/migstg?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+Globals.Stg.Url=jdbc:mysql://\uc6b4\uc601STGIP\uc785\ub825:3306/migstg?characterEncoding=UTF-8&useSSL=false&serverTimezone=UTC
 Globals.Stg.UserName=miguser
 Globals.Stg.Password=mig!1234
 


### PR DESCRIPTION
## Summary
- 환경별 MySQL URL에 `useSSL=false&serverTimezone=UTC` 옵션 추가
- 로컬/개발/운영용 globals.properties에 동일 옵션 반영

## Testing
- `mvn -q test` *(실패: 원격 저장소 접속 불가)*

------
https://chatgpt.com/codex/tasks/task_e_68a82ccb98ac832a86485f86dd19e780