### PR TITLE
feat: add batch management service

### DIFF
--- a/src/main/java/egovframework/bat/service/BatchManagementMapper.java
+++ b/src/main/java/egovframework/bat/service/BatchManagementMapper.java
@@ -1,0 +1,37 @@
+package egovframework.bat.service;
+
+import java.util.List;
+
+import org.springframework.batch.core.JobExecution;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 배치 메타데이터 조회를 위한 매퍼 인터페이스.
+ */
+@Repository
+public interface BatchManagementMapper {
+
+    /**
+     * 등록된 배치 잡 이름 목록을 조회한다.
+     *
+     * @return 잡 이름 목록
+     */
+    List<String> selectJobNames();
+
+    /**
+     * 특정 잡의 실행 이력을 조회한다.
+     *
+     * @param jobName 잡 이름
+     * @return 실행 이력 목록
+     */
+    List<JobExecution> selectJobExecutions(String jobName);
+
+    /**
+     * 특정 잡 실행의 에러 로그를 조회한다.
+     *
+     * @param jobExecutionId 잡 실행 ID
+     * @return 에러 로그 목록
+     */
+    List<String> selectErrorLogs(Long jobExecutionId);
+}
+

--- a/src/main/java/egovframework/bat/service/BatchManagementService.java
+++ b/src/main/java/egovframework/bat/service/BatchManagementService.java
@@ -1,0 +1,72 @@
+package egovframework.bat.service;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.stereotype.Service;
+
+/**
+ * 배치 잡 관리 기능을 제공하는 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class BatchManagementService {
+
+    /** 배치 메타데이터 조회를 위한 매퍼 */
+    private final BatchManagementMapper batchManagementMapper;
+
+    /** 잡 재실행 및 중지를 위한 JobOperator */
+    private final JobOperator jobOperator;
+
+    /**
+     * 등록된 배치 잡 이름 목록을 반환한다.
+     *
+     * @return 잡 이름 목록
+     */
+    public List<String> getJobNames() {
+        return batchManagementMapper.selectJobNames();
+    }
+
+    /**
+     * 특정 잡의 실행 이력을 조회한다.
+     *
+     * @param jobName 잡 이름
+     * @return 실행 이력 목록
+     */
+    public List<JobExecution> getJobExecutions(String jobName) {
+        return batchManagementMapper.selectJobExecutions(jobName);
+    }
+
+    /**
+     * 특정 잡 실행에 대한 에러 로그를 조회한다.
+     *
+     * @param jobExecutionId 잡 실행 ID
+     * @return 에러 로그 목록
+     */
+    public List<String> getErrorLogs(Long jobExecutionId) {
+        return batchManagementMapper.selectErrorLogs(jobExecutionId);
+    }
+
+    /**
+     * 실패한 잡 실행을 재시도한다.
+     *
+     * @param jobExecutionId 재실행할 잡 실행 ID
+     * @throws Exception JobOperator에서 발생한 예외
+     */
+    public void restart(Long jobExecutionId) throws Exception {
+        jobOperator.restart(jobExecutionId);
+    }
+
+    /**
+     * 실행 중인 잡을 중지한다.
+     *
+     * @param jobExecutionId 중지할 잡 실행 ID
+     * @throws Exception JobOperator에서 발생한 예외
+     */
+    public void stop(Long jobExecutionId) throws Exception {
+        jobOperator.stop(jobExecutionId);
+    }
+}
+

--- a/src/test/java/egovframework/bat/service/BatchManagementServiceTest.java
+++ b/src/test/java/egovframework/bat/service/BatchManagementServiceTest.java
@@ -1,0 +1,80 @@
+package egovframework.bat.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.launch.JobOperator;
+
+/**
+ * BatchManagementService의 기능을 검증하는 단위 테스트.
+ */
+public class BatchManagementServiceTest {
+
+    private BatchManagementService batchManagementService;
+
+    @Mock
+    private BatchManagementMapper batchManagementMapper;
+
+    @Mock
+    private JobOperator jobOperator;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        batchManagementService = new BatchManagementService(batchManagementMapper, jobOperator);
+    }
+
+    @Test
+    public void getJobNamesReturnsMapperResult() {
+        List<String> expected = Arrays.asList("job1", "job2");
+        when(batchManagementMapper.selectJobNames()).thenReturn(expected);
+
+        List<String> result = batchManagementService.getJobNames();
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void getJobExecutionsReturnsMapperResult() {
+        List<JobExecution> executions = Arrays.asList(new JobExecution(1L), new JobExecution(2L));
+        when(batchManagementMapper.selectJobExecutions("job")).thenReturn(executions);
+
+        List<JobExecution> result = batchManagementService.getJobExecutions("job");
+
+        assertEquals(executions, result);
+    }
+
+    @Test
+    public void getErrorLogsReturnsMapperResult() {
+        List<String> logs = Arrays.asList("error1", "error2");
+        when(batchManagementMapper.selectErrorLogs(1L)).thenReturn(logs);
+
+        List<String> result = batchManagementService.getErrorLogs(1L);
+
+        assertEquals(logs, result);
+    }
+
+    @Test
+    public void restartDelegatesToJobOperator() throws Exception {
+        batchManagementService.restart(1L);
+
+        verify(jobOperator).restart(1L);
+    }
+
+    @Test
+    public void stopDelegatesToJobOperator() throws Exception {
+        batchManagementService.stop(1L);
+
+        verify(jobOperator).stop(1L);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add service for batch job management and repository interface
- support job restart/stop with JobOperator
- cover service logic with unit tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b45b5563e0832a9335d6c2528993a2