### PR TITLE
데이터소스 명칭 정규화

### DIFF
--- a/src/main/resources/egovframework/batch/context-batch-datasource.xml
+++ b/src/main/resources/egovframework/batch/context-batch-datasource.xml
@@ -10,25 +10,25 @@
 
     <!-- 데이터소스 설정 -->
     <bean id="dataSource-remote1" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
-        <property name="driverClassName" value="${spring.datasource.egovremote1_cubrid.driver-class-name}"/>
-        <property name="url" value="${spring.datasource.egovremote1_cubrid.url}" />
-        <property name="username" value="${spring.datasource.egovremote1_cubrid.username}"/>
-        <property name="password" value="${spring.datasource.egovremote1_cubrid.password}"/>
+        <property name="driverClassName" value="${spring.datasource.egovremote1-cubrid.driver-class-name}"/>
+        <property name="url" value="${spring.datasource.egovremote1-cubrid.url}" />
+        <property name="username" value="${spring.datasource.egovremote1-cubrid.username}"/>
+        <property name="password" value="${spring.datasource.egovremote1-cubrid.password}"/>
     </bean>
 
     <!-- 스테이징 DB 데이터소스 -->
     <bean id="dataSource-stg" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
-        <property name="driverClassName" value="${spring.datasource.migstg_mysql.driver-class-name}"/>
-        <property name="url" value="${spring.datasource.migstg_mysql.url}" />
-        <property name="username" value="${spring.datasource.migstg_mysql.username}"/>
-        <property name="password" value="${spring.datasource.migstg_mysql.password}"/>
+        <property name="driverClassName" value="${spring.datasource.migstg-mysql.driver-class-name}"/>
+        <property name="url" value="${spring.datasource.migstg-mysql.url}" />
+        <property name="username" value="${spring.datasource.migstg-mysql.username}"/>
+        <property name="password" value="${spring.datasource.migstg-mysql.password}"/>
     </bean>
 
     <bean id="dataSource-local" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
-        <property name="driverClassName" value="${spring.datasource.egovlocal_mysql.driver-class-name}"/>
-        <property name="url" value="${spring.datasource.egovlocal_mysql.url}" />
-        <property name="username" value="${spring.datasource.egovlocal_mysql.username}"/>
-        <property name="password" value="${spring.datasource.egovlocal_mysql.password}"/>
+        <property name="driverClassName" value="${spring.datasource.egovlocal-mysql.driver-class-name}"/>
+        <property name="url" value="${spring.datasource.egovlocal-mysql.url}" />
+        <property name="username" value="${spring.datasource.egovlocal-mysql.username}"/>
+        <property name="password" value="${spring.datasource.egovlocal-mysql.password}"/>
     </bean>
 
     <!-- 로컬 데이터소스를 사용하는 JdbcTemplate -->


### PR DESCRIPTION
## 요약
- XML 데이터소스 정의의 접두어/이름을 application.yml과 동일하게 하이픈 표기로 통일

## 테스트
- `mvn -q test` (실패: parent POM을 네트워크에서 받을 수 없어 빌드 불가)

------
https://chatgpt.com/codex/tasks/task_e_68a891c524c8832abc085700e6830ee2