### PR TITLE
EgovSchedulerRunner에서 ApplicationContext 설정 제거

### DIFF
--- a/src/main/java/com/springboot/main/EgovBootApplication.java
+++ b/src/main/java/com/springboot/main/EgovBootApplication.java
@@ -81,8 +81,7 @@ public class EgovBootApplication implements CommandLineRunner {
 		EgovSchedulerRunner egovSchedulerRunner = new EgovSchedulerRunner("/egovframework/batch/context-batch-scheduler.xml", "/egovframework/batch/context-scheduler-job.xml",
 //				jobPaths, 30000);
 				jobPaths, Long.MAX_VALUE);
-	// Boot 컨텍스트를 부모로 사용하여 dataSource 빈 재사용
-		egovSchedulerRunner.setApplicationContext(applicationContext);
+		// EgovSchedulerRunner 실행
 		egovSchedulerRunner.start();
 		
     }


### PR DESCRIPTION
## Summary
- EgovSchedulerRunner에서 존재하지 않는 `setApplicationContext` 호출 삭제
- 실행 주석을 정리하여 스케줄러 실행 로직만 남김

## Testing
- `mvn test -e` *(네트워크 오류로 parent POM 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cbb44b98832a849b5f60e05e6c5c