### PR TITLE
ERP 차량 STG 초기화 Tasklet 추가

### DIFF
--- a/src/main/java/egovframework/bat/erp/tasklet/TruncateErpVehicleTasklet.java
+++ b/src/main/java/egovframework/bat/erp/tasklet/TruncateErpVehicleTasklet.java
@@ -1,0 +1,35 @@
+package egovframework.bat.erp.tasklet;
+
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+
+/**
+ * STG 차량 테이블을 비우는 Tasklet.
+ */
+public class TruncateErpVehicleTasklet implements Tasklet {
+
+    /** MyBatis SqlSessionFactory */
+    private SqlSessionFactory sqlSessionFactory;
+
+    /**
+     * SqlSessionFactory 주입.
+     * @param sqlSessionFactory STG용 SqlSessionFactory
+     */
+    public void setSqlSessionFactory(SqlSessionFactory sqlSessionFactory) {
+        this.sqlSessionFactory = sqlSessionFactory;
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        try (SqlSession session = sqlSessionFactory.openSession()) {
+            // STG 차량 테이블 비우기
+            session.update("Vehicle.truncateErpStg");
+            session.commit();
+        }
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/resources/egovframework/batch/job/erp/erpRestToStgJob.xml
+++ b/src/main/resources/egovframework/batch/job/erp/erpRestToStgJob.xml
@@ -5,9 +5,18 @@
 
     <!-- ERP REST API에서 데이터를 조회하여 STG 테이블에 적재하는 잡 -->
     <job id="erpRestToStgJob" parent="eGovBaseJob" xmlns="http://www.springframework.org/schema/batch">
+        <!-- STG 테이블을 먼저 초기화 -->
+        <step id="truncateErpVehicleStep" parent="eGovTaskletStep" next="fetchErpDataStep">
+            <tasklet ref="truncateErpVehicleTasklet" />
+        </step>
         <step id="fetchErpDataStep" parent="eGovTaskletStep">
             <tasklet ref="fetchErpDataTasklet" />
         </step>
     </job>
+
+    <!-- STG 차량 테이블 초기화용 Tasklet 빈 정의 -->
+    <bean id="truncateErpVehicleTasklet" class="egovframework.bat.erp.tasklet.TruncateErpVehicleTasklet">
+        <property name="sqlSessionFactory" ref="sqlSessionFactory-stg" />
+    </bean>
 
 </beans>


### PR DESCRIPTION
## Summary
- STG 차량 테이블을 비우는 `TruncateErpVehicleTasklet` 추가
- `erpRestToStgJob`에 초기화 단계와 Tasklet 빈 정의를 반영
- 기존 매퍼의 `truncateErpStg` SQL을 검토하여 사용

## Testing
- `mvn -q test` *(실패: 원격 저장소 접속 불가로 의존성 해석 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68afe3e135b0832abbfa6ce9f144172b