### PR TITLE
빈 정의 덮어쓰기 허용 설정 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  main:
+    # 동일한 빈 정의가 있을 경우 덮어쓰기를 허용
+    allow-bean-definition-overriding: true
   config:
     # application/env 경로의 설정 파일을 추가로 읽도록 설정
     additional-location: classpath:/application/env/


### PR DESCRIPTION
## Summary
- `application.yml`에 `spring.main.allow-bean-definition-overriding` 설정 추가

## Testing
- `mvn -q test` (네트워크 문제로 의존성을 받아오지 못해 실패)


------
https://chatgpt.com/codex/tasks/task_e_68afd3dd1ad8832a9b79cc3025d1e68d