### PR TITLE
Rename sample job to avoid duplicate registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Spring Batch는 두 가지 대표적인 Step 구현 방식을 제공합니다.
 
 `src/main/resources/egovframework/batch/job/example` 디렉터리는 예제 배치 Job 설정을 모아둔 곳입니다. 예제 Job과 관련된 주요 파일은 다음과 같습니다.
 
-- `src/main/resources/egovframework/batch/job/example/mybatisToMybatisJob.xml`: MyBatis 간 데이터 이동을 정의한 배치 Job 설정 파일
+- `src/main/resources/egovframework/batch/job/example/mybatisToMybatisJob.xml`: MyBatis 간 데이터 이동을 정의한 배치 Job 설정 파일(잡 ID: `mybatisToMybatisSampleJob`)
 - `src/main/resources/egovframework/batch/mapper/example/Egov_Example_SQL.xml`: 예제 배치를 위한 SQL 매퍼 파일
 - `src/main/java/egovframework/bat/example/domain/CustomerCredit.java`: 고객 신용 정보를 담는 도메인 클래스
 - `src/main/java/egovframework/bat/example/processor/CustomerCreditIncreaseProcessor.java`: 신용 증가 로직을 처리하는 배치 프로세서

--- a/src/main/java/egovframework/bat/example/api/ExampleJobController.java
+++ b/src/main/java/egovframework/bat/example/api/ExampleJobController.java
@@ -9,6 +9,7 @@ import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,7 +31,8 @@ public class ExampleJobController {
     private final JobLauncher jobLauncher;
 
     // MyBatis 데이터를 MyBatis 데이터베이스로 옮기는 배치 잡
-    private final Job mybatisToMybatisJob;
+    // 동일 이름의 중복 등록을 방지하기 위해 잡 이름을 변경하였다
+    private final @Qualifier("mybatisToMybatisSampleJob") Job mybatisToMybatisSampleJob;
 
     /**
      * 마이바티스 배치 잡을 실행한다.
@@ -51,7 +53,8 @@ public class ExampleJobController {
         JobParameters jobParameters = builder.toJobParameters();
 
         try {
-            JobExecution execution = jobLauncher.run(mybatisToMybatisJob, jobParameters);
+            // 변경된 잡 이름으로 실행한다
+            JobExecution execution = jobLauncher.run(mybatisToMybatisSampleJob, jobParameters);
             return ResponseEntity.ok(execution.getStatus());
         } catch (Exception e) {
             LOGGER.error("마이바티스 배치 실행 실패", e);

--- a/src/main/resources/egovframework/batch/context-scheduler-job.xml
+++ b/src/main/resources/egovframework/batch/context-scheduler-job.xml
@@ -8,7 +8,8 @@
 		<property name="jobDataAsMap">
 			<map>
 				<!-- DB에서 DB로 데이터 이동을 위한 작업 이름 설정 (샘플) -->
-				<entry key="jobName" value="mybatisToMybatisJob" />
+                                <!-- 변경된 잡 이름을 사용하도록 수정 -->
+                                <entry key="jobName" value="mybatisToMybatisSampleJob" />
 				<entry key="jobLocator" value-ref="jobRegistry" />
 				<entry key="jobLauncher" value-ref="jobLauncher" />
 			</map>

--- a/src/main/resources/egovframework/batch/job/example/mybatisToMybatisJob.xml
+++ b/src/main/resources/egovframework/batch/job/example/mybatisToMybatisJob.xml
@@ -7,7 +7,8 @@
 	<import resource="../abstract/eGovBase.xml" />
 
 	<!-- commit-interval 값은 일반적으로 500~1000으로 설정함 -->
-	<job id="mybatisToMybatisJob" parent="eGovBaseJob" xmlns="http://www.springframework.org/schema/batch">
+        <!-- 중복 등록을 피하기 위해 잡 이름을 변경하였다 -->
+        <job id="mybatisToMybatisSampleJob" parent="eGovBaseJob" xmlns="http://www.springframework.org/schema/batch">
 		<step id="mybatisToMybatisStep" parent="eGovBaseStep">
 			<tasklet>
 				<chunk reader="mybatisToIbatisJob.mybatisToIbatisStep.mybatisItemReader"


### PR DESCRIPTION
## Summary
- rename MyBatis sample job to prevent DuplicateJobException
- update REST controller and scheduler config to use new job name
- document new job ID in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a82df34240832a817c29d13296d70c