### PR TITLE
remote1ToStgOrgnztStep에 stepCountLogger 리스너 추가

### DIFF
--- a/src/main/resources/egovframework/batch/job/insa/insaRemote1ToStgJob.xml
+++ b/src/main/resources/egovframework/batch/job/insa/insaRemote1ToStgJob.xml
@@ -19,6 +19,10 @@
                        writer="insaRemote1ToStgJob.remote1ToStgOrgnztStep.mybatisItemWriter"
                        commit-interval="500" />
             </tasklet>
+            <!-- step 실행 통계 로깅을 위한 리스너 등록 -->
+            <listeners>
+                <listener ref="stepCountLogger"/>
+            </listeners>
         </step>
         <step id="remote1ToStgStep" parent="eGovBaseStep">
             <tasklet>


### PR DESCRIPTION
## Summary
- remote1ToStgOrgnztStep에 stepCountLogger 리스너 추가

## Testing
- `mvn -q test` (parent POM 의존성 해석 실패로 테스트 실행 불가)

------
https://chatgpt.com/codex/tasks/task_e_68ad3dde69d4832ab056e862989afb9a