### PR TITLE
ERP API URL 설정을 application.yml로 이동

### DIFF
--- a/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
+++ b/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
@@ -37,7 +37,7 @@ public class FetchErpDataTasklet implements Tasklet {
     private final List<NotificationSender> notificationSenders;
 
     /** 차량 정보를 조회할 API URL */
-    @Value("${Globals.Erp.ApiUrl}")
+    @Value("${erp.api-url}")
     private String apiUrl;
 
     public FetchErpDataTasklet(WebClient.Builder builder,

--- a/src/main/resources/application/env/dev/application.yml
+++ b/src/main/resources/application/env/dev/application.yml
@@ -22,3 +22,7 @@ spring:
       url: "jdbc:cubrid:192.168.10.10:33000:egovremote1_dev:::"
       username: devread
       password: devread!1234
+
+erp:
+  # ERP 시스템 API URL
+  api-url: http://localhost:8080/api/erp

--- a/src/main/resources/application/env/local/application.yml
+++ b/src/main/resources/application/env/local/application.yml
@@ -22,3 +22,7 @@ spring:
       url: "jdbc:cubrid:192.168.0.10:33000:egovremote1:::"
       username: readuser
       password: read!1234
+
+erp:
+  # ERP 시스템 API URL
+  api-url: http://localhost:8080/api/erp

--- a/src/main/resources/application/env/prod/application.yml
+++ b/src/main/resources/application/env/prod/application.yml
@@ -22,3 +22,7 @@ spring:
       url: "jdbc:cubrid:192.168.20.20:33000:egovremote1_prod:::"
       username: prodread
       password: prodread!1234
+
+erp:
+  # ERP 시스템 API URL
+  api-url: http://localhost:8080/api/erp

--- a/src/main/resources/egovframework/batch/properties/env/dev/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/env/dev/globals.properties
@@ -39,6 +39,5 @@ Globals.Stg.UserName=miguser
 Globals.Stg.Password=mig!1234
 
 # ERP REST API \ud638\ucd9c \uc815\ubcf4
-Globals.Erp.ApiUrl=http://localhost:8080/api/erp
 Globals.Erp.AuthToken=CHANGE_ME
 

--- a/src/main/resources/egovframework/batch/properties/env/local/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/env/local/globals.properties
@@ -45,6 +45,5 @@ Globals.Stg.UserName=miguser
 Globals.Stg.Password=mig!1234
 
 # ERP REST API \ud638\ucd9c \uc815\ubcf4
-Globals.Erp.ApiUrl=http://localhost:8080/api/erp
 Globals.Erp.AuthToken=CHANGE_ME
 

--- a/src/main/resources/egovframework/batch/properties/env/prod/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/env/prod/globals.properties
@@ -39,6 +39,5 @@ Globals.Stg.UserName=miguser
 Globals.Stg.Password=mig!1234
 
 # ERP REST API \ud638\ucd9c \uc815\ubcf4
-Globals.Erp.ApiUrl=http://localhost:8080/api/erp
 Globals.Erp.AuthToken=CHANGE_ME
 


### PR DESCRIPTION
## Summary
- FetchErpDataTasklet에서 ERP API URL 프로퍼티 키를 `erp.api-url`로 변경
- 환경별 application.yml에 `erp.api-url` 추가하고 기존 `Globals.Erp.ApiUrl` 값 이동
- 각 globals.properties에서 `Globals.Erp.ApiUrl` 제거

## Testing
- `mvn -q test` *(네트워크 문제로 의존성 해석 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68a8895cae20832aa0f7403776d51b8f