### PR TITLE
feat: add MyBatis configuration class

### DIFF
--- a/src/main/java/egovframework/bat/config/MyBatisConfig.java
+++ b/src/main/java/egovframework/bat/config/MyBatisConfig.java
@@ -1,0 +1,37 @@
+package egovframework.bat.config;
+
+import javax.sql.DataSource;
+
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+/**
+ * MyBatis 설정을 담당하는 구성 클래스.
+ * XML 형태의 매퍼 파일을 자동으로 로딩한다.
+ */
+@Configuration
+@MapperScan(basePackages = "egovframework.bat")
+public class MyBatisConfig {
+
+    /**
+     * SqlSessionFactoryBean을 생성하여 매퍼 XML 위치만 지정한다.
+     *
+     * @param dataSource 기본 데이터소스
+     * @return 설정된 SqlSessionFactoryBean
+     * @throws Exception 리소스 로딩 실패 시
+     */
+    @Bean
+    public SqlSessionFactoryBean sqlSessionFactory(@Qualifier("dataSource") DataSource dataSource) throws Exception {
+        SqlSessionFactoryBean factoryBean = new SqlSessionFactoryBean();
+        factoryBean.setDataSource(dataSource);
+        // 매퍼 XML 경로 지정
+        factoryBean.setMapperLocations(
+            new PathMatchingResourcePatternResolver()
+                .getResources("classpath:/egovframework/batch/mapper/**/*.xml"));
+        return factoryBean;
+    }
+}


### PR DESCRIPTION
## Summary
- configure MyBatis with `SqlSessionFactoryBean` and XML mappers

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b461f742c4832aafaeba5e9c3a4905