### PR TITLE
refactor: BatchManagementController 이름 변경 및 빈 이름 지정

### DIFF
--- a/src/main/java/egovframework/bat/api/BatchApiController.java
+++ b/src/main/java/egovframework/bat/api/BatchApiController.java
@@ -20,10 +20,10 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 배치 잡과 실행 정보를 조회/관리하기 위한 REST 컨트롤러.
  */
-@RestController
+@RestController("batchApiController")
 @RequestMapping("/api/batch")
 @RequiredArgsConstructor
-public class BatchManagementController {
+public class BatchApiController {
 
     /** 배치 관리 서비스 */
     private final BatchManagementService batchManagementService;


### PR DESCRIPTION
## Summary
- BatchManagementController를 BatchApiController로 리팩터링
- `@RestController("batchApiController")`로 빈 이름 중복 해결

## Testing
- `mvn -q -e -DskipTests package` *(실패: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e4c3d48c832a87d393ded1b136e5