### PR TITLE
환경별 application.yml 복사 구조 정리

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,0 @@
-spring:
-  main:
-    # 동일한 빈 정의가 있을 경우 덮어쓰기를 허용
-    allow-bean-definition-overriding: true
-  config:
-    # application/env 경로의 설정 파일을 추가로 읽도록 설정
-    additional-location: classpath:/application/env/


### PR DESCRIPTION
## 요약
- 루트 `application.yml` 제거로 환경별 설정만 사용
- Maven 리소스 설정에서 env별 `application.yml` 복사 확인
- `spring.config.additional-location` 미사용 확인

## 테스트
- `mvn -P dev package` (네트워크 문제로 parent POM 다운로드 실패)


------
https://chatgpt.com/codex/tasks/task_e_68afd87c9988832aa49c8a115ce84cc7