### PR TITLE
feat: 공통 알림 설정 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ migstg 데이터베이스 초기화 시 `src/script/mysql/test/2.stg_ddl-mysql.s
   - → 각_업무_job.xml
   - → BatchJobLauncherConfig.java
   - → context-batch-mapper.xml
-                      
+
+## 기타 공통 설정
+WebClient처럼 이미 자바 설정으로 작성된 클래스(`WebClientConfig`)는 좋은 예시입니다.
+반복적으로 사용하는 공통 빈(예: 로깅, 글로벌 메시지)은 별도의 `@Configuration` 클래스에 배치하여 응집력을 높입니다.
+예를 들어, `NotificationConfig`는 이메일 및 SMS 알림 전송기를 빈으로 등록합니다.
 
 ## Spring Batch 처리 방식: Chunk와 Tasklet
 

--- a/src/main/java/egovframework/bat/config/NotificationConfig.java
+++ b/src/main/java/egovframework/bat/config/NotificationConfig.java
@@ -1,0 +1,34 @@
+package egovframework.bat.config;
+
+import egovframework.bat.notification.EmailNotificationSender;
+import egovframework.bat.notification.NotificationSender;
+import egovframework.bat.notification.SmsNotificationSender;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 공통 알림 컴포넌트를 빈으로 등록하는 설정 클래스.
+ */
+@Configuration
+public class NotificationConfig {
+
+    /**
+     * 이메일 알림 전송기를 빈으로 등록한다.
+     *
+     * @return EmailNotificationSender 인스턴스
+     */
+    @Bean
+    public NotificationSender emailNotificationSender() {
+        return new EmailNotificationSender();
+    }
+
+    /**
+     * SMS 알림 전송기를 빈으로 등록한다.
+     *
+     * @return SmsNotificationSender 인스턴스
+     */
+    @Bean
+    public NotificationSender smsNotificationSender() {
+        return new SmsNotificationSender();
+    }
+}

--- a/src/main/java/egovframework/bat/notification/EmailNotificationSender.java
+++ b/src/main/java/egovframework/bat/notification/EmailNotificationSender.java
@@ -2,12 +2,10 @@ package egovframework.bat.notification;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
 /**
  * 메일 알림 전송 컴포넌트.
  */
-@Service
 public class EmailNotificationSender implements NotificationSender {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EmailNotificationSender.class);

--- a/src/main/java/egovframework/bat/notification/SmsNotificationSender.java
+++ b/src/main/java/egovframework/bat/notification/SmsNotificationSender.java
@@ -2,12 +2,10 @@ package egovframework.bat.notification;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
 /**
  * SMS 알림 전송 컴포넌트.
  */
-@Service
 public class SmsNotificationSender implements NotificationSender {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SmsNotificationSender.class);


### PR DESCRIPTION
## 요약
- 이메일, SMS 알림 컴포넌트를 빈으로 등록하는 `NotificationConfig` 추가
- 알림 전송기 클래스를 일반 클래스로 변경하고 설정에서 관리
- 반복 사용 빈을 설정 클래스로 분리하라는 가이드 문서화

## 테스트
- `mvn -q test` *(네트워크 오류로 의존성 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68b46478674c832a93c6bd772d60b376