### PR TITLE
Replace PropertyPlaceholderConfigurer with context property placeholder and verify YAML injection

### DIFF
--- a/src/main/resources/egovframework/batch/context-batch-datasource.xml
+++ b/src/main/resources/egovframework/batch/context-batch-datasource.xml
@@ -11,13 +11,9 @@
     <bean id="yamlProperties" class="org.springframework.beans.factory.config.YamlPropertiesFactoryBean">
         <property name="resources" value="classpath:application.yml" />
     </bean>
-   	<bean id="egov.propertyConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
-        <property name="locations">
-            <list>
-                <value>classpath:/egovframework/batch/properties/globals.properties</value>
-            </list>
-        </property>
-    </bean>
+    <context:property-placeholder
+            location="classpath:/egovframework/batch/properties/globals.properties"
+            properties-ref="yamlProperties"/>
 
  	
 	<!-- 운영 MySQL용 데이타소스 -->

--- a/src/test/java/egovframework/bat/erp/tasklet/FetchErpDataTaskletPropertyInjectionTest.java
+++ b/src/test/java/egovframework/bat/erp/tasklet/FetchErpDataTaskletPropertyInjectionTest.java
@@ -3,7 +3,8 @@ package egovframework.bat.erp.tasklet;
 import egovframework.bat.notification.NotificationSender;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.io.ClassPathResource;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -20,7 +21,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import reactor.core.publisher.Mono;
 
 /**
- * Globals.Erp.ApiUrl 프로퍼티가 주입되는지 검증하는 테스트.
+ * erp.api-url 프로퍼티가 주입되는지 검증하는 테스트.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = FetchErpDataTaskletPropertyInjectionTest.TestConfig.class)
@@ -30,13 +31,13 @@ public class FetchErpDataTaskletPropertyInjectionTest {
     @ComponentScan(basePackageClasses = FetchErpDataTasklet.class)
     static class TestConfig {
 
-        // 테스트용 프로퍼티 설정
+        // application.yml을 로딩하여 프로퍼티를 주입
         @Bean
         public static PropertySourcesPlaceholderConfigurer properties() {
-            Properties props = new Properties();
-            props.setProperty("Globals.Erp.ApiUrl", "http://127.0.0.1:8080/api/v1/vehicles");
+            YamlPropertiesFactoryBean yaml = new YamlPropertiesFactoryBean();
+            yaml.setResources(new ClassPathResource("application/env/local/application.yml"));
             PropertySourcesPlaceholderConfigurer config = new PropertySourcesPlaceholderConfigurer();
-            config.setProperties(props);
+            config.setProperties(yaml.getObject());
             return config;
         }
 


### PR DESCRIPTION
## Summary
- Use `<context:property-placeholder>` with `yamlProperties` to load both `globals.properties` and `application.yml`
- Update ERP tasklet test to load `application.yml` and verify `erp.api-url` injection

## Testing
- ⚠️ `mvn -q test` *(네트워크 오류로 의존성 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68afd881f5a8832a95ca12eaf3c1dfe6