### PR TITLE
SpEL을 이용하여 CustomEditorConfigurer 수정

### DIFF
--- a/src/main/resources/egovframework/batch/context-batch-datasource.xml
+++ b/src/main/resources/egovframework/batch/context-batch-datasource.xml
@@ -80,13 +80,14 @@
 
 	<bean id="lobHandler" class="org.springframework.jdbc.support.lob.DefaultLobHandler" />
 
-        <bean id="customEditorConfigurer" class="org.springframework.beans.factory.config.CustomEditorConfigurer">
-                <property name="customEditors">
-                        <!-- 키와 값이 Class 타입으로 변환되도록 명시 -->
-                        <map key-type="java.lang.Class" value-type="java.lang.Class">
-                                <entry key="int[]" value="org.springframework.batch.support.IntArrayPropertyEditor" />
-                        </map>
-                </property>
-        </bean>
+    <bean id="customEditorConfigurer" class="org.springframework.beans.factory.config.CustomEditorConfigurer">
+        <property name="customEditors">
+            <!-- SpEL을 사용하여 문자열 변환 없이 클래스 지정 -->
+            <map>
+                <entry key="#{T(int[])}"
+                       value="#{T(org.springframework.batch.support.IntArrayPropertyEditor)}"/>
+            </map>
+        </property>
+    </bean>
 
 </beans>


### PR DESCRIPTION
## Summary
- CustomEditorConfigurer에서 SpEL 사용으로 문자열 기반 클래스 변환 제거

## Testing
- `mvn -q test` *(실패: Maven 부모 POM을 가져오지 못함 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b00b9188a0832a968449583c2e361c