### PR TITLE
JobRegistry 기반으로 Remote1ToStg 잡 실행 변경

### DIFF
--- a/src/main/java/egovframework/bat/config/BatchInfrastructureConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchInfrastructureConfig.java
@@ -11,9 +11,8 @@ import org.springframework.context.annotation.ImportResource;
 @Configuration
 @ImportResource({
     // 배치 잡 실행기 관련 기본 설정
-    "classpath:/egovframework/batch/context-batch-job-launcher.xml",
-    // ERP REST -> STG 배치 잡 설정을 로딩하여 Job 빈을 등록
-    "classpath:/egovframework/batch/job/erp/erpRestToStgJob.xml"
+    "classpath:/egovframework/batch/context-batch-job-launcher.xml"
+    // 개별 잡 XML은 JobRegistry를 통해 조회하므로 별도 import 불필요
 })
 public class BatchInfrastructureConfig {
     // 필요 시 JobLauncher 빈을 직접 정의할 수 있다.

--- a/src/main/java/egovframework/bat/insa/api/Remote1ToStgJobController.java
+++ b/src/main/java/egovframework/bat/insa/api/Remote1ToStgJobController.java
@@ -8,6 +8,7 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.configuration.JobRegistry;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -29,8 +30,8 @@ public class Remote1ToStgJobController {
     // 스프링 배치 잡 실행기
     private final JobLauncher jobLauncher;
 
-    // Remote1 데이터를 중간 저장소로 옮기는 배치 잡
-    private final Job insaRemote1ToStgJob;
+    // 잡 레지스트리를 통해 배치 잡을 조회하기 위한 레지스트리
+    private final JobRegistry jobRegistry;
 
     /**
      * Remote1 데이터를 중간 저장소로 옮기는 배치 잡을 실행한다.
@@ -51,7 +52,9 @@ public class Remote1ToStgJobController {
         JobParameters jobParameters = builder.toJobParameters();
 
         try {
-            JobExecution execution = jobLauncher.run(insaRemote1ToStgJob, jobParameters);
+            // 잡 레지스트리에서 배치 잡을 조회하여 실행
+            Job job = jobRegistry.getJob("insaRemote1ToStgJob");
+            JobExecution execution = jobLauncher.run(job, jobParameters);
             return ResponseEntity.ok(execution.getStatus());
         } catch (Exception e) {
             LOGGER.error("Remote1 배치 실행 실패", e);


### PR DESCRIPTION
## Summary
- Remote1ToStgJobController에서 Job을 직접 주입하던 방식을 JobRegistry 조회 방식으로 전환
- 잡 XML을 @ImportResource로 중복 등록하던 설정 제거

## Testing
- `mvn -q -e -DskipTests package` *(실패: 네트워크에 접근할 수 없음)*

------
https://chatgpt.com/codex/tasks/task_e_68abc98895f0832a92fc13469e2fe5b6