### PR TITLE
Load ERP API URL from application.yml

### DIFF
--- a/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
+++ b/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
@@ -42,8 +42,7 @@ public class FetchErpDataTasklet implements Tasklet {
     private final List<NotificationSender> notificationSenders;
 
     /** 차량 정보를 조회할 API URL */
-    //@Value("${erp.api-url}")
-    @Value("${Globals.Erp.ApiUrl}")
+    @Value("${erp.api-url}")
     private String apiUrl;
 
     public FetchErpDataTasklet(WebClient.Builder builder,

--- a/src/main/resources/egovframework/batch/context-batch-datasource.xml
+++ b/src/main/resources/egovframework/batch/context-batch-datasource.xml
@@ -6,12 +6,19 @@
 			http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
 			http://www.springframework.org/schema/jdbc  http://www.springframework.org/schema/jdbc/spring-jdbc-4.0.xsd">
 
-	<bean id="egov.propertyConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+    <!-- application.yml 속성 로딩을 위한 YamlPropertiesFactoryBean -->
+    <bean id="yamlProperties" class="org.springframework.beans.factory.config.YamlPropertiesFactoryBean">
+        <property name="resources" value="classpath:application.yml" />
+    </bean>
+
+    <!-- globals.properties와 application.yml을 함께 로딩 -->
+    <bean id="egov.propertyConfigurer" class="org.springframework.beans.factory.config.PropertySourcesPlaceholderConfigurer">
         <property name="locations">
             <list>
                 <value>classpath:/egovframework/batch/properties/globals.properties</value>
             </list>
         </property>
+        <property name="properties" ref="yamlProperties" />
     </bean>
 
     <!-- 데이터소스 설정 -->

--- a/src/test/java/egovframework/bat/erp/tasklet/FetchErpDataTaskletPropertyInjectionTest.java
+++ b/src/test/java/egovframework/bat/erp/tasklet/FetchErpDataTaskletPropertyInjectionTest.java
@@ -1,0 +1,80 @@
+package egovframework.bat.erp.tasklet;
+
+import egovframework.bat.notification.NotificationSender;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.junit.runner.RunWith;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.http.HttpStatus;
+import reactor.core.publisher.Mono;
+
+/**
+ * application.yml의 erp.api-url 프로퍼티가 주입되는지 검증하는 테스트.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = FetchErpDataTaskletPropertyInjectionTest.TestConfig.class)
+public class FetchErpDataTaskletPropertyInjectionTest {
+
+    @Configuration
+    @ComponentScan(basePackageClasses = FetchErpDataTasklet.class)
+    static class TestConfig {
+
+        // Yaml 설정을 읽어 PropertySourcesPlaceholderConfigurer에 등록
+        @Bean
+        public static PropertySourcesPlaceholderConfigurer properties() {
+            YamlPropertiesFactoryBean yaml = new YamlPropertiesFactoryBean();
+            yaml.setResources(new ClassPathResource("application.yml"));
+            PropertySourcesPlaceholderConfigurer config = new PropertySourcesPlaceholderConfigurer();
+            config.setProperties(yaml.getObject());
+            return config;
+        }
+
+        @Bean
+        public WebClient.Builder builder() {
+            return WebClient.builder().exchangeFunction(req -> Mono.just(
+                ClientResponse.create(HttpStatus.OK)
+                    .header("Content-Type", "application/json")
+                    .body("[]")
+                    .build()));
+        }
+
+        @Bean
+        public JdbcTemplate jdbcTemplate() {
+            return new JdbcTemplate();
+        }
+
+        @Bean
+        public List<NotificationSender> notificationSenders() {
+            return Collections.emptyList();
+        }
+    }
+
+    @Autowired
+    FetchErpDataTasklet tasklet;
+
+    @Test
+    public void propertyInjected() throws Exception {
+        // 배치 실행
+        tasklet.execute(null, null);
+
+        // apiUrl 필드에 프로퍼티가 주입되었는지 확인
+        Field field = FetchErpDataTasklet.class.getDeclaredField("apiUrl");
+        field.setAccessible(true);
+        String apiUrl = (String) field.get(tasklet);
+        org.junit.Assert.assertEquals("http://127.0.0.1:8080/api/v1/vehicles", apiUrl);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Load application.yml via YamlPropertiesFactoryBean and PropertySourcesPlaceholderConfigurer
- Inject `erp.api-url` into `FetchErpDataTasklet`
- Add test confirming `erp.api-url` property injection

## Testing
- `mvn -q -Plocal test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.18)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1ccbf86c832aa132164e3cb0ee8b