### PR TITLE
Quartz 잡 지속성 설정 추가

### DIFF
--- a/src/main/resources/egovframework/batch/context-scheduler-job.xml
+++ b/src/main/resources/egovframework/batch/context-scheduler-job.xml
@@ -68,6 +68,7 @@
     <bean id="erpStgToLocalJobDetail" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
         <property name="jobClass" value="egovframework.bat.scheduler.EgovQuartzJobLauncher" />
         <property name="group" value="quartz-batch" />
+        <property name="durability" value="true" />
         <property name="jobDataAsMap">
             <map>
                 <!-- STG에 있는 ERP 고객 정보를 로컬 DB로 이관하는 잡 -->


### PR DESCRIPTION
## 요약
- Quartz 잡 `erpStgToLocalJobDetail`에 지속성 속성 추가로 재시작 시 잡 정보 유지

## 테스트
- `mvn -q -e -DskipTests=false package` (네트워크 문제로 의존성 다운로드 실패)


------
https://chatgpt.com/codex/tasks/task_e_68ada8aaf550832abee8458a0ca7099b