### PR TITLE
feat: JobRegistry 기반으로 MyBatis 잡 실행

### DIFF
--- a/src/main/java/egovframework/bat/example/api/ExampleJobController.java
+++ b/src/main/java/egovframework/bat/example/api/ExampleJobController.java
@@ -9,7 +9,7 @@ import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.batch.core.configuration.JobRegistry;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,9 +30,8 @@ public class ExampleJobController {
     // 스프링 배치 잡 실행기
     private final JobLauncher jobLauncher;
 
-    // MyBatis 데이터를 MyBatis 데이터베이스로 옮기는 배치 잡
-    // 동일 이름의 중복 등록을 방지하기 위해 잡 이름을 변경하였다
-    private final @Qualifier("mybatisToMybatisSampleJob") Job mybatisToMybatisSampleJob;
+    // 등록된 배치 잡을 조회하기 위한 잡 레지스트리
+    private final JobRegistry jobRegistry;
 
     /**
      * 마이바티스 배치 잡을 실행한다.
@@ -53,8 +52,9 @@ public class ExampleJobController {
         JobParameters jobParameters = builder.toJobParameters();
 
         try {
-            // 변경된 잡 이름으로 실행한다
-            JobExecution execution = jobLauncher.run(mybatisToMybatisSampleJob, jobParameters);
+            // 잡 레지스트리에서 잡을 조회한 뒤 실행한다
+            Job job = jobRegistry.getJob("mybatisToMybatisSampleJob");
+            JobExecution execution = jobLauncher.run(job, jobParameters);
             return ResponseEntity.ok(execution.getStatus());
         } catch (Exception e) {
             LOGGER.error("마이바티스 배치 실행 실패", e);


### PR DESCRIPTION
## Summary
- REST 컨트롤러에서 직접 주입하던 Job 대신 JobRegistry를 사용해 잡을 조회 후 실행

## Testing
- `mvn -q test` *(실패: 원격 저장소 연결 불가)*
- `mvn -q spring-boot:run` *(실패: 원격 저장소 연결 불가)*

------
https://chatgpt.com/codex/tasks/task_e_68abcfdd30c4832a82119e898b2625e7