### PR TITLE
스케줄러 설정 분리 및 잡 XML 임포트 정리

### DIFF
--- a/src/main/resources/egovframework/batch/context-batch-scheduler.xml
+++ b/src/main/resources/egovframework/batch/context-batch-scheduler.xml
@@ -3,13 +3,8 @@
         xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
 
         <import resource="context-batch-job-launcher.xml" />
-
-		<!-- 각 잡을 넣는다 -->
-		<import resource="classpath:/egovframework/batch/job/insa/insaRemote1ToStgJob.xml" />
-		<import resource="classpath:/egovframework/batch/job/insa/insaStgToLocalJob.xml" />
-		<import resource="job/erp/erpRestToStgJob.xml" />
-		<import resource="job/erp/erpStgToLocalJob.xml" />
-		<import resource="job/example/mybatisToMybatisSampleJob.xml" />
+        <!-- JobDetail 정의를 포함하는 설정 -->
+        <import resource="context-scheduler-job.xml" />
         
         <!-- 각 잡에 대한 크론 트리거 정의 -->
 

--- a/src/main/resources/egovframework/batch/context-scheduler-job.xml
+++ b/src/main/resources/egovframework/batch/context-scheduler-job.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+    <!-- 각 배치 잡 XML을 한곳에서 임포트한다 -->
+    <import resource="classpath:/egovframework/batch/job/insa/insaRemote1ToStgJob.xml" />
+    <import resource="classpath:/egovframework/batch/job/insa/insaStgToLocalJob.xml" />
+    <import resource="classpath:/egovframework/batch/job/erp/erpRestToStgJob.xml" />
+    <import resource="classpath:/egovframework/batch/job/erp/erpStgToLocalJob.xml" />
+    <import resource="classpath:/egovframework/batch/job/example/mybatisToMybatisSampleJob.xml" />
+
 
 	<bean id="jobDetail" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
         <property name="jobClass" value="egovframework.bat.scheduler.EgovQuartzJobLauncher" />


### PR DESCRIPTION
## 요약
- 잡 XML 임포트를 `context-scheduler-job.xml`로 이동하여 JobDetail과 함께 관리
- 스케줄러 설정 파일에서 JobDetail 정의 파일만 로드하도록 구성 단순화

## 테스트
- `mvn -q test` *(네트워크 문제로 부모 POM을 내려받지 못해 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68ac10a6df5c832ab9cc52a48e117234