### PR TITLE
feat: ERP DB 적재 실패 로그 저장

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ mvn -Pprod package    # 운영 환경 빌드
 
 ## STG 환경용 DDL 스크립트
 
-migstg 데이터베이스 초기화 시 `src/script/mysql/test/2.stg_ddl-mysql.sql`을 실행해 테이블 구조를 생성합니다. STG 연결 정보는 각 환경별 `application-<프로필>.yml` 파일의 관련 항목을 참고하세요.
+migstg 데이터베이스 초기화 시 `src/script/mysql/test/2.stg_ddl-mysql.sql`을 실행해 테이블 구조를 생성합니다. STG 연결 정보는 각 환경별 `application-<프로필>.yml` 파일의 관련 항목을 참고하세요. 해당 스크립트에는 REST 호출 실패 로그 테이블(`erp_api_fail_log`)과 DB 적재 실패 로그 테이블(`erp_db_fail_log`) DDL이 포함되어 있으며, `FetchErpDataTasklet`이 DB 적재 실패 시 이 테이블에 로그를 남깁니다.
 
 배치 잡 실행 시 `sourceSystem` 파라미터를 생략하면 `LND` 프리픽스로 ESNTL_ID가 생성됩니다.
 

--- a/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
+++ b/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
@@ -70,8 +70,8 @@ public class FetchErpDataTasklet implements Tasklet {
             LOGGER.error("DB 커넥션 획득 실패", e);
         } catch (Exception e) {
             LOGGER.error("STG 테이블 적재 실패", e);
-            // 실패 로그 저장
-            saveFailLog(e);
+            // DB 적재 실패 로그 저장
+            saveDbFail(e);
             notifyFailure("차량 데이터 적재 실패: " + e.getMessage());
         }
 
@@ -145,6 +145,8 @@ public class FetchErpDataTasklet implements Tasklet {
             });
         } catch (CannotGetJdbcConnectionException e) {
             LOGGER.error("차량 정보 적재 중 커넥션 획득 실패", e);
+            // DB 적재 실패 로그 저장
+            saveDbFail(e);
         }
     }
 
@@ -159,6 +161,20 @@ public class FetchErpDataTasklet implements Tasklet {
             jdbcTemplate.update(sql, apiUrl, e.getMessage(), new Timestamp(System.currentTimeMillis()));
         } catch (CannotGetJdbcConnectionException ex) {
             LOGGER.error("REST 호출 실패 로그 저장 중 커넥션 획득 실패", ex);
+        }
+    }
+
+    /**
+     * DB 적재 실패 로그를 저장한다.
+     *
+     * @param e 발생한 예외
+     */
+    private void saveDbFail(Exception e) {
+        String sql = "INSERT INTO migstg.erp_db_fail_log (error_message, reg_dttm) VALUES (?, ?)";
+        try {
+            jdbcTemplate.update(sql, e.getMessage(), new Timestamp(System.currentTimeMillis()));
+        } catch (CannotGetJdbcConnectionException ex) {
+            LOGGER.error("DB 적재 실패 로그 저장 중 커넥션 획득 실패", ex);
         }
     }
 

--- a/src/script/mysql/test/2.stg_ddl-mysql.sql
+++ b/src/script/mysql/test/2.stg_ddl-mysql.sql
@@ -3,6 +3,7 @@ DROP TABLE IF EXISTS comtnemplyrinfo;
 DROP TABLE IF EXISTS comtnorgnztinfo;
 DROP TABLE IF EXISTS erp_vehicle;
 DROP TABLE IF EXISTS erp_api_fail_log;
+DROP TABLE IF EXISTS erp_db_fail_log;
 
 -- 조직 테이블
 CREATE TABLE `comtnorgnztinfo` (
@@ -52,3 +53,11 @@ CREATE TABLE `erp_api_fail_log` (
   PRIMARY KEY (`FAIL_LOG_ID`),
   KEY `ERP_API_FAIL_LOG_i01` (`API_URL`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='ERP API 실패 로그';
+
+-- ERP DB 적재 실패 로그 테이블
+CREATE TABLE `erp_db_fail_log` (
+  `FAIL_LOG_ID` bigint NOT NULL AUTO_INCREMENT COMMENT '실패 로그 ID',
+  `ERROR_MESSAGE` varchar(1000) DEFAULT NULL COMMENT '오류 메시지',
+  `REG_DTTM` datetime NOT NULL COMMENT '등록일시',
+  PRIMARY KEY (`FAIL_LOG_ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='ERP DB 적재 실패 로그';


### PR DESCRIPTION
## 요약
- ERP 데이터 적재 실패 시 `erp_db_fail_log`에 기록하는 `saveDbFail` 추가
- DB 로그 테이블 DDL 및 문서화

## 테스트
- `mvn -q -e -Plocal test` *(네트워크 문제로 부모 POM을 해석하지 못해 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68a9be70c214832a84967802f531c186