### PR TITLE
EmployeeInfoProcessor에 디버그 로그 추가

### DIFF
--- a/src/main/java/egovframework/bat/insa/processor/EmployeeInfoProcessor.java
+++ b/src/main/java/egovframework/bat/insa/processor/EmployeeInfoProcessor.java
@@ -1,5 +1,7 @@
 package egovframework.bat.insa.processor;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,6 +19,9 @@ import lombok.RequiredArgsConstructor;
 @StepScope
 @RequiredArgsConstructor
 public class EmployeeInfoProcessor implements ItemProcessor<EmployeeInfo, EmployeeInfo> {
+
+    /** 로깅을 위한 로거 */
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmployeeInfoProcessor.class);
 
     /** ESNTL_ID 생성기 */
     private final EsntlIdGenerator esntlIdGenerator;
@@ -38,6 +43,8 @@ public class EmployeeInfoProcessor implements ItemProcessor<EmployeeInfo, Employ
         }
         // 프리픽스로 ESNTL_ID 생성
         item.setEsntlId(esntlIdGenerator.generate(prefix));
+        // 디버그 로그: 원천 시스템과 프리픽스, 생성된 ID를 출력
+        LOGGER.debug("sourceSystem={}, prefix={}, generatedId={}", sourceSystem, prefix, item.getEsntlId());
 
         return item;
     }

--- a/src/main/resources/log4j2/env/local/log4j2.xml
+++ b/src/main/resources/log4j2/env/local/log4j2.xml
@@ -8,8 +8,7 @@
     </Console>
   </Appenders>
   <Loggers>
-    <!-- <Root level="DEBUG"> -->
-    <Root level="INFO">
+    <Root level="DEBUG">
       <AppenderRef ref="Console"/>
     </Root>
   </Loggers>

--- a/src/test/java/egovframework/bat/insa/processor/EmployeeInfoProcessorTest.java
+++ b/src/test/java/egovframework/bat/insa/processor/EmployeeInfoProcessorTest.java
@@ -1,0 +1,39 @@
+package egovframework.bat.insa.processor;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Field;
+
+import org.junit.Test;
+
+import egovframework.bat.insa.common.EsntlIdGenerator;
+import egovframework.bat.insa.domain.EmployeeInfo;
+
+/**
+ * EmployeeInfoProcessor의 기능을 검증하는 테스트
+ */
+public class EmployeeInfoProcessorTest {
+
+    @Test
+    public void processGeneratesId() throws Exception {
+        // 테스트용 ESNTL_ID 생성기 스텁
+        EsntlIdGenerator generator = new EsntlIdGenerator(null) {
+            @Override
+            public String generate(String prefix) {
+                return prefix + "0000001";
+            }
+        };
+        // 프로세서 생성
+        EmployeeInfoProcessor processor = new EmployeeInfoProcessor(generator);
+        // sourceSystem 필드에 테스트 값 주입
+        Field sourceSystemField = EmployeeInfoProcessor.class.getDeclaredField("sourceSystem");
+        sourceSystemField.setAccessible(true);
+        sourceSystemField.set(processor, "remote1");
+
+        EmployeeInfo item = new EmployeeInfo();
+        processor.process(item);
+
+        // 생성된 ESNTL_ID가 예상값인지 확인
+        assertEquals("LND0000001", item.getEsntlId());
+    }
+}


### PR DESCRIPTION
## Summary
- EmployeeInfoProcessor에 SLF4J 로거와 디버그 로그 추가
- 로컬 환경의 Log4j2 루트 로그레벨을 DEBUG로 변경
- ESNTL_ID 생성 기능 검증을 위한 단위 테스트 추가

## Testing
- `mvn -q test` *(네트워크 문제로 부모 POM을 받을 수 없어 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68acffde3cdc832a93766c7c33e00bb3