### PR TITLE
배치 관리 화면과 REST API 추가

### DIFF
--- a/src/main/java/egovframework/bat/management/api/BatchManagementController.java
+++ b/src/main/java/egovframework/bat/management/api/BatchManagementController.java
@@ -1,0 +1,108 @@
+package egovframework.bat.management.api;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import egovframework.bat.repository.dto.BatchJobExecutionDto;
+import egovframework.bat.service.BatchManagementService;
+
+/**
+ * 배치 잡 조회와 제어를 위한 REST 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api/batch/management")
+@RequiredArgsConstructor
+public class BatchManagementController {
+
+    /** 배치 관리 서비스를 주입 */
+    private final BatchManagementService batchManagementService;
+
+    /**
+     * 등록된 배치 잡 이름 목록을 반환한다.
+     *
+     * @return 잡 이름 목록
+     */
+    @GetMapping("/jobs")
+    public ResponseEntity<List<String>> getJobNames() {
+        return ResponseEntity.ok(batchManagementService.getJobNames());
+    }
+
+    /**
+     * 특정 잡의 실행 이력을 반환한다.
+     *
+     * @param jobName 잡 이름
+     * @return 실행 이력 목록
+     */
+    @GetMapping("/jobs/{jobName}/executions")
+    public ResponseEntity<List<BatchJobExecutionDto>> getExecutions(@PathVariable String jobName) {
+        List<JobExecution> executions = batchManagementService.getJobExecutions(jobName);
+        List<BatchJobExecutionDto> dtos = executions.stream().map(je -> {
+            BatchJobExecutionDto dto = new BatchJobExecutionDto();
+            dto.setJobExecutionId(je.getId());
+            if (je.getJobInstance() != null) {
+                dto.setJobInstanceId(je.getJobInstance().getInstanceId());
+            }
+            if (je.getStartTime() != null) {
+                dto.setStartTime(LocalDateTime.ofInstant(je.getStartTime().toInstant(), ZoneId.systemDefault()));
+            }
+            if (je.getEndTime() != null) {
+                dto.setEndTime(LocalDateTime.ofInstant(je.getEndTime().toInstant(), ZoneId.systemDefault()));
+            }
+            if (je.getStatus() != null) {
+                dto.setStatus(je.getStatus().toString());
+            }
+            dto.setJobName(jobName);
+            return dto;
+        }).collect(Collectors.toList());
+        return ResponseEntity.ok(dtos);
+    }
+
+    /**
+     * 특정 잡 실행의 에러 로그를 반환한다.
+     *
+     * @param jobExecutionId 잡 실행 ID
+     * @return 에러 로그 목록
+     */
+    @GetMapping("/executions/{jobExecutionId}/errors")
+    public ResponseEntity<List<String>> getErrorLogs(@PathVariable Long jobExecutionId) {
+        return ResponseEntity.ok(batchManagementService.getErrorLogs(jobExecutionId));
+    }
+
+    /**
+     * 실패한 잡 실행을 재실행한다.
+     *
+     * @param jobExecutionId 잡 실행 ID
+     * @return 처리 결과
+     * @throws Exception 재실행 중 예외 발생 시
+     */
+    @PostMapping("/executions/{jobExecutionId}/restart")
+    public ResponseEntity<Void> restart(@PathVariable Long jobExecutionId) throws Exception {
+        batchManagementService.restart(jobExecutionId);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 실행 중인 잡을 중지한다.
+     *
+     * @param jobExecutionId 잡 실행 ID
+     * @return 처리 결과
+     * @throws Exception 중지 중 예외 발생 시
+     */
+    @PostMapping("/executions/{jobExecutionId}/stop")
+    public ResponseEntity<Void> stop(@PathVariable Long jobExecutionId) throws Exception {
+        batchManagementService.stop(jobExecutionId);
+        return ResponseEntity.ok().build();
+    }
+}
+

--- a/src/main/resources/egovframework/message/message-common.properties
+++ b/src/main/resources/egovframework/message/message-common.properties
@@ -39,3 +39,15 @@ errors.korean={0}\uc740 \ud55c\uae00\uc744 \uc785\ub825\ud558\uc154\uc57c \ud569
 title.sample.name=\uce74\ud14c\uace0\ub9ac\uba85
 title.sample.description=Description
 title.sample.regUser=\ub4f1\ub85d\uc790
+# Batch management messages
+batch.title.list=\ubc30\uce58 \ubaa9\ub85d
+batch.title.detail=\uc7a5\uc138 \uc0c1\uc138
+batch.title.log=\uc5d0\ub7ec \ub85c\uadf8
+batch.label.jobName=\uc7a5 \uc774\ub984
+batch.label.status=\uc0c1\ud0dc
+batch.label.actions=\uc561\uc158
+batch.button.detail=\uc0c1\uc138
+batch.button.restart=\uc7ac\uc2dc\uc791
+batch.button.stop=\uc911\uc9c0
+batch.button.log=\ub85c\uadf8
+batch.search.placeholder=\uc7a5 \uc774\ub984 \uac80\uc0c9

--- a/src/main/resources/egovframework/message/message-common_en.properties
+++ b/src/main/resources/egovframework/message/message-common_en.properties
@@ -38,3 +38,15 @@ errors.korean={0} must be a Korean.
 title.sample.name=Category Name
 title.sample.description=Description
 title.sample.regUser=User Name
+# Batch management messages
+batch.title.list=Batch List
+batch.title.detail=Job Detail
+batch.title.log=Error Log
+batch.label.jobName=Job Name
+batch.label.status=Status
+batch.label.actions=Actions
+batch.button.detail=Detail
+batch.button.restart=Restart
+batch.button.stop=Stop
+batch.button.log=Log
+batch.search.placeholder=Search job name

--- a/src/main/resources/egovframework/message/message-common_ko.properties
+++ b/src/main/resources/egovframework/message/message-common_ko.properties
@@ -39,3 +39,15 @@ errors.korean={0}\uc740 \ud55c\uae00\uc744 \uc785\ub825\ud558\uc154\uc57c \ud569
 title.sample.name=\uce74\ud14c\uace0\ub9ac\uba85
 title.sample.description=Description
 title.sample.regUser=\ub4f1\ub85d\uc790
+# Batch management messages
+batch.title.list=\ubc30\uce58 \ubaa9\ub85d
+batch.title.detail=\uc7a5\uc138 \uc0c1\uc138
+batch.title.log=\uc5d0\ub7ec \ub85c\uadf8
+batch.label.jobName=\uc7a5 \uc774\ub984
+batch.label.status=\uc0c1\ud0dc
+batch.label.actions=\uc561\uc158
+batch.button.detail=\uc0c1\uc138
+batch.button.restart=\uc7ac\uc2dc\uc791
+batch.button.stop=\uc911\uc9c0
+batch.button.log=\ub85c\uadf8
+batch.search.placeholder=\uc7a5 \uc774\ub984 \uac80\uc0c9

--- a/src/main/resources/static/css/batch.css
+++ b/src/main/resources/static/css/batch.css
@@ -1,0 +1,17 @@
+/* 테이블 공통 스타일 */
+table {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+th, td {
+    border: 1px solid #ccc;
+    padding: 8px;
+    text-align: left;
+}
+
+/* 상태별 색상 */
+.status-completed { color: green; }
+.status-failed { color: red; }
+.status-started { color: blue; }
+.status-stopped { color: gray; }

--- a/src/main/resources/static/js/batch-common.js
+++ b/src/main/resources/static/js/batch-common.js
@@ -1,0 +1,49 @@
+/**
+ * 배치 상태에 따라 CSS 클래스를 반환한다.
+ * @param {string} status 배치 상태
+ * @returns {string} CSS 클래스 이름
+ */
+function statusClass(status) {
+    if (!status) return '';
+    return 'status-' + status.toLowerCase();
+}
+
+/**
+ * 간단한 페이지네이션을 렌더링한다.
+ * @param {HTMLElement} container 컨테이너 요소
+ * @param {number} total 전체 데이터 수
+ * @param {number} page 현재 페이지 (0부터 시작)
+ * @param {number} size 페이지당 항목 수
+ * @param {Function} onPage 페이지 변경 시 호출될 함수
+ */
+function renderPagination(container, total, page, size, onPage) {
+    container.innerHTML = '';
+    const pages = Math.ceil(total / size);
+    for (let i = 0; i < pages; i++) {
+        const btn = document.createElement('button');
+        btn.textContent = i + 1;
+        if (i === page) {
+            btn.disabled = true;
+        }
+        btn.addEventListener('click', () => onPage(i));
+        container.appendChild(btn);
+    }
+}
+
+/**
+ * 상태 텍스트에 아이콘을 추가하여 반환한다.
+ * @param {string} status 배치 상태
+ * @returns {HTMLElement} 상태 표시 요소
+ */
+function renderStatus(status) {
+    const span = document.createElement('span');
+    const icons = {
+        completed: '✔',
+        failed: '✖',
+        started: '▶',
+        stopped: '■'
+    };
+    span.className = statusClass(status);
+    span.textContent = (icons[status.toLowerCase()] || '?') + ' ' + status;
+    return span;
+}

--- a/src/main/resources/static/js/batch-detail.js
+++ b/src/main/resources/static/js/batch-detail.js
@@ -1,0 +1,61 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const params = new URLSearchParams(location.search);
+    const jobName = params.get('jobName');
+    const tableBody = document.querySelector('#executionTable tbody');
+    const pagination = document.getElementById('pagination');
+    const size = 5;
+    let executions = [];
+    let page = 0;
+
+    document.getElementById('pageTitle').textContent = `잡 상세 - ${jobName}`;
+
+    function load() {
+        fetch(`/api/batch/management/jobs/${jobName}/executions`)
+            .then(res => res.json())
+            .then(data => { executions = data; render(); });
+    }
+
+    function render() {
+        tableBody.innerHTML = '';
+        const start = page * size;
+        const items = executions.slice(start, start + size);
+        items.forEach(exec => {
+            const tr = document.createElement('tr');
+            const idTd = document.createElement('td');
+            idTd.textContent = exec.jobExecutionId || '';
+            tr.appendChild(idTd);
+
+            const statusTd = document.createElement('td');
+            statusTd.appendChild(renderStatus(exec.status));
+            tr.appendChild(statusTd);
+
+            const actionTd = document.createElement('td');
+            const restartBtn = document.createElement('button');
+            restartBtn.textContent = '재시작';
+            restartBtn.addEventListener('click', () => {
+                fetch(`/api/batch/management/executions/${exec.jobExecutionId}/restart`, { method: 'POST' })
+                    .then(() => load());
+            });
+            actionTd.appendChild(restartBtn);
+
+            const stopBtn = document.createElement('button');
+            stopBtn.textContent = '중지';
+            stopBtn.addEventListener('click', () => {
+                fetch(`/api/batch/management/executions/${exec.jobExecutionId}/stop`, { method: 'POST' })
+                    .then(() => load());
+            });
+            actionTd.appendChild(stopBtn);
+
+            const logBtn = document.createElement('a');
+            logBtn.textContent = '로그';
+            logBtn.href = `log.html?executionId=${exec.jobExecutionId}`;
+            actionTd.appendChild(logBtn);
+
+            tr.appendChild(actionTd);
+            tableBody.appendChild(tr);
+        });
+        renderPagination(pagination, executions.length, page, size, p => { page = p; render(); });
+    }
+
+    load();
+});

--- a/src/main/resources/static/js/batch-list.js
+++ b/src/main/resources/static/js/batch-list.js
@@ -1,0 +1,69 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const tableBody = document.querySelector('#jobTable tbody');
+    const pagination = document.getElementById('pagination');
+    const searchForm = document.getElementById('searchForm');
+    let jobs = [];
+    let filtered = [];
+    const size = 5; // 페이지당 표시 수
+    let page = 0;
+
+    // 잡 이름 목록을 로드
+    function loadJobs() {
+        fetch('/api/batch/management/jobs')
+            .then(res => res.json())
+            .then(data => {
+                jobs = data;
+                filtered = jobs;
+                render();
+            });
+    }
+
+    // 테이블 렌더링
+    function render() {
+        tableBody.innerHTML = '';
+        const start = page * size;
+        const items = filtered.slice(start, start + size);
+        items.forEach(jobName => {
+            const tr = document.createElement('tr');
+            const nameTd = document.createElement('td');
+            nameTd.textContent = jobName;
+            tr.appendChild(nameTd);
+
+            const statusTd = document.createElement('td');
+            statusTd.textContent = '조회중';
+            // 실행 이력 조회 후 상태 표시
+            fetch(`/api/batch/management/jobs/${jobName}/executions`)
+                .then(res => res.json())
+                .then(exec => {
+                    if (exec.length > 0) {
+                        statusTd.textContent = '';
+                        statusTd.appendChild(renderStatus(exec[0].status));
+                    } else {
+                        statusTd.textContent = '-';
+                    }
+                })
+                .catch(() => statusTd.textContent = '-');
+            tr.appendChild(statusTd);
+
+            const actionTd = document.createElement('td');
+            const detailBtn = document.createElement('a');
+            detailBtn.textContent = '상세';
+            detailBtn.href = `detail.html?jobName=${encodeURIComponent(jobName)}`;
+            actionTd.appendChild(detailBtn);
+            tr.appendChild(actionTd);
+            tableBody.appendChild(tr);
+        });
+        renderPagination(pagination, filtered.length, page, size, p => { page = p; render(); });
+    }
+
+    // 검색 처리
+    searchForm.addEventListener('submit', e => {
+        e.preventDefault();
+        const keyword = document.getElementById('searchInput').value.toLowerCase();
+        filtered = jobs.filter(name => name.toLowerCase().includes(keyword));
+        page = 0;
+        render();
+    });
+
+    loadJobs();
+});

--- a/src/main/resources/static/js/batch-log.js
+++ b/src/main/resources/static/js/batch-log.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const params = new URLSearchParams(location.search);
+    const id = params.get('executionId');
+    const container = document.getElementById('logContainer');
+    fetch(`/api/batch/management/executions/${id}/errors`)
+        .then(res => res.json())
+        .then(lines => {
+            container.textContent = lines.join('\n');
+        });
+});

--- a/src/main/resources/templates/batch/detail.html
+++ b/src/main/resources/templates/batch/detail.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <title data-i18n="batch.title.detail">잡 상세</title>
+    <link rel="stylesheet" href="/css/batch.css" />
+    <script src="/js/batch-common.js"></script>
+    <script src="/js/batch-detail.js"></script>
+</head>
+<body>
+    <h1 id="pageTitle" data-i18n="batch.title.detail">잡 상세</h1>
+    <table id="executionTable">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th data-i18n="batch.label.status">상태</th>
+                <th data-i18n="batch.label.actions">액션</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+    <div id="pagination"></div>
+</body>
+</html>

--- a/src/main/resources/templates/batch/list.html
+++ b/src/main/resources/templates/batch/list.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <title data-i18n="batch.title.list">배치 목록</title>
+    <link rel="stylesheet" href="/css/batch.css" />
+    <script src="/js/batch-common.js"></script>
+    <script src="/js/batch-list.js"></script>
+</head>
+<body>
+    <h1 data-i18n="batch.title.list">배치 목록</h1>
+    <form id="searchForm">
+        <input type="text" id="searchInput" placeholder="잡 이름" data-i18n-placeholder="batch.search.placeholder" />
+        <button type="submit" data-i18n="button.search">검색</button>
+    </form>
+    <table id="jobTable">
+        <thead>
+            <tr>
+                <th data-i18n="batch.label.jobName">잡 이름</th>
+                <th data-i18n="batch.label.status">상태</th>
+                <th data-i18n="batch.label.actions">액션</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+    <div id="pagination"></div>
+</body>
+</html>

--- a/src/main/resources/templates/batch/log.html
+++ b/src/main/resources/templates/batch/log.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <title data-i18n="batch.title.log">에러 로그</title>
+    <link rel="stylesheet" href="/css/batch.css" />
+    <script src="/js/batch-log.js"></script>
+</head>
+<body>
+    <h1 data-i18n="batch.title.log">에러 로그</h1>
+    <pre id="logContainer"></pre>
+</body>
+</html>


### PR DESCRIPTION
## 요약
- 배치 잡 목록/상세/로그 화면 템플릿과 CSS·JS 추가
- 배치 메타데이터 조회 및 제어를 위한 REST API 컨트롤러 구현
- 다국어 메시지 파일에 배치 관리 문구 확장

## 테스트
- `mvn -q test` *(실패: 네트워크 연결 불가로 의존성 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68b45dd3ecf0832ab4478a4adad90519