### PR TITLE
egov 패키지 컴포넌트 스캔 활성화

### DIFF
--- a/src/main/resources/egovframework/batch/context-common.xml
+++ b/src/main/resources/egovframework/batch/context-common.xml
@@ -4,14 +4,12 @@
 		xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
 				http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd">
 
-    <!-- component-scan 설정-->
-    <!-- 
-        <context:component-scan base-package="egovframework">
-                <context:include-filter type="annotation" expression="org.springframework.stereotype.Service"/>
-                <context:include-filter type="annotation" expression="org.springframework.stereotype.Repository"/>
-                Tasklet 등 @Component 빈 자동 등록을 위한 포함 필터
-                <context:include-filter type="annotation" expression="org.springframework.stereotype.Component"/>
-                <context:exclude-filter type="annotation" expression="org.springframework.stereotype.Controller"/>
-        </context:component-scan>
-         -->
+    <!-- component-scan 설정 -->
+    <context:component-scan base-package="egovframework">
+        <context:include-filter type="annotation" expression="org.springframework.stereotype.Service"/>
+        <context:include-filter type="annotation" expression="org.springframework.stereotype.Repository"/>
+        <!-- Tasklet 등 @Component 빈 자동 등록을 위한 포함 필터 -->
+        <context:include-filter type="annotation" expression="org.springframework.stereotype.Component"/>
+        <context:exclude-filter type="annotation" expression="org.springframework.stereotype.Controller"/>
+    </context:component-scan>
 </beans>


### PR DESCRIPTION
## Summary
- `egovframework` 패키지의 @Component 빈 자동 등록을 위해 `context-common.xml`에 컴포넌트 스캔을 활성화했습니다.

## Testing
- `mvn -q -e test` (네트워크 문제로 parent POM을 내려받지 못해 빌드 실패)


------
https://chatgpt.com/codex/tasks/task_e_68abbf7601a8832abb0217d0a8668a1d