### PR TITLE
javax.persistence-api 의존성 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,12 @@
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
         </dependency>
+        <!-- JPA 엔티티를 사용하기 위한 의존성 추가 -->
+        <dependency>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
+        </dependency>
         <!-- For Testing -->
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
## Summary
- JPA 엔티티 사용을 위해 javax.persistence-api 의존성 추가

## Testing
- `mvn -q clean compile` *(네트워크 연결 불가로 parent POM을 다운로드하지 못함)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e8dcf82c832a8eeea102460d2ded