### PR TITLE
test: simulate DB failure with DataAccessException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,15 +116,21 @@
 			<artifactId>spring-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.quartz-scheduler</groupId>
-			<artifactId>quartz</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-core</artifactId>
+                        <version>4.11.0</version>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.quartz-scheduler</groupId>
+                        <artifactId>quartz</artifactId>
+                </dependency>
 		<dependency>
 			<groupId>org.antlr</groupId>
 			<artifactId>antlr</artifactId>


### PR DESCRIPTION
## Summary
- refine ERP tasklet failure test to mock DB error with DataAccessResourceFailureException
- verify DB failure log insertion via Mockito
- add Mockito test dependency

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.18)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c05e7e40832a8d5be7e5a1aae253