### PR TITLE
Spring Boot 속성 기반 데이터소스 설정 적용

### DIFF
--- a/src/main/java/egovframework/bat/config/BatchInfrastructureConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchInfrastructureConfig.java
@@ -10,6 +10,8 @@ import org.springframework.context.annotation.ImportResource;
  */
 @Configuration
 @ImportResource({
+    // 데이터소스 및 트랜잭션 매니저 설정
+    "classpath:/egovframework/batch/context-batch-datasource.xml",
     // 배치 잡 실행기 관련 기본 설정
     "classpath:/egovframework/batch/context-batch-job-launcher.xml",
     // ERP REST -> STG 배치 잡 설정을 로딩하여 Job 빈을 등록

--- a/src/main/resources/egovframework/batch/context-batch-datasource.xml
+++ b/src/main/resources/egovframework/batch/context-batch-datasource.xml
@@ -8,35 +8,27 @@
 
 	<context:annotation-config />
 
-	<bean id="egov.propertyConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
-        <property name="locations">
-            <list>
-                <value>classpath:/egovframework/batch/properties/globals.properties</value>
-            </list>
-        </property>
-    </bean>
-
     <!-- 데이터소스 설정 -->
     <bean id="dataSource-remote1" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
-        <property name="driverClassName" value="${Globals.Remote1.DriverClassName}"/>
-        <property name="url" value="${Globals.Remote1.Url}" />
-        <property name="username" value="${Globals.Remote1.UserName}"/>
-        <property name="password" value="${Globals.Remote1.Password}"/>
+        <property name="driverClassName" value="${spring.datasource.egovremote1_cubrid.driver-class-name}"/>
+        <property name="url" value="${spring.datasource.egovremote1_cubrid.url}" />
+        <property name="username" value="${spring.datasource.egovremote1_cubrid.username}"/>
+        <property name="password" value="${spring.datasource.egovremote1_cubrid.password}"/>
     </bean>
 
     <!-- 스테이징 DB 데이터소스 -->
     <bean id="dataSource-stg" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
-        <property name="driverClassName" value="${Globals.Stg.DriverClassName}"/>
-        <property name="url" value="${Globals.Stg.Url}" />
-        <property name="username" value="${Globals.Stg.UserName}"/>
-        <property name="password" value="${Globals.Stg.Password}"/>
+        <property name="driverClassName" value="${spring.datasource.migstg_mysql.driver-class-name}"/>
+        <property name="url" value="${spring.datasource.migstg_mysql.url}" />
+        <property name="username" value="${spring.datasource.migstg_mysql.username}"/>
+        <property name="password" value="${spring.datasource.migstg_mysql.password}"/>
     </bean>
 
     <bean id="dataSource-local" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
-        <property name="driverClassName" value="${Globals.Local.DriverClassName}"/>
-        <property name="url" value="${Globals.Local.Url}" />
-        <property name="username" value="${Globals.Local.UserName}"/>
-        <property name="password" value="${Globals.Local.Password}"/>
+        <property name="driverClassName" value="${spring.datasource.egovlocal_mysql.driver-class-name}"/>
+        <property name="url" value="${spring.datasource.egovlocal_mysql.url}" />
+        <property name="username" value="${spring.datasource.egovlocal_mysql.username}"/>
+        <property name="password" value="${spring.datasource.egovlocal_mysql.password}"/>
     </bean>
 
     <!-- 로컬 데이터소스를 사용하는 JdbcTemplate -->

--- a/src/main/resources/egovframework/batch/context-batch-job-launcher.xml
+++ b/src/main/resources/egovframework/batch/context-batch-job-launcher.xml
@@ -5,7 +5,6 @@
 			http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
 			http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-3.0.xsd">
 
-        <import resource="classpath:/egovframework/batch/context-batch-datasource.xml" />
         <import resource="classpath:/egovframework/batch/context-batch-mapper.xml" />
         <!-- 공통 설정(컴포넌트 스캔 등)을 포함하여 Bean 등록 누락 방지 -->
         <import resource="classpath:/egovframework/batch/context-common.xml" />


### PR DESCRIPTION
## 요약
- Globals 기반 설정을 Spring Boot `application.yml` 속성으로 교체
- 배치 인프라 설정 클래스에 데이터소스 XML 직접 로딩 추가
- 중복 XML import 제거

## 테스트
- `mvn -q test` *(네트워크 문제로 parent POM을 받을 수 없어 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68a88887f178832a9f2304f2de7ec5f0