### PR TITLE
yamlProperties 빈 제거 및 데이터소스 설정 정리

### DIFF
--- a/src/main/resources/egovframework/batch/context-batch-datasource.xml
+++ b/src/main/resources/egovframework/batch/context-batch-datasource.xml
@@ -1,17 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-			http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.0.xsd
-			http://www.springframework.org/schema/jdbc  http://www.springframework.org/schema/jdbc/spring-jdbc-4.0.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
 
-
-    <!-- globals.properties와 application.yml을 함께 로딩 -->
-    <bean id="yamlProperties" class="org.springframework.beans.factory.config.YamlPropertiesFactoryBean">
-        <property name="resources" value="classpath:application.yml" />
-    </bean>
-   	<bean id="egov.propertyConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+    <bean id="egov.propertyConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="locations">
             <list>
                 <value>classpath:/egovframework/batch/properties/globals.properties</value>
@@ -19,8 +11,7 @@
         </property>
     </bean>
 
- 	
-	<!-- 운영 MySQL용 데이타소스 -->
+    <!-- 운영 MySQL용 데이타소스 -->
     <bean id="dataSource-local" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
         <property name="driverClassName" value="${Globals.Local.DriverClassName}"/>
         <property name="url" value="${Globals.Local.Url}" />
@@ -43,16 +34,6 @@
         <property name="username" value="${Globals.Remote1.UserName}"/>
         <property name="password" value="${Globals.Remote1.Password}"/>
     </bean>
-    
-    <!-- Remote2 CUBRID 데이타소스 -->
-    <!-- 
-    <bean id="dataSource-remote2" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
-        <property name="driverClassName" value="${Globals.Remote2.DriverClassName}"/>
-        <property name="url" value="${Globals.Remote2.Url}" />
-        <property name="username" value="${Globals.Remote2.UserName}"/>
-        <property name="password" value="${Globals.Remote2.Password}"/>
-    </bean>
-    -->
 
     <!-- 운영 MySQL용 데이타소스를 사용하는 JdbcTemplate -->
     <bean id="jdbcTemplateLocal" class="org.springframework.jdbc.core.JdbcTemplate">
@@ -63,8 +44,8 @@
     <bean id="jdbcTemplateStg" class="org.springframework.jdbc.core.JdbcTemplate">
         <property name="dataSource" ref="dataSource-stg" />
     </bean>
-    
-    <!-- Remote1 CUBRID 데이타소스를 사용하는 JdbcTemplate -->
+
+    <!-- Remote1 MySQL 데이타소스를 사용하는 JdbcTemplate -->
     <bean id="jdbcTemplateRemote1" class="org.springframework.jdbc.core.JdbcTemplate">
         <property name="dataSource" ref="dataSource-remote1" />
     </bean>
@@ -75,14 +56,14 @@
         <property name="dataSource" ref="dataSource" />
     </bean>
 
-	<bean id="lobHandler" class="org.springframework.jdbc.support.lob.DefaultLobHandler" />
+    <bean id="lobHandler" class="org.springframework.jdbc.support.lob.DefaultLobHandler" />
 
-	<bean id="customEditorConfigurer" class="org.springframework.beans.factory.config.CustomEditorConfigurer">
-		<property name="customEditors">
-			<map>
-				<entry key="int[]" value="org.springframework.batch.support.IntArrayPropertyEditor" />
-			</map>
-		</property>
-	</bean>
+    <bean id="customEditorConfigurer" class="org.springframework.beans.factory.config.CustomEditorConfigurer">
+        <property name="customEditors">
+            <map>
+                <entry key="int[]" value="org.springframework.batch.support.IntArrayPropertyEditor" />
+            </map>
+        </property>
+    </bean>
 
 </beans>


### PR DESCRIPTION
## Summary
- application.yml을 로딩하던 yamlProperties 빈 제거
- 불필요한 네임스페이스와 주석 정리
- Remote1 관련 주석 수정 및 사용하지 않는 설정 제거

## Testing
- `mvn -q test` *(실패: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afd87dd638832a93576f6b129e1d1e