### PR TITLE
Quartz JobDetail에 sourceSystem 파라미터 추가

### DIFF
--- a/src/main/resources/egovframework/batch/context-scheduler-job.xml
+++ b/src/main/resources/egovframework/batch/context-scheduler-job.xml
@@ -44,6 +44,8 @@
                 <entry key="jobName" value="insaStgToLocalJob" />
                 <entry key="jobLocator" value-ref="jobRegistry" />
                 <entry key="jobLauncher" value-ref="jobLauncher" />
+                <!-- 잡에서 사용할 원천 시스템 값 -->
+                <entry key="sourceSystem" value="remote1" />
             </map>
         </property>
     </bean>


### PR DESCRIPTION
## 요약
- Quartz 스케줄러에서 insaStgToLocalJobDetail의 JobDataMap에 `sourceSystem` 값을 추가하여 배치 잡에서 원천 시스템 정보를 전달

## 테스트
- `mvn -q test -Dtest=EmployeeInfoProcessorTest` *(네트워크 오류로 의존성 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0affd9b8832a83bdd5f7538fd7f1