### PR TITLE
Hibernate Validator 의존성 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,43 +79,48 @@
             <artifactId>spring-boot-starter-log4j2</artifactId>
         </dependency>
         <!-- spring boot dependency end -->
-		<dependency>
-			<groupId>org.egovframe.rte</groupId>
-			<artifactId>org.egovframe.rte.bat.core</artifactId>
-			<version>${org.egovframe.rte.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.egovframe.rte</groupId>
-			<artifactId>org.egovframe.rte.ptl.mvc</artifactId>
-			<version>${org.egovframe.rte.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>quartz</groupId>
-					<artifactId>quartz</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.egovframe.rte</groupId>
-			<artifactId>org.egovframe.rte.psl.dataaccess</artifactId>
-			<version>${org.egovframe.rte.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.egovframe.rte</groupId>
-			<artifactId>org.egovframe.rte.fdl.idgnr</artifactId>
-			<version>${org.egovframe.rte.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.egovframe.rte</groupId>
-			<artifactId>org.egovframe.rte.fdl.property</artifactId>
-			<version>${org.egovframe.rte.version}</version>
-		</dependency>
-		<!-- For Testing -->
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.egovframe.rte</groupId>
+                        <artifactId>org.egovframe.rte.bat.core</artifactId>
+                        <version>${org.egovframe.rte.version}</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.egovframe.rte</groupId>
+                        <artifactId>org.egovframe.rte.ptl.mvc</artifactId>
+                        <version>${org.egovframe.rte.version}</version>
+                        <exclusions>
+                                <exclusion>
+                                        <groupId>quartz</groupId>
+                                        <artifactId>quartz</artifactId>
+                                </exclusion>
+                        </exclusions>
+                </dependency>
+                <dependency>
+                        <groupId>org.egovframe.rte</groupId>
+                        <artifactId>org.egovframe.rte.psl.dataaccess</artifactId>
+                        <version>${org.egovframe.rte.version}</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.egovframe.rte</groupId>
+                        <artifactId>org.egovframe.rte.fdl.idgnr</artifactId>
+                        <version>${org.egovframe.rte.version}</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.egovframe.rte</groupId>
+                        <artifactId>org.egovframe.rte.fdl.property</artifactId>
+                        <version>${org.egovframe.rte.version}</version>
+                </dependency>
+                <!-- Bean Validation을 위한 Hibernate Validator 의존성 추가 -->
+                <dependency>
+                        <groupId>org.hibernate.validator</groupId>
+                        <artifactId>hibernate-validator</artifactId>
+                </dependency>
+                <!-- For Testing -->
+                <dependency>
+                        <groupId>org.springframework</groupId>
+                        <artifactId>spring-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
                 <dependency>
                         <groupId>junit</groupId>
                         <artifactId>junit</artifactId>


### PR DESCRIPTION
## Summary
- pom.xml에 Hibernate Validator 의존성 추가

## Testing
- `mvn -q test` *(네트워크 문제로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68b005ef1a38832a80499c734a8f64d3