### PR TITLE
ERP STG 데이터를 외부 ERP API로 전송하는 배치 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,24 +142,28 @@ public class SampleTasklet implements Tasklet {
 
 ## ERP 배치 잡 디렉터리(`erp`)
 
-`src/main/resources/egovframework/batch/job/erp` 디렉터리는 ERP 관련 배치 Job 설정을 모아두는 곳입니다. 현재 포함된 Job은 다음과 같습니다.
+`src/main/resources/egovframework/batch/job/erp` 디렉터리는 ERP 관련 배치 Job 설정을 모아두는 곳입니다. ERP 배치는 외부 시스템에서 우리쪽으로 데이터를 수집하는 흐름과, 우리 시스템의 데이터를 외부로 전송하는 흐름 두 가지를 모두 지원합니다. 현재 포함된 Job은 다음과 같습니다.
 
-- `erpRestToStgJob`
-- `erpStgToLocalJob`
+- `erpRestToStgJob` : 외부 ERP \u2192 STG (데이터 수집)
+- `erpStgToRestJob` : STG \u2192 외부 ERP (데이터 전송)
+- `erpStgToLocalJob` : STG \u2192 로컬 DB
 
 다음은 관련된 주요 파일들입니다.
 
 - 잡 설정:
   - `src/main/resources/egovframework/batch/job/erp/erpRestToStgJob.xml`: ERP REST API에서 데이터를 조회하여 STG에 적재하는 Job 설정 파일
+  - `src/main/resources/egovframework/batch/job/erp/erpStgToRestJob.xml`: STG 데이터를 외부 ERP REST API로 전송하는 Job 설정 파일
   - `src/main/resources/egovframework/batch/job/erp/erpStgToLocalJob.xml`: STG에 적재된 ERP 데이터를 로컬 DB로 이관하는 Job 설정 파일
 - 매퍼 파일:
   - `src/main/resources/egovframework/batch/mapper/erp/erp_rest_to_stg.xml`: ERP REST 데이터→STG 적재를 위한 SQL 매퍼
   - `src/main/resources/egovframework/batch/mapper/erp/erp_stg_to_local.xml`: STG→로컬 데이터 이동을 위한 SQL 매퍼
 - 공통, 도메인 및 유틸 클래스:
   - `src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java`: ERP 시스템에서 차량 정보를 조회하여 STG에 적재하는 Tasklet
+  - `src/main/java/egovframework/bat/erp/tasklet/SendErpDataTasklet.java`: STG 데이터를 외부 ERP로 전송하는 Tasklet
   - `src/main/java/egovframework/bat/erp/processor/VehicleInfoProcessor.java`: ERP 차량 정보를 처리하는 배치 프로세서
   - `src/main/java/egovframework/bat/erp/domain/VehicleInfo.java`: ERP 차량 정보를 담는 도메인 클래스
-  - `src/main/java/egovframework/bat/erp/api/RestToStgJobController.java`: ERP REST 배치를 수동 실행하는 컨트롤러
+  - `src/main/java/egovframework/bat/erp/api/RestToStgJobController.java`: 외부 ERP에서 STG로 적재하는 배치를 수동 실행하는 컨트롤러
+  - `src/main/java/egovframework/bat/erp/api/StgToRestJobController.java`: STG 데이터를 외부 ERP로 전송하는 배치를 수동 실행하는 컨트롤러
 
 ## 예제 배치 잡 디렉터리(`example`)
 
@@ -183,9 +187,15 @@ public class SampleTasklet implements Tasklet {
 
 ### ERP 배치 잡 실행 API
 
-`RestToStgJobController`를 통해 ERP 배치를 REST로 호출할 수 있습니다.
+`RestToStgJobController`를 통해 외부 ERP \u2192 STG 배치를 REST로 호출할 수 있습니다.
 
 - **URL**: `POST /api/batch/erp-rest-to-stg`
+- **파라미터**: 없음
+- **응답**: 실행 결과 `BatchStatus`
+
+`StgToRestJobController`를 통해 STG \u2192 외부 ERP 배치를 REST로 호출할 수 있습니다.
+
+- **URL**: `POST /api/batch/erp-stg-to-rest`
 - **파라미터**: 없음
 - **응답**: 실행 결과 `BatchStatus`
 

--- a/src/main/java/egovframework/bat/erp/api/StgToRestJobController.java
+++ b/src/main/java/egovframework/bat/erp/api/StgToRestJobController.java
@@ -1,0 +1,56 @@
+package egovframework.bat.erp.api;
+
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * STG 데이터 외부 ERP 시스템으로 전송 배치를 수동 실행하기 위한 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api/batch")
+@RequiredArgsConstructor
+public class StgToRestJobController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StgToRestJobController.class);
+
+    /** 잡 실행기 */
+    private final JobLauncher jobLauncher;
+
+    /** STG 데이터를 외부로 전송하는 잡 */
+    private final Job erpStgToRestJob;
+
+    /**
+     * ERP STG 데이터를 외부 REST API로 전송하는 잡을 실행한다.
+     *
+     * @return 배치 실행 결과 상태
+     */
+    @PostMapping("/erp-stg-to-rest")
+    public ResponseEntity<BatchStatus> runErpStgToRestJob() {
+        LOGGER.info("ERP STG→REST 배치 실행 요청 수신");
+        JobParameters jobParameters = new JobParametersBuilder()
+            .addLong("timestamp", System.currentTimeMillis())
+            .toJobParameters();
+        try {
+            JobExecution execution = jobLauncher.run(erpStgToRestJob, jobParameters);
+            LOGGER.info("ERP STG→REST 배치 실행 완료: {}", execution.getStatus());
+            return ResponseEntity.ok(execution.getStatus());
+        } catch (Exception e) {
+            LOGGER.error("ERP STG→REST 배치 실행 실패", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(BatchStatus.FAILED);
+        }
+    }
+}
+

--- a/src/main/java/egovframework/bat/erp/tasklet/SendErpDataTasklet.java
+++ b/src/main/java/egovframework/bat/erp/tasklet/SendErpDataTasklet.java
@@ -1,0 +1,120 @@
+package egovframework.bat.erp.tasklet;
+
+import egovframework.bat.erp.domain.VehicleInfo;
+import egovframework.bat.erp.exception.ErpApiException;
+import egovframework.bat.notification.NotificationSender;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+/**
+ * STG DB에 적재된 ERP 데이터를 외부 시스템으로 전송하는 Tasklet.
+ */
+@Component
+public class SendErpDataTasklet implements Tasklet {
+
+    /** 로거 */
+    private static final Logger LOGGER = LoggerFactory.getLogger(SendErpDataTasklet.class);
+
+    /** WebClient 인스턴스 */
+    private final WebClient webClient;
+
+    /** STG DB 접근을 위한 JdbcTemplate */
+    private final JdbcTemplate jdbcTemplate;
+
+    /** 장애 알림 전송기 목록 */
+    private final List<NotificationSender> notificationSenders;
+
+    /** 외부 ERP API URL */
+    private final String apiUrl;
+
+    public SendErpDataTasklet(WebClient.Builder builder,
+                              @Qualifier("migstgJdbcTemplate") JdbcTemplate jdbcTemplate,
+                              List<NotificationSender> notificationSenders,
+                              @Value("${erp.outbound-api-url}") String apiUrl) {
+        this.webClient = builder.build();
+        this.jdbcTemplate = jdbcTemplate;
+        this.notificationSenders = notificationSenders;
+        this.apiUrl = apiUrl;
+    }
+
+    /** 현재 설정된 외부 API URL 반환 */
+    public String getApiUrl() {
+        return apiUrl;
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        LOGGER.info("ERP 데이터 외부 전송 시작");
+        List<VehicleInfo> vehicles;
+        try {
+            vehicles = fetchVehicles();
+        } catch (DataAccessException e) {
+            LOGGER.error("STG 데이터 조회 실패", e);
+            notifyFailure("STG 데이터 조회 실패: " + e.getMessage());
+            throw e;
+        }
+
+        if (vehicles.isEmpty()) {
+            LOGGER.info("전송할 데이터가 없습니다.");
+            return RepeatStatus.FINISHED;
+        }
+
+        for (VehicleInfo vehicle : vehicles) {
+            try {
+                sendVehicle(vehicle);
+            } catch (ErpApiException e) {
+                LOGGER.error("차량 전송 실패: {}", vehicle.getVehicleId(), e);
+                notifyFailure("차량 전송 실패: " + e.getMessage());
+                throw e;
+            }
+        }
+
+        LOGGER.info("ERP 데이터 외부 전송 완료");
+        return RepeatStatus.FINISHED;
+    }
+
+    /** STG DB에서 전송 대상 차량 목록 조회 */
+    private List<VehicleInfo> fetchVehicles() {
+        String sql = "SELECT VEHICLE_ID, MODEL, MANUFACTURER, PRICE, REG_DTTM, MOD_DTTM FROM MIGSTG.ERP_VEHICLE";
+        return jdbcTemplate.query(sql, new BeanPropertyRowMapper<>(VehicleInfo.class));
+    }
+
+    /** 단건 차량 정보를 외부 ERP API로 전송 */
+    private void sendVehicle(VehicleInfo vehicle) {
+        try {
+            webClient.post()
+                    .uri(apiUrl)
+                    .bodyValue(vehicle)
+                    .retrieve()
+                    .bodyToMono(Void.class)
+                    .block();
+        } catch (WebClientResponseException e) {
+            throw new ErpApiException("ERP API 호출 실패", e);
+        }
+    }
+
+    /** 장애 알림 전송 */
+    private void notifyFailure(String message) {
+        for (NotificationSender sender : notificationSenders) {
+            try {
+                sender.send(message);
+            } catch (Exception e) {
+                LOGGER.warn("알림 전송 중 오류 발생", e);
+            }
+        }
+    }
+}
+

--- a/src/main/resources/application/env/dev/application.yml
+++ b/src/main/resources/application/env/dev/application.yml
@@ -42,3 +42,5 @@ logging:
 erp:
   # ERP 시스템 API URL
   api-url: http://127.0.0.1:8080/api/v1/vehicles
+  # ERP 시스템으로 데이터를 전송할 때 사용할 URL
+  outbound-api-url: http://127.0.0.1:8080/api/v1/vehicles

--- a/src/main/resources/application/env/local/application.yml
+++ b/src/main/resources/application/env/local/application.yml
@@ -44,3 +44,5 @@ logging:
 erp:
   # ERP 시스템 API URL
   api-url: http://127.0.0.1:8080/api/v1/vehicles
+  # ERP 시스템으로 데이터를 전송할 때 사용할 URL
+  outbound-api-url: http://127.0.0.1:8080/api/v1/vehicles

--- a/src/main/resources/application/env/prod/application.yml
+++ b/src/main/resources/application/env/prod/application.yml
@@ -42,3 +42,5 @@ logging:
 erp:
   # ERP 시스템 API URL
   api-url: http://127.0.0.1:8080/api/v1/vehicles
+  # ERP 시스템으로 데이터를 전송할 때 사용할 URL
+  outbound-api-url: http://127.0.0.1:8080/api/v1/vehicles

--- a/src/main/resources/egovframework/batch/context-batch-scheduler.xml
+++ b/src/main/resources/egovframework/batch/context-batch-scheduler.xml
@@ -13,10 +13,15 @@
             <property name="cronExpression" value="0 * * * * ?" />
         </bean>
 
-	    <bean id="erpRestToStgCronTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
-	        <property name="jobDetail" ref="erpRestToStgJobDetail" />
-	        <property name="cronExpression" value="0 0/5 * * * ?" />
-	    </bean>
+        <bean id="erpRestToStgCronTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
+            <property name="jobDetail" ref="erpRestToStgJobDetail" />
+            <property name="cronExpression" value="0 0/5 * * * ?" />
+        </bean>
+
+        <bean id="erpStgToRestCronTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
+            <property name="jobDetail" ref="erpStgToRestJobDetail" />
+            <property name="cronExpression" value="0 0/10 * * * ?" />
+        </bean>
 
         <!-- JobChainingJobListener를 이용하여 순차 실행 설정 (insaStgToLocalJobDetail은 트리거 없이 insaRemote1ToStgJobDetail 후에 실행됨) -->
         <bean id="jobChainingJobListener" class="org.quartz.listeners.JobChainingJobListener">
@@ -61,6 +66,7 @@
                 <list>
                     <ref bean="insaRemote1ToStgCronTrigger" />
                     <ref bean="erpRestToStgCronTrigger" />
+                    <ref bean="erpStgToRestCronTrigger" />
                 </list>
             </property>
             <!-- 트리거가 없는 작업을 등록하기 위한 jobDetails 설정 -->

--- a/src/main/resources/egovframework/batch/context-scheduler-job.xml
+++ b/src/main/resources/egovframework/batch/context-scheduler-job.xml
@@ -7,6 +7,7 @@
     <import resource="classpath:/egovframework/batch/job/insa/insaStgToLocalJob.xml" />
     <import resource="classpath:/egovframework/batch/job/erp/erpRestToStgJob.xml" />
     <import resource="classpath:/egovframework/batch/job/erp/erpStgToLocalJob.xml" />
+    <import resource="classpath:/egovframework/batch/job/erp/erpStgToRestJob.xml" />
     <import resource="classpath:/egovframework/batch/job/example/mybatisToMybatisSampleJob.xml" />
 
 
@@ -74,6 +75,19 @@
             <map>
                 <!-- STG에 있는 ERP 고객 정보를 로컬 DB로 이관하는 잡 -->
                 <entry key="jobName" value="erpStgToLocalJob" />
+                <entry key="jobLocator" value-ref="jobRegistry" />
+                <entry key="jobLauncher" value-ref="jobLauncher" />
+            </map>
+        </property>
+    </bean>
+
+    <bean id="erpStgToRestJobDetail" class="org.springframework.scheduling.quartz.JobDetailFactoryBean">
+        <property name="jobClass" value="egovframework.bat.scheduler.EgovQuartzJobLauncher" />
+        <property name="group" value="quartz-batch" />
+        <property name="jobDataAsMap">
+            <map>
+                <!-- STG 데이터를 외부 ERP로 전송하는 잡 -->
+                <entry key="jobName" value="erpStgToRestJob" />
                 <entry key="jobLocator" value-ref="jobRegistry" />
                 <entry key="jobLauncher" value-ref="jobLauncher" />
             </map>

--- a/src/main/resources/egovframework/batch/job/erp/erpStgToRestJob.xml
+++ b/src/main/resources/egovframework/batch/job/erp/erpStgToRestJob.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+        http://www.springframework.org/schema/batch D:\\DEV\\xsd\\spring-batch-3.0.xsd">
+
+    <!-- STG에 있는 ERP 데이터를 외부 REST API로 전송하는 잡 -->
+    <job id="erpStgToRestJob" parent="eGovBaseJob" xmlns="http://www.springframework.org/schema/batch">
+        <step id="sendErpDataStep" parent="eGovTaskletStep">
+            <tasklet ref="sendErpDataTasklet" />
+        </step>
+    </job>
+
+</beans>

--- a/src/main/resources/egovframework/batch/properties/env/dev/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/env/dev/globals.properties
@@ -41,4 +41,5 @@ Globals.Stg.Password=mig!1234
 # ERP REST API \ud638\ucd9c \uc815\ubcf4
 Globals.Erp.ApiUrl=http://localhost:8080/api/erp
 Globals.Erp.AuthToken=CHANGE_ME
+Globals.Erp.OutboundApiUrl=http://localhost:8080/api/erp/outbound
 

--- a/src/main/resources/egovframework/batch/properties/env/local/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/env/local/globals.properties
@@ -47,4 +47,5 @@ Globals.Stg.Password=mig!1234
 # ERP REST API \ud638\ucd9c \uc815\ubcf4
 Globals.Erp.ApiUrl=http://localhost:8080/api/erp
 Globals.Erp.AuthToken=CHANGE_ME
+Globals.Erp.OutboundApiUrl=http://localhost:8080/api/erp/outbound
 

--- a/src/main/resources/egovframework/batch/properties/env/prod/globals.properties
+++ b/src/main/resources/egovframework/batch/properties/env/prod/globals.properties
@@ -41,4 +41,5 @@ Globals.Stg.Password=mig!1234
 # ERP REST API \ud638\ucd9c \uc815\ubcf4
 Globals.Erp.ApiUrl=http://localhost:8080/api/erp
 Globals.Erp.AuthToken=CHANGE_ME
+Globals.Erp.OutboundApiUrl=http://localhost:8080/api/erp/outbound
 


### PR DESCRIPTION
## Summary
- STG DB 데이터를 외부 ERP REST API로 전송하는 `SendErpDataTasklet`과 수동 실행 컨트롤러 추가
- ERP STG→REST 배치 Job 및 Quartz 스케줄러 설정, 크론 트리거 등록
- ERP outbound API URL 프로퍼티 및 문서 보강

## Testing
- `mvn -q test` *(실패: 의존성 해석 불가 - 네트워크 연결 오류)*

------
https://chatgpt.com/codex/tasks/task_e_68b458f3ba88832ab8fd125c652e149d