### PR TITLE
SchedulerFactoryBean에 jobDetails 추가로 후행 잡 등록

### DIFF
--- a/src/main/resources/egovframework/batch/context-batch-scheduler.xml
+++ b/src/main/resources/egovframework/batch/context-batch-scheduler.xml
@@ -61,6 +61,13 @@
         </bean>
 
         <bean class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
+            <!-- 트리거가 없는 작업을 등록하기 위한 jobDetails 설정 -->
+            <property name="jobDetails">
+                <list>
+                    <ref bean="insaRemote1ToStgJobDetail" />
+                    <ref bean="insaStgToLocalJobDetail" />
+                </list>
+            </property>
             <property name="triggers">
                 <list>
                     <ref bean="insaRemote1ToStgCronTrigger" />


### PR DESCRIPTION
## Summary
- SchedulerFactoryBean에 jobDetails 프로퍼티를 추가하여 insaStgToLocalJobDetail을 트리거 없이 등록
- 선행 잡 완료 후 후행 잡을 즉시 실행할 수 있도록 설정

## Testing
- ⚠️ `mvn -q test` (의존성 다운로드 실패: Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68ad351e4558832a84c6c422c9ee21ab