### PR TITLE
fix: 스텝 청크 설정 및 트랜잭션 매니저 체인 분리

### DIFF
--- a/src/main/java/egovframework/bat/example/config/MybatisToMybatisJobConfig.java
+++ b/src/main/java/egovframework/bat/example/config/MybatisToMybatisJobConfig.java
@@ -72,10 +72,11 @@ public class MybatisToMybatisJobConfig {
             ItemProcessor<CustomerCredit, CustomerCredit> itemProcessor,
             ItemWriter<CustomerCredit> mybatisItemWriter) {
         return new StepBuilder("mybatisToMybatisStep").repository(jobRepository)
-                .<CustomerCredit, CustomerCredit>chunk(500, transactionManager)
+                .<CustomerCredit, CustomerCredit>chunk(500)
                 .reader(mybatisItemReader)
                 .processor(itemProcessor)
                 .writer(mybatisItemWriter)
+                .transactionManager(transactionManager) // 트랜잭션 매니저 설정
                 .build();
     }
 


### PR DESCRIPTION
## Summary
- StepBuilder 청크 설정에서 트랜잭션 매니저 인자를 제거
- 라이터 이후에 트랜잭션 매니저 체인을 추가해 가독성 향상

## Testing
- `mvn -q clean compile` (실패: Non-resolvable parent POM, 네트워크 연결 불가)


------
https://chatgpt.com/codex/tasks/task_e_68b4e6fdeb28832ab83473b42853c42d