### PR TITLE
Ensure durable job details without triggers

### DIFF
--- a/src/main/resources/egovframework/batch/context-scheduler-job.xml
+++ b/src/main/resources/egovframework/batch/context-scheduler-job.xml
@@ -38,6 +38,8 @@
     <bean id="insaStgToLocalJobDetail" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
         <property name="jobClass" value="egovframework.bat.scheduler.EgovQuartzJobLauncher" />
         <property name="group" value="quartz-batch" />
+        <!-- 트리거 없이 등록되는 잡을 지속적으로 유지 -->
+        <property name="durability" value="true" />
         <property name="jobDataAsMap">
             <map>
                 <!-- 스테이징 DB 데이터를 로컬로 적재하기 위한 작업 이름 설정 (가이드) -->


### PR DESCRIPTION
## Summary
- 유지되지 않던 insaStgToLocalJobDetail 잡에 durability 속성 추가

## Testing
- `mvn -q test` (실패: 원격 저장소에 접근할 수 없어 parent POM을 다운로드하지 못함)

------
https://chatgpt.com/codex/tasks/task_e_68ad37f84bd8832a9299fed8b1419aa2