### PR TITLE
fix: XML 기반 배치 스캔 구성

### DIFF
--- a/src/main/java/com/springboot/main/EgovBootApplication.java
+++ b/src/main/java/com/springboot/main/EgovBootApplication.java
@@ -33,7 +33,8 @@ import org.springframework.context.annotation.FilterType;
 
 @SpringBootApplication
 @ComponentScan(
-    basePackages = {"com.springboot.main", "egovframework.bat"}
+    basePackages = {"com.springboot.main"}
+    // 배치 관련 빈은 XML에서만 스캔되도록 설정
 //    ,
 //    excludeFilters = {
 //        @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = org.springframework.stereotype.Component.class)

--- a/src/main/resources/egovframework/batch/context-batch-scheduler.xml
+++ b/src/main/resources/egovframework/batch/context-batch-scheduler.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
 
-        <import resource="context-batch-job-launcher.xml" />
+        <!-- context-batch-job-launcher.xml은 Boot 설정에서 로딩됨 -->
 
         <!-- 각 잡에 대한 크론 트리거 정의 -->
 


### PR DESCRIPTION
## Summary
- 애플리케이션 컴포넌트 스캔 범위에서 배치 패키지를 제외하여 XML 기반 빈 등록 유지
- 스케줄러 설정에서 배치 잡 런처 중복 import 제거

## Testing
- `mvn -q test` *(실패: parent POM을 다운로드하지 못함)*
- `mvn -q spring-boot:run` *(실패: parent POM을 다운로드하지 못함)*

------
https://chatgpt.com/codex/tasks/task_e_68abdd083a8c832a91ff640e1deb7fbc