### PR TITLE
기본 데이터소스 alias 설정 추가

### DIFF
--- a/src/main/java/egovframework/bat/config/DataSourceAliasConfig.java
+++ b/src/main/java/egovframework/bat/config/DataSourceAliasConfig.java
@@ -1,0 +1,37 @@
+package egovframework.bat.config;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+/**
+ * app.datasource.primary 프로퍼티에 지정된 데이터소스에
+ * 'dataSource'라는 별칭을 등록한다.
+ */
+@Configuration
+public class DataSourceAliasConfig implements BeanFactoryPostProcessor, EnvironmentAware {
+
+    /** 환경 정보를 제공하는 객체 */
+    private Environment environment;
+
+    @Override
+    public void setEnvironment(Environment environment) {
+        this.environment = environment;
+    }
+
+    /**
+     * BeanFactory 초기화 시점에 데이터소스 별칭을 등록한다.
+     */
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        String primary = environment.getProperty("app.datasource.primary");
+        if (primary != null && beanFactory.containsBeanDefinition(primary)) {
+            // 예: dataSource-stg → dataSource 별칭 등록
+            beanFactory.registerAlias(primary, "dataSource");
+        }
+    }
+}
+

--- a/src/main/resources/application/env/dev/application.yml
+++ b/src/main/resources/application/env/dev/application.yml
@@ -42,3 +42,8 @@ logging:
 erp:
   # ERP 시스템 API URL
   api-url: http://localhost:8080/api/erp
+
+# 기본 데이터소스 설정
+app:
+  datasource:
+    primary: dataSource-stg

--- a/src/main/resources/application/env/local/application.yml
+++ b/src/main/resources/application/env/local/application.yml
@@ -42,3 +42,8 @@ logging:
 erp:
   # ERP 시스템 API URL
   api-url: http://localhost:8080/api/erp
+
+# 기본 데이터소스 설정
+app:
+  datasource:
+    primary: dataSource-stg

--- a/src/main/resources/application/env/prod/application.yml
+++ b/src/main/resources/application/env/prod/application.yml
@@ -42,3 +42,8 @@ logging:
 erp:
   # ERP 시스템 API URL
   api-url: http://localhost:8080/api/erp
+
+# 기본 데이터소스 설정
+app:
+  datasource:
+    primary: dataSource-stg

--- a/src/main/resources/egovframework/batch/context-batch-datasource.xml
+++ b/src/main/resources/egovframework/batch/context-batch-datasource.xml
@@ -36,8 +36,6 @@
         <property name="dataSource" ref="dataSource-local" />
     </bean>
 
-    <alias name="dataSource-stg" alias="dataSource"/>
-
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager" lazy-init="true">
         <property name="dataSource" ref="dataSource" />
     </bean>


### PR DESCRIPTION
## Summary
- 환경별 `application.yml`에 `app.datasource.primary` 프로퍼티 추가
- `BeanFactoryPostProcessor`로 기본 데이터소스 alias 등록
- XML의 `<alias>` 제거로 설정 단순화

## Testing
- `mvn -q test` *(실패: 부모 POM을 가져오지 못함)*

------
https://chatgpt.com/codex/tasks/task_e_68a893e9c1e0832a9a119d156be20080