### PR TITLE
ERP 차량 데이터 수집 시 빈 목록 처리

### DIFF
--- a/src/test/java/egovframework/bat/erp/tasklet/FetchErpDataTaskletTest.java
+++ b/src/test/java/egovframework/bat/erp/tasklet/FetchErpDataTaskletTest.java
@@ -1,0 +1,45 @@
+package egovframework.bat.erp.tasklet;
+
+import egovframework.bat.notification.NotificationSender;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import static org.junit.Assert.*;
+
+/**
+ * 원격 사이트 장애 시 빈 목록을 반환할 때 정상 종료되는지 테스트.
+ */
+public class FetchErpDataTaskletTest {
+
+    @Test
+    public void executeFinishedWhenNoVehicles() throws Exception {
+        // 원격 호출 실패를 모의하기 위한 WebClient
+        WebClient.Builder builder = WebClient.builder()
+            .exchangeFunction(clientRequest -> Mono.error(new RuntimeException("remote error")));
+
+        // DB 작업이 호출되지 않도록 update를 오버라이드한 JdbcTemplate
+        JdbcTemplate jdbcTemplate = new JdbcTemplate() {
+            @Override
+            public int update(String sql, Object... args) {
+                return 0;
+            }
+        };
+
+        List<NotificationSender> senders = Collections.emptyList();
+        FetchErpDataTasklet tasklet = new FetchErpDataTasklet(builder, jdbcTemplate, senders);
+
+        // apiUrl 필드 설정
+        Field field = FetchErpDataTasklet.class.getDeclaredField("apiUrl");
+        field.setAccessible(true);
+        field.set(tasklet, "http://example.com");
+
+        RepeatStatus status = tasklet.execute(null, null);
+        assertEquals(RepeatStatus.FINISHED, status);
+    }
+}
+


### PR DESCRIPTION
## Summary
- ERP 차량 데이터 조회 후 결과가 비어 있으면 경고 로그만 남기고 즉시 종료하도록 처리
- insertVehicles에서 빈 목록 전달 시 DB 작업을 생략하도록 보호 로직 추가
- 원격 ERP 장애를 모의하는 단위 테스트 작성

## Testing
- `mvn -q test` *(실패: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ba9382b8832aa651a2fb03bdc9ac