### PR TITLE
데이터소스 초기화 시점 조정 및 배치 컨텍스트 부모 설정

### DIFF
--- a/src/main/java/com/springboot/main/EgovBootApplication.java
+++ b/src/main/java/com/springboot/main/EgovBootApplication.java
@@ -6,11 +6,13 @@ import java.util.List;
 import org.egovframe.rte.bat.core.launch.support.EgovSchedulerRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.Banner;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
 
 /**
@@ -30,8 +32,12 @@ import org.springframework.context.annotation.ComponentScan;
 @SpringBootApplication
 @ComponentScan(basePackages = {"com.springboot.main", "egovframework.bat"}) // 스캔할 패키지 지정
 public class EgovBootApplication implements CommandLineRunner {
-	
-	private static final Logger LOGGER = LoggerFactory.getLogger(EgovBootApplication.class);
+
+        private static final Logger LOGGER = LoggerFactory.getLogger(EgovBootApplication.class);
+
+        // Boot 애플리케이션 컨텍스트를 주입받아 배치 컨텍스트의 부모로 사용
+        @Autowired
+        private ApplicationContext applicationContext;
 
 	public static void main(String[] args) {
 		//SpringApplication.run(EgovBootApplication.class, args);
@@ -75,6 +81,8 @@ public class EgovBootApplication implements CommandLineRunner {
 		EgovSchedulerRunner egovSchedulerRunner = new EgovSchedulerRunner("/egovframework/batch/context-batch-scheduler.xml", "/egovframework/batch/context-scheduler-job.xml",
 //				jobPaths, 30000);
 				jobPaths, Long.MAX_VALUE);
+	// Boot 컨텍스트를 부모로 사용하여 dataSource 빈 재사용
+		egovSchedulerRunner.setApplicationContext(applicationContext);
 		egovSchedulerRunner.start();
 		
     }

--- a/src/main/java/egovframework/bat/config/MultiDataSourceConfig.java
+++ b/src/main/java/egovframework/bat/config/MultiDataSourceConfig.java
@@ -7,7 +7,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -37,7 +36,6 @@ public class MultiDataSourceConfig {
     // 운영 MySQL용 데이타소스
     //@Bean(name = "egovlocalDataSource")
     @Bean(name = "dataSource-local")
-    @Lazy // 필요한 시점까지 Bean 초기화를 지연
     @ConfigurationProperties("spring.datasource.egovlocal-mysql")
     DataSource egovlocalDataSource() {
         return DataSourceBuilder.create().build();
@@ -55,7 +53,6 @@ public class MultiDataSourceConfig {
     // Remote1 CUBRID 데이타소스
     //@Bean(name = "egovremote1CubridDataSource")
     @Bean(name = "dataSource-remote1")
-    @Lazy // 필요한 시점까지 Bean 초기화를 지연
     @ConfigurationProperties("spring.datasource.egovremote1-cubrid")
     DataSource egovremote1CubridDataSource() {
         return DataSourceBuilder.create().build();


### PR DESCRIPTION
## 개요
- `@Lazy` 제거로 데이터소스 빈을 즉시 초기화
- 스케줄러 실행 시 Boot 컨텍스트를 부모로 지정하여 `dataSource` 재사용

## 테스트
- `mvn -q -DskipTests package` (실패: org.springframework.boot:spring-boot-starter-parent:2.7.18 를 가져올 수 없음)

------
https://chatgpt.com/codex/tasks/task_e_68a9c73185e4832a9778ffd44406ddef