### PR TITLE
DB 기반 배치 스케줄 동적 등록 기능 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-log4j2</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
         <!-- spring boot dependency end -->
         <dependency>
             <groupId>org.egovframe.rte</groupId>

--- a/src/main/java/egovframework/bat/scheduler/BatchJobSchedule.java
+++ b/src/main/java/egovframework/bat/scheduler/BatchJobSchedule.java
@@ -1,0 +1,61 @@
+package egovframework.bat.scheduler;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * 배치 잡 스케줄 정보를 저장하는 엔티티.
+ * DB 테이블 BATCH_JOB_SCHEDULE과 매핑된다.
+ */
+@Entity
+@Table(name = "BATCH_JOB_SCHEDULE")
+public class BatchJobSchedule {
+
+    /** 잡 이름 (JobDetail의 빈 이름) */
+    @Id
+    @Column(name = "job_name", nullable = false, length = 100)
+    private String jobName;
+
+    /** 크론 표현식 */
+    @Column(name = "cron_expression", nullable = false, length = 100)
+    private String cronExpression;
+
+    /** 설명 (선택) */
+    @Column(name = "description")
+    private String description;
+
+    /** 기본 생성자 */
+    public BatchJobSchedule() {}
+
+    public BatchJobSchedule(String jobName, String cronExpression, String description) {
+        this.jobName = jobName;
+        this.cronExpression = cronExpression;
+        this.description = description;
+    }
+
+    public String getJobName() {
+        return jobName;
+    }
+
+    public void setJobName(String jobName) {
+        this.jobName = jobName;
+    }
+
+    public String getCronExpression() {
+        return cronExpression;
+    }
+
+    public void setCronExpression(String cronExpression) {
+        this.cronExpression = cronExpression;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/egovframework/bat/scheduler/BatchJobScheduleRepository.java
+++ b/src/main/java/egovframework/bat/scheduler/BatchJobScheduleRepository.java
@@ -1,0 +1,11 @@
+package egovframework.bat.scheduler;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 배치 잡 스케줄을 조회하는 리포지토리.
+ */
+@Repository
+public interface BatchJobScheduleRepository extends JpaRepository<BatchJobSchedule, String> {
+}

--- a/src/main/java/egovframework/bat/scheduler/BatchJobScheduleService.java
+++ b/src/main/java/egovframework/bat/scheduler/BatchJobScheduleService.java
@@ -1,0 +1,66 @@
+package egovframework.bat.scheduler;
+
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+
+import org.quartz.CronScheduleBuilder;
+import org.quartz.CronTrigger;
+import org.quartz.JobDetail;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.TriggerBuilder;
+import org.springframework.context.ApplicationContext;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+import org.springframework.stereotype.Service;
+
+/**
+ * DB에서 크론 표현식을 조회하여 Quartz 스케줄을 등록/재등록하는 서비스.
+ */
+@Service
+public class BatchJobScheduleService {
+
+    private final Scheduler scheduler;
+    private final ApplicationContext applicationContext;
+    private final BatchJobScheduleRepository repository;
+
+    public BatchJobScheduleService(SchedulerFactoryBean schedulerFactoryBean,
+                                   ApplicationContext applicationContext,
+                                   BatchJobScheduleRepository repository) {
+        this.scheduler = schedulerFactoryBean.getScheduler();
+        this.applicationContext = applicationContext;
+        this.repository = repository;
+    }
+
+    /**
+     * 애플리케이션 시작 시 스케줄을 등록한다.
+     */
+    @PostConstruct
+    public void init() throws SchedulerException {
+        refresh();
+    }
+
+    /**
+     * DB 내용을 기반으로 스케줄을 모두 재등록한다.
+     * 변경된 크론 표현식을 반영하기 위해 사용한다.
+     */
+    public void refresh() throws SchedulerException {
+        // 기존 스케줄 초기화
+        scheduler.clear();
+
+        // 트리거 없이 등록해야 하는 잡 추가
+        scheduler.addJob(applicationContext.getBean("insaStgToLocalJobDetail", JobDetail.class), true);
+        scheduler.addJob(applicationContext.getBean("erpStgToLocalJobDetail", JobDetail.class), true);
+
+        List<BatchJobSchedule> schedules = repository.findAll();
+        for (BatchJobSchedule schedule : schedules) {
+            JobDetail jobDetail = applicationContext.getBean(schedule.getJobName(), JobDetail.class);
+            CronTrigger trigger = TriggerBuilder.newTrigger()
+                    .forJob(jobDetail)
+                    .withIdentity(schedule.getJobName() + "Trigger")
+                    .withSchedule(CronScheduleBuilder.cronSchedule(schedule.getCronExpression()))
+                    .build();
+            scheduler.scheduleJob(jobDetail, trigger);
+        }
+    }
+}

--- a/src/main/java/egovframework/bat/scheduler/SchedulerConfig.java
+++ b/src/main/java/egovframework/bat/scheduler/SchedulerConfig.java
@@ -1,0 +1,29 @@
+package egovframework.bat.scheduler;
+
+import org.quartz.JobDetail;
+import org.quartz.JobListener;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+
+/**
+ * DB의 크론 정보를 이용해 스케줄을 설정하는 구성 클래스.
+ */
+@Configuration
+public class SchedulerConfig {
+
+    /**
+     * SchedulerFactoryBean을 생성하여 글로벌 리스너와 기본 JobDetail을 등록한다.
+     */
+    @Bean
+    public SchedulerFactoryBean schedulerFactoryBean(
+            @Qualifier("insaStgToLocalJobDetail") JobDetail insaStgToLocalJobDetail,
+            @Qualifier("erpStgToLocalJobDetail") JobDetail erpStgToLocalJobDetail,
+            @Qualifier("jobChainingJobListener") JobListener jobChainingJobListener) {
+        SchedulerFactoryBean factoryBean = new SchedulerFactoryBean();
+        factoryBean.setJobDetails(insaStgToLocalJobDetail, erpStgToLocalJobDetail);
+        factoryBean.setGlobalJobListeners(jobChainingJobListener);
+        return factoryBean;
+    }
+}

--- a/src/main/resources/egovframework/batch/context-batch-scheduler.xml
+++ b/src/main/resources/egovframework/batch/context-batch-scheduler.xml
@@ -7,16 +7,18 @@
         <!-- JobDetail 정의를 포함하는 설정 -->
         <import resource="context-scheduler-job.xml" />
         
-        <!-- 각 잡에 대한 크론 트리거 정의 -->
+        <!-- 각 잡에 대한 크론 트리거 정의는 자바 설정에서 동적으로 등록됨 -->
+        <!--
         <bean id="insaRemote1ToStgCronTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
             <property name="jobDetail" ref="insaRemote1ToStgJobDetail" />
             <property name="cronExpression" value="0 * * * * ?" />
         </bean>
 
-	    <bean id="erpRestToStgCronTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
-	        <property name="jobDetail" ref="erpRestToStgJobDetail" />
-	        <property name="cronExpression" value="0 0/5 * * * ?" />
-	    </bean>
+        <bean id="erpRestToStgCronTrigger" class="org.springframework.scheduling.quartz.CronTriggerFactoryBean">
+            <property name="jobDetail" ref="erpRestToStgJobDetail" />
+            <property name="cronExpression" value="0 0/5 * * * ?" />
+        </bean>
+        -->
 
         <!-- JobChainingJobListener를 이용하여 순차 실행 설정 (insaStgToLocalJobDetail은 트리거 없이 insaRemote1ToStgJobDetail 후에 실행됨) -->
         <bean id="jobChainingJobListener" class="org.quartz.listeners.JobChainingJobListener">
@@ -55,7 +57,8 @@
             </property>
         </bean>
 
-		<!-- 트리거들을 실행가능상태로 한다 -->
+        <!-- SchedulerFactoryBean 설정은 SchedulerConfig 클래스에서 처리 -->
+        <!--
         <bean class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
             <property name="triggers">
                 <list>
@@ -63,18 +66,18 @@
                     <ref bean="erpRestToStgCronTrigger" />
                 </list>
             </property>
-            <!-- 트리거가 없는 작업을 등록하기 위한 jobDetails 설정 -->
             <property name="jobDetails">
                 <list>
                     <ref bean="insaStgToLocalJobDetail" />
                     <ref bean="erpStgToLocalJobDetail" />
                 </list>
-            </property>            
+            </property>
             <property name="globalJobListeners">
                 <list>
                     <ref bean="jobChainingJobListener" />
                 </list>
             </property>
         </bean>
+        -->
 
 </beans>

--- a/src/script/mysql/main/BATCH_JOB_SCHEDULE.sql
+++ b/src/script/mysql/main/BATCH_JOB_SCHEDULE.sql
@@ -1,0 +1,6 @@
+-- 배치 잡 스케줄 테이블 생성
+CREATE TABLE BATCH_JOB_SCHEDULE (
+    job_name VARCHAR(100) NOT NULL PRIMARY KEY,
+    cron_expression VARCHAR(100) NOT NULL,
+    description VARCHAR(255)
+);


### PR DESCRIPTION
## Summary
- 배치 잡 스케줄을 위한 테이블 및 JPA 엔티티/리포지토리 추가
- SchedulerConfig와 서비스로 DB 크론 식을 읽어 Quartz 트리거 동적 등록
- 기존 XML의 정적 CronTrigger 설정 제거

## Testing
- `mvn -q test` *(실패: org.springframework.boot:spring-boot-starter-parent 의존성을 내려받지 못함)*

------
https://chatgpt.com/codex/tasks/task_e_68b459df30a4832abb57b81d4761a090