### PR TITLE
환경별 ERP API URL 설정 및 설정 경로 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+  config:
+    # application/env 경로의 설정 파일을 추가로 읽도록 설정
+    additional-location: classpath:/application/env/

--- a/src/main/resources/application/env/dev/application.yml
+++ b/src/main/resources/application/env/dev/application.yml
@@ -41,7 +41,7 @@ logging:
 
 erp:
   # ERP 시스템 API URL
-  api-url: http://localhost:8080/api/erp
+  api-url: http://127.0.0.1:8080/api/v1/vehicles
 
 # 기본 데이터소스 설정
 app:

--- a/src/main/resources/application/env/prod/application.yml
+++ b/src/main/resources/application/env/prod/application.yml
@@ -41,7 +41,7 @@ logging:
 
 erp:
   # ERP 시스템 API URL
-  api-url: http://localhost:8080/api/erp
+  api-url: http://127.0.0.1:8080/api/v1/vehicles
 
 # 기본 데이터소스 설정
 app:


### PR DESCRIPTION
## 요약
- 개발/운영 환경의 ERP API URL을 로컬 테스트용 URL로 통일
- 환경별 설정 파일을 읽기 위해 `spring.config.additional-location` 지정

## 테스트
- `mvn -q test` (실패: 프로젝트 의존성을 내려받을 수 없음)


------
https://chatgpt.com/codex/tasks/task_e_68afc028f8f0832a9caacc3b2a8b5d35