### PR TITLE
test: 더미 ERP 응답 JSON 외부 파일 사용

### DIFF
--- a/src/test/java/egovframework/bat/erp/api/DummyErpApiInfo.java
+++ b/src/test/java/egovframework/bat/erp/api/DummyErpApiInfo.java
@@ -11,12 +11,4 @@ public final class DummyErpApiInfo {
     public static final String DUMMY_ENDPOINT =
         "https://dummy-erp.example.com/api/v1/vehicles";
 
-    /** 더미 응답 JSON (테스트용) */
-    public static final String DUMMY_RESPONSE = "{\\n"
-        + "  \\\"vehicleId\\\": \\\"DUMMY-VEHICLE-0001\\\",\\n"
-        + "  \\\"model\\\": \\\"테스트 더미 차량\\\",\\n"
-        + "  \\\"manufacturer\\\": \\\"더미 제조사\\\",\\n"
-        + "  \\\"price\\\": 1000000,\\n"
-        + "  \\\"created_at\\\": \\\"2024-05-10T09:00:00Z\\\"\\n"
-        + "}";
 }

--- a/src/test/java/egovframework/bat/erp/api/DummyErpApiInfoTest.java
+++ b/src/test/java/egovframework/bat/erp/api/DummyErpApiInfoTest.java
@@ -1,0 +1,37 @@
+package egovframework.bat.erp.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+/**
+ * 더미 ERP API 정보와 응답 JSON 파일을 검증하는 테스트.
+ */
+public class DummyErpApiInfoTest {
+
+    /**
+     * JSON 파일에서 더미 응답을 읽어 올 수 있는지 확인한다.
+     */
+    @Test
+    public void 더미_JSON_파일_읽기_테스트() throws Exception {
+        URL resource = getClass().getClassLoader().getResource("dummy-vehicle-response.json");
+        String json = new String(
+                Files.readAllBytes(Paths.get(resource.toURI())),
+                StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"vehicleId\": \"DUMMY-VEHICLE-0001\""));
+    }
+
+    /**
+     * 더미 ERP 엔드포인트 상수가 예상 값과 일치하는지 확인한다.
+     */
+    @Test
+    public void 더미_엔드포인트_상수_테스트() {
+        assertEquals("https://dummy-erp.example.com/api/v1/vehicles", DummyErpApiInfo.DUMMY_ENDPOINT);
+    }
+}


### PR DESCRIPTION
## Summary
- DummyErpApiInfo에서 하드코딩된 DUMMY_RESPONSE 제거
- 더미 JSON 파일을 읽어 검증하는 DummyErpApiInfoTest 추가

## Testing
- `mvn -q test` *(네트워크 문제로 Maven 의존성을 받을 수 없어 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4e950638832a9558d82f7a3f0293