### PR TITLE
feat: 조직 이관 스텝을 배치 시작으로 설정

### DIFF
--- a/src/main/resources/egovframework/batch/job/insa/insaStgToLocalJob.xml
+++ b/src/main/resources/egovframework/batch/job/insa/insaStgToLocalJob.xml
@@ -8,37 +8,35 @@
 
     <!-- commit-interval 값은 일반적으로 500~1000으로 설정함 -->
     <job id="insaStgToLocalJob" parent="eGovBaseJob" incrementer="runIdIncrementer" xmlns="http://www.springframework.org/schema/batch">
-   	    <step id="stgToLocalStep" parent="eGovBaseStep">
-	        <tasklet>
-	            <chunk reader="insaStgToLocalJob.stgToLocalStep.mybatisItemReader"
-	                   processor="insaStgToLocalJob.stgToLocalStep.itemProcessor"
-	                   writer="insaStgToLocalJob.stgToLocalStep.mybatisItemWriter"
-	                   commit-interval="500" />
-	        </tasklet>
-	        <listeners>
-	            <listener ref="stepCountLogger" />
-	        </listeners>
-	    </step>
-    
-    
         <!-- 조직 정보를 먼저 복사한 후 사원 정보를 복사 -->
-	    <!-- <step id="stgToLocalOrgnztStep" parent="eGovBaseStep" next="stgEmplyrCountStep"> -->
-	    <step id="stgToLocalOrgnztStep" parent="eGovBaseStep" next="stgToLocalStep">
-	        <tasklet>
-	            <chunk reader="insaStgToLocalJob.stgToLocalOrgnztStep.mybatisItemReader"
-	                   writer="insaStgToLocalJob.stgToLocalOrgnztStep.mybatisItemWriter"
-	                   commit-interval="500" />
-	        </tasklet>
-	        <listeners>
-	            <listener ref="stepCountLogger" />
-	        </listeners>
-	    </step>
-	    <!-- <step id="stgEmplyrCountStep" parent="eGovTaskletStep" next="stgToLocalStep">
-	        완료된 후에도 재실행할 수 있도록 allow-start-if-complete을 true로 설정
-	        <tasklet ref="stgEmplyrCountTasklet" allow-start-if-complete="true" />
-	    </step> -->
-
-	</job>
+        <flow id="stgToLocalFlow">
+            <step id="stgToLocalOrgnztStep" parent="eGovBaseStep" next="stgToLocalStep">
+                <tasklet>
+                    <chunk reader="insaStgToLocalJob.stgToLocalOrgnztStep.mybatisItemReader"
+                           writer="insaStgToLocalJob.stgToLocalOrgnztStep.mybatisItemWriter"
+                           commit-interval="500" />
+                </tasklet>
+                <listeners>
+                    <listener ref="stepCountLogger" />
+                </listeners>
+            </step>
+            <step id="stgToLocalStep" parent="eGovBaseStep">
+                <tasklet>
+                    <chunk reader="insaStgToLocalJob.stgToLocalStep.mybatisItemReader"
+                           processor="insaStgToLocalJob.stgToLocalStep.itemProcessor"
+                           writer="insaStgToLocalJob.stgToLocalStep.mybatisItemWriter"
+                           commit-interval="500" />
+                </tasklet>
+                <listeners>
+                    <listener ref="stepCountLogger" />
+                </listeners>
+            </step>
+        </flow>
+        <!-- <step id="stgEmplyrCountStep" parent="eGovTaskletStep" next="stgToLocalStep">
+            완료된 후에도 재실행할 수 있도록 allow-start-if-complete을 true로 설정
+            <tasklet ref="stgEmplyrCountTasklet" allow-start-if-complete="true" />
+        </step> -->
+    </job>
 
     <bean id="insaStgToLocalJob.stgToLocalOrgnztStep.mybatisItemReader" class="org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader" scope="step">
         <!-- 스테이징 DB에서 조직 정보 목록을 조회 -->


### PR DESCRIPTION
## Summary
- 배치 Job에서 시작 스텝을 `stgToLocalOrgnztStep`으로 변경
- flow를 사용하여 `stgToLocalOrgnztStep` 실행 후 `stgToLocalStep`으로 이동하도록 수정

## Testing
- `mvn -q test` *(실패: org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 를 받을 수 없음)*
- `mvn -q spring-boot:run -Dspring.batch.job.names=insaStgToLocalJob` *(실패: org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 를 받을 수 없음)*

------
https://chatgpt.com/codex/tasks/task_e_68ada4a329b4832aac5d2fbcd33d0457