### PR TITLE
fix: eGovBase import 정리

### DIFF
--- a/src/main/resources/egovframework/batch/context-scheduler-job.xml
+++ b/src/main/resources/egovframework/batch/context-scheduler-job.xml
@@ -2,6 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
     <!-- 각 배치 잡 XML을 임포트한다 -->
+    <import resource="classpath:/egovframework/batch/job/abstract/eGovBase.xml" />
     <import resource="classpath:/egovframework/batch/job/insa/insaRemote1ToStgJob.xml" />
     <import resource="classpath:/egovframework/batch/job/insa/insaStgToLocalJob.xml" />
     <import resource="classpath:/egovframework/batch/job/erp/erpRestToStgJob.xml" />

--- a/src/main/resources/egovframework/batch/job/erp/erpRestToStgJob.xml
+++ b/src/main/resources/egovframework/batch/job/erp/erpRestToStgJob.xml
@@ -3,8 +3,6 @@
     xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
         http://www.springframework.org/schema/batch D:\\DEV\\xsd\\spring-batch-3.0.xsd">
 
-    <import resource="../abstract/eGovBase.xml" />
-
     <!-- ERP REST API에서 데이터를 조회하여 STG 테이블에 적재하는 잡 -->
     <job id="erpRestToStgJob" parent="eGovBaseJob" xmlns="http://www.springframework.org/schema/batch">
         <step id="fetchErpDataStep" parent="eGovTaskletStep">

--- a/src/main/resources/egovframework/batch/job/erp/erpStgToLocalJob.xml
+++ b/src/main/resources/egovframework/batch/job/erp/erpStgToLocalJob.xml
@@ -3,8 +3,6 @@
     xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
         http://www.springframework.org/schema/batch D:\\DEV\\xsd\\spring-batch-3.0.xsd">
 
-    <import resource="../abstract/eGovBase.xml" />
-
     <!-- STG에 적재된 ERP 차량 정보를 로컬 DB로 이관하는 잡 -->
     <job id="erpStgToLocalJob" parent="eGovBaseJob" xmlns="http://www.springframework.org/schema/batch">
         <step id="erpStgToLocalVehicleStep" parent="eGovBaseStep">

--- a/src/main/resources/egovframework/batch/job/example/mybatisToMybatisSampleJob.xml
+++ b/src/main/resources/egovframework/batch/job/example/mybatisToMybatisSampleJob.xml
@@ -4,8 +4,6 @@
 		http://www.springframework.org/schema/batch D:\DEV\xsd\spring-batch-3.0.xsd">
 		<!-- http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-3.0.xsd"> -->
 
-	<import resource="../abstract/eGovBase.xml" />
-
 	<!-- commit-interval 값은 일반적으로 500~1000으로 설정함 -->
         <!-- 중복 등록을 피하기 위해 잡 이름을 변경하였다 -->
         <job id="mybatisToMybatisSampleJob" parent="eGovBaseJob" xmlns="http://www.springframework.org/schema/batch">

--- a/src/main/resources/egovframework/batch/job/insa/insaRemote1ToStgJob.xml
+++ b/src/main/resources/egovframework/batch/job/insa/insaRemote1ToStgJob.xml
@@ -4,8 +4,6 @@
         http://www.springframework.org/schema/batch D:\DEV\xsd\spring-batch-3.0.xsd">
         <!-- http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-3.0.xsd"> -->
 
-    <import resource="../abstract/eGovBase.xml" />
-
     <!-- commit-interval 값은 일반적으로 500~1000으로 설정함 -->
     <job id="insaRemote1ToStgJob" parent="eGovBaseJob" xmlns="http://www.springframework.org/schema/batch">
         <!-- STG 테이블 초기화 후 조직 정보, 사원 정보 순으로 이관 -->

--- a/src/main/resources/egovframework/batch/job/insa/insaStgToLocalJob.xml
+++ b/src/main/resources/egovframework/batch/job/insa/insaStgToLocalJob.xml
@@ -4,8 +4,6 @@
         http://www.springframework.org/schema/batch D:\DEV\xsd\spring-batch-3.0.xsd">
         <!-- http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-3.0.xsd -->
 
-    <import resource="../abstract/eGovBase.xml" />
-
     <!-- commit-interval 값은 일반적으로 500~1000으로 설정함 -->
     <job id="insaStgToLocalJob" parent="eGovBaseJob" incrementer="runIdIncrementer" xmlns="http://www.springframework.org/schema/batch">
         <!-- 조직 정보를 먼저 복사한 후 사원 정보를 복사 -->    


### PR DESCRIPTION
## 요약
- scheduler context에 eGovBase 공통 import 추가
- 각 배치 잡 XML에서 중복된 eGovBase import 제거

## 테스트
- `mvn -q -e -DskipTests package` (네트워크 오류로 실패)
- `mvn -q -o -DskipTests package` (오프라인 모드, 부모 POM 부재로 실패)

------
https://chatgpt.com/codex/tasks/task_e_68afd248da3c832aa3ac12e33806932f