### PR TITLE
feat: log staging employee count before local migration

### DIFF
--- a/src/main/java/egovframework/bat/insa/tasklet/StgEmplyrCountTasklet.java
+++ b/src/main/java/egovframework/bat/insa/tasklet/StgEmplyrCountTasklet.java
@@ -1,0 +1,49 @@
+package egovframework.bat.insa.tasklet;
+
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * 스테이징 DB의 COMTNEMPLYRINFO 테이블 건수를 로그로 출력하는 Tasklet.
+ */
+public class StgEmplyrCountTasklet implements Tasklet {
+
+    /** 로거 */
+    private static final Logger LOGGER = LoggerFactory.getLogger(StgEmplyrCountTasklet.class);
+
+    /** MyBatis SqlSessionFactory */
+    private SqlSessionFactory sqlSessionFactory;
+
+    /**
+     * SqlSessionFactory 주입
+     * @param sqlSessionFactory STG용 SqlSessionFactory
+     */
+    public void setSqlSessionFactory(SqlSessionFactory sqlSessionFactory) {
+        this.sqlSessionFactory = sqlSessionFactory;
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        String sql = "SELECT COUNT(*) FROM COMTNEMPLYRINFO";
+        try (SqlSession session = sqlSessionFactory.openSession();
+             Connection conn = session.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            if (rs.next()) {
+                int count = rs.getInt(1);
+                LOGGER.info("COMTNEMPLYRINFO 현재 건수: {}", count);
+            }
+        }
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/resources/egovframework/batch/job/insa/insaStgToLocalJob.xml
+++ b/src/main/resources/egovframework/batch/job/insa/insaStgToLocalJob.xml
@@ -9,7 +9,7 @@
     <!-- commit-interval 값은 일반적으로 500~1000으로 설정함 -->
     <job id="insaStgToLocalJob" parent="eGovBaseJob" xmlns="http://www.springframework.org/schema/batch">
         <!-- 조직 정보를 먼저 복사한 후 사원 정보를 복사 -->
-    <step id="stgToLocalOrgnztStep" parent="eGovBaseStep" next="stgToLocalStep">
+    <step id="stgToLocalOrgnztStep" parent="eGovBaseStep" next="stgEmplyrCountStep">
         <tasklet>
             <chunk reader="insaStgToLocalJob.stgToLocalOrgnztStep.mybatisItemReader"
                    writer="insaStgToLocalJob.stgToLocalOrgnztStep.mybatisItemWriter"
@@ -18,6 +18,9 @@
         <listeners>
             <listener ref="stepCountLogger" />
         </listeners>
+    </step>
+    <step id="stgEmplyrCountStep" parent="eGovTaskletStep" next="stgToLocalStep">
+        <tasklet ref="stgEmplyrCountTasklet" />
     </step>
     <step id="stgToLocalStep" parent="eGovBaseStep">
         <tasklet>
@@ -62,6 +65,11 @@
     <bean id="insaStgToLocalJob.stgToLocalStep.itemProcessor"
           class="egovframework.bat.insa.processor.EmployeeInfoProcessor"
           scope="step" />
+
+    <!-- COMTNEMPLYRINFO 건수를 출력하는 Tasklet -->
+    <bean id="stgEmplyrCountTasklet" class="egovframework.bat.insa.tasklet.StgEmplyrCountTasklet">
+        <property name="sqlSessionFactory" ref="sqlSessionFactory-stg" />
+    </bean>
 
 </beans>
 


### PR DESCRIPTION
## Summary
- add tasklet that logs the number of rows in COMTNEMPLYRINFO
- run the new tasklet before copying staging employees to local

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad3deba768832a8b4fa578399da992