### PR TITLE
docs: 배치 컨텍스트 파일 관계 설명 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ migstg 데이터베이스 초기화 시 `src/script/mysql/test/2.stg_ddl-mysql.s
 
 > ⚠️ 운영 데이터베이스에서 실행하기 전에 반드시 전체 백업을 완료하세요.
 
+## 배치 컨텍스트 파일 관계
+
+작성 순서: `context-batch-datasource.xml → context-batch-job-launcher.xml → context-scheduler-job.xml → context-batch-scheduler.xml`
+
+- `context-batch-datasource.xml`: 공통 데이터소스와 트랜잭션 매니저 등을 정의한다.
+- `context-batch-job-launcher.xml`: 데이터소스 설정을 import하여 `JobLauncher`, `JobRepository` 등을 구성한다.
+- `context-scheduler-job.xml`: 각 배치 잡 XML을 import하고 Quartz `JobDetail`을 정의하며, 상위에서 제공하는 `jobLauncher`와 `jobRegistry`를 참조한다.
+- `context-batch-scheduler.xml`: 앞선 두 설정을 import하여 크론 트리거와 `SchedulerFactoryBean`을 설정하고 잡 실행 순서를 제어한다.
+
+상위→하위 참조 구조: `context-batch-scheduler.xml` → `context-scheduler-job.xml` → `context-batch-job-launcher.xml` → `context-batch-datasource.xml`.
+
 ## Spring Batch 처리 방식: Chunk와 Tasklet
 
 Spring Batch는 두 가지 대표적인 Step 구현 방식을 제공합니다.


### PR DESCRIPTION
## Summary
- README에 배치 컨텍스트 파일 간 작성 순서와 참조 구조를 추가하여 구성 흐름을 명확히 설명합니다.

## Testing
- `mvn -q test` *(실패: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68afebb896dc832abdafddd86d9d3973