### PR TITLE
FetchErpDataTasklet apiUrl 주입 방식 개선

### DIFF
--- a/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
+++ b/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
@@ -42,17 +42,26 @@ public class FetchErpDataTasklet implements Tasklet {
     private final List<NotificationSender> notificationSenders;
 
     /** 차량 정보를 조회할 API URL */
-    //@Value("${erp.api-url}")
-    @Value("${Globals.Erp.ApiUrl}")
-    private String apiUrl;
+    private final String apiUrl;
 
     public FetchErpDataTasklet(WebClient.Builder builder,
                                @Qualifier("jdbcTemplateLocal") JdbcTemplate jdbcTemplate,
-                               List<NotificationSender> notificationSenders) {
+                               List<NotificationSender> notificationSenders,
+                               @Value("${Globals.Erp.ApiUrl}") String apiUrl) {
         // WebClient 생성
         this.webClient = builder.build();
         this.jdbcTemplate = jdbcTemplate;
         this.notificationSenders = notificationSenders;
+        this.apiUrl = apiUrl;
+    }
+
+    /**
+     * 현재 설정된 API URL을 반환한다.
+     *
+     * @return API URL
+     */
+    public String getApiUrl() {
+        return apiUrl;
     }
 
     @Override

--- a/src/test/java/egovframework/bat/erp/tasklet/FetchErpDataTaskletPropertyInjectionTest.java
+++ b/src/test/java/egovframework/bat/erp/tasklet/FetchErpDataTaskletPropertyInjectionTest.java
@@ -1,28 +1,26 @@
 package egovframework.bat.erp.tasklet;
 
 import egovframework.bat.notification.NotificationSender;
-import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.junit.runner.RunWith;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.http.HttpStatus;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import reactor.core.publisher.Mono;
 
 /**
- * application.yml의 erp.api-url 프로퍼티가 주입되는지 검증하는 테스트.
+ * Globals.Erp.ApiUrl 프로퍼티가 주입되는지 검증하는 테스트.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = FetchErpDataTaskletPropertyInjectionTest.TestConfig.class)
@@ -32,13 +30,13 @@ public class FetchErpDataTaskletPropertyInjectionTest {
     @ComponentScan(basePackageClasses = FetchErpDataTasklet.class)
     static class TestConfig {
 
-        // Yaml 설정을 읽어 PropertySourcesPlaceholderConfigurer에 등록
+        // 테스트용 프로퍼티 설정
         @Bean
         public static PropertySourcesPlaceholderConfigurer properties() {
-            YamlPropertiesFactoryBean yaml = new YamlPropertiesFactoryBean();
-            yaml.setResources(new ClassPathResource("application.yml"));
+            Properties props = new Properties();
+            props.setProperty("Globals.Erp.ApiUrl", "http://127.0.0.1:8080/api/v1/vehicles");
             PropertySourcesPlaceholderConfigurer config = new PropertySourcesPlaceholderConfigurer();
-            config.setProperties(yaml.getObject());
+            config.setProperties(props);
             return config;
         }
 
@@ -51,7 +49,7 @@ public class FetchErpDataTaskletPropertyInjectionTest {
                     .build()));
         }
 
-        @Bean
+        @Bean(name = "jdbcTemplateLocal")
         public JdbcTemplate jdbcTemplate() {
             return new JdbcTemplate();
         }
@@ -71,9 +69,7 @@ public class FetchErpDataTaskletPropertyInjectionTest {
         tasklet.execute(null, null);
 
         // apiUrl 필드에 프로퍼티가 주입되었는지 확인
-        Field field = FetchErpDataTasklet.class.getDeclaredField("apiUrl");
-        field.setAccessible(true);
-        String apiUrl = (String) field.get(tasklet);
+        String apiUrl = tasklet.getApiUrl();
         org.junit.Assert.assertEquals("http://127.0.0.1:8080/api/v1/vehicles", apiUrl);
     }
 }

--- a/src/test/java/egovframework/bat/erp/tasklet/FetchErpDataTaskletTest.java
+++ b/src/test/java/egovframework/bat/erp/tasklet/FetchErpDataTaskletTest.java
@@ -1,7 +1,6 @@
 package egovframework.bat.erp.tasklet;
 
 import egovframework.bat.notification.NotificationSender;
-import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
@@ -37,12 +36,7 @@ public class FetchErpDataTaskletTest {
         };
 
         List<NotificationSender> senders = Collections.emptyList();
-        FetchErpDataTasklet tasklet = new FetchErpDataTasklet(builder, jdbcTemplate, senders);
-
-        // apiUrl 필드 설정
-        Field field = FetchErpDataTasklet.class.getDeclaredField("apiUrl");
-        field.setAccessible(true);
-        field.set(tasklet, "http://example.com");
+        FetchErpDataTasklet tasklet = new FetchErpDataTasklet(builder, jdbcTemplate, senders, "http://example.com");
 
         RepeatStatus status = tasklet.execute(null, null);
         assertEquals(RepeatStatus.FINISHED, status);
@@ -68,12 +62,7 @@ public class FetchErpDataTaskletTest {
         when(jdbcTemplate.update(anyString(), any(), any())).thenReturn(1);
 
         List<NotificationSender> senders = Collections.emptyList();
-        FetchErpDataTasklet tasklet = new FetchErpDataTasklet(builder, jdbcTemplate, senders);
-
-        // apiUrl 필드 설정
-        Field field = FetchErpDataTasklet.class.getDeclaredField("apiUrl");
-        field.setAccessible(true);
-        field.set(tasklet, "http://example.com");
+        FetchErpDataTasklet tasklet = new FetchErpDataTasklet(builder, jdbcTemplate, senders, "http://example.com");
 
         RepeatStatus status = tasklet.execute(null, null);
 


### PR DESCRIPTION
## Summary
- FetchErpDataTasklet에 apiUrl 생성자 파라미터와 getter 추가
- 테스트에서 Reflection을 제거하고 생성자/메서드 기반 주입으로 통일

## Testing
- `mvn -q test` *(실패: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4e8eae38832aaa46d8ec8ec20f3d