### PR TITLE
customEditorConfigurer 키 타입 명시

### DIFF
--- a/src/main/resources/egovframework/batch/context-batch-datasource.xml
+++ b/src/main/resources/egovframework/batch/context-batch-datasource.xml
@@ -80,12 +80,13 @@
 
 	<bean id="lobHandler" class="org.springframework.jdbc.support.lob.DefaultLobHandler" />
 
-	<bean id="customEditorConfigurer" class="org.springframework.beans.factory.config.CustomEditorConfigurer">
-		<property name="customEditors">
-			<map>
-				<entry key="int[]" value="org.springframework.batch.support.IntArrayPropertyEditor" />
-			</map>
-		</property>
-	</bean>
+        <bean id="customEditorConfigurer" class="org.springframework.beans.factory.config.CustomEditorConfigurer">
+                <property name="customEditors">
+                        <!-- 키와 값이 Class 타입으로 변환되도록 명시 -->
+                        <map key-type="java.lang.Class" value-type="java.lang.Class">
+                                <entry key="int[]" value="org.springframework.batch.support.IntArrayPropertyEditor" />
+                        </map>
+                </property>
+        </bean>
 
 </beans>


### PR DESCRIPTION
## Summary
- customEditorConfigurer의 customEditors 맵에 key-type과 value-type을 명시하여 Class 변환 문제 해결

## Testing
- `mvn -q test` *(네트워크 문제로 부모 POM을 내려받지 못하여 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68b008d6e888832a9f9b5768e5e62b0b