### PR TITLE
STG 적재 실패 시에도 배치 중단 방지

### DIFF
--- a/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
+++ b/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
@@ -70,8 +70,9 @@ public class FetchErpDataTasklet implements Tasklet {
             LOGGER.error("DB 커넥션 획득 실패", e);
         } catch (Exception e) {
             LOGGER.error("STG 테이블 적재 실패", e);
+            // 실패 로그 저장
+            saveFailLog(e);
             notifyFailure("차량 데이터 적재 실패: " + e.getMessage());
-            throw e;
         }
 
         LOGGER.info("ERP 차량 데이터 수집 완료");
@@ -103,7 +104,8 @@ public class FetchErpDataTasklet implements Tasklet {
             } catch (Exception e) {
                 LOGGER.error("ERP API 호출 실패: 시도 {} / {}", attempt, maxAttempts, e);
                 if (attempt == maxAttempts) {
-                    saveFailedCall(e);
+                    // 실패 로그 저장
+                    saveFailLog(e);
                     notifyFailure("ERP API 호출 실패: " + e.getMessage());
                 }
             }
@@ -147,11 +149,11 @@ public class FetchErpDataTasklet implements Tasklet {
     }
 
     /**
-     * 실패한 REST 호출 정보를 저장한다.
+     * 실패 로그를 저장한다.
      *
      * @param e 발생한 예외
      */
-    private void saveFailedCall(Exception e) {
+    private void saveFailLog(Exception e) {
         String sql = "INSERT INTO migstg.erp_api_fail_log (api_url, error_message, reg_dttm) VALUES (?, ?, ?)";
         try {
             jdbcTemplate.update(sql, apiUrl, e.getMessage(), new Timestamp(System.currentTimeMillis()));

--- a/src/test/java/egovframework/bat/erp/tasklet/FetchErpDataTaskletTest.java
+++ b/src/test/java/egovframework/bat/erp/tasklet/FetchErpDataTaskletTest.java
@@ -7,7 +7,9 @@ import java.util.List;
 import org.junit.Test;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.http.HttpStatus;
 import reactor.core.publisher.Mono;
 import static org.junit.Assert.*;
 
@@ -40,6 +42,50 @@ public class FetchErpDataTaskletTest {
 
         RepeatStatus status = tasklet.execute(null, null);
         assertEquals(RepeatStatus.FINISHED, status);
+    }
+
+    @Test
+    public void executeFinishedWhenInsertFails() throws Exception {
+        // 정상 데이터를 반환하는 WebClient 구성
+        String json = "[{\"vehicleId\":\"1\",\"model\":\"model\",\"manufacturer\":\"maker\",\"price\":100}]";
+        WebClient.Builder builder = WebClient.builder()
+            .exchangeFunction(clientRequest -> Mono.just(
+                ClientResponse.create(HttpStatus.OK)
+                    .header("Content-Type", "application/json")
+                    .body(json)
+                    .build()
+            ));
+
+        // insert 시 예외를 발생시키고 update 호출 횟수를 기록하는 JdbcTemplate
+        class TestJdbcTemplate extends JdbcTemplate {
+            int updateCount = 0;
+
+            @Override
+            public <T> int[] batchUpdate(String sql, java.util.List<T> batchArgs, int batchSize,
+                                        org.springframework.jdbc.core.ParameterizedPreparedStatementSetter<T> pss) {
+                throw new RuntimeException("insert fail");
+            }
+
+            @Override
+            public int update(String sql, Object... args) {
+                updateCount++;
+                return 1;
+            }
+        }
+
+        TestJdbcTemplate jdbcTemplate = new TestJdbcTemplate();
+        List<NotificationSender> senders = Collections.emptyList();
+        FetchErpDataTasklet tasklet = new FetchErpDataTasklet(builder, jdbcTemplate, senders);
+
+        // apiUrl 필드 설정
+        Field field = FetchErpDataTasklet.class.getDeclaredField("apiUrl");
+        field.setAccessible(true);
+        field.set(tasklet, "http://example.com");
+
+        RepeatStatus status = tasklet.execute(null, null);
+
+        assertEquals(RepeatStatus.FINISHED, status);
+        assertTrue("로그 저장이 호출되어야 합니다.", jdbcTemplate.updateCount > 0);
     }
 }
 


### PR DESCRIPTION
## 요약
- STG 테이블 적재 실패 시 예외를 DB에 기록하고 배치를 계속 진행하도록 수정
- ERP API 실패 및 적재 실패를 공통 메서드로 로그 저장
- 적재 실패 상황에서도 작업이 완료되는지 검증하는 테스트 추가

## 테스트
- `mvn -q test` *(네트워크 문제로 의존성 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bc8f7960832a9e964447754d254a