### PR TITLE
StepBuilder와 JobBuilder에 repository 체이닝 적용

### DIFF
--- a/src/main/java/egovframework/bat/example/config/MybatisToMybatisJobConfig.java
+++ b/src/main/java/egovframework/bat/example/config/MybatisToMybatisJobConfig.java
@@ -71,7 +71,7 @@ public class MybatisToMybatisJobConfig {
             ItemReader<CustomerCredit> mybatisItemReader,
             ItemProcessor<CustomerCredit, CustomerCredit> itemProcessor,
             ItemWriter<CustomerCredit> mybatisItemWriter) {
-        return new StepBuilder("mybatisToMybatisStep", jobRepository)
+        return new StepBuilder("mybatisToMybatisStep").repository(jobRepository)
                 .<CustomerCredit, CustomerCredit>chunk(500, transactionManager)
                 .reader(mybatisItemReader)
                 .processor(itemProcessor)
@@ -84,7 +84,7 @@ public class MybatisToMybatisJobConfig {
      */
     @Bean
     public Job mybatisToMybatisSampleJob(JobRepository jobRepository, Step mybatisToMybatisStep) {
-        return new JobBuilder("mybatisToMybatisSampleJob", jobRepository)
+        return new JobBuilder("mybatisToMybatisSampleJob").repository(jobRepository)
                 .start(mybatisToMybatisStep)
                 .build();
     }


### PR DESCRIPTION
## 요약
- StepBuilder 생성자 호출 방식을 repository 체이닝으로 변경
- JobBuilder 생성자 호출 방식을 repository 체이닝으로 변경

## 테스트
- `mvn -q test` (네트워크 오류로 실패)


------
https://chatgpt.com/codex/tasks/task_e_68b4e5da0f24832aa8cb9efb56a6ccf7