### PR TITLE
sqlSessionFactory-stg 빈을 기본으로 지정

### DIFF
--- a/src/main/resources/egovframework/batch/context-batch-mapper.xml
+++ b/src/main/resources/egovframework/batch/context-batch-mapper.xml
@@ -18,7 +18,7 @@
     </bean>
 
     <!-- 스테이징 MySQL (Primary)용 SqlSessionFactory -->
-    <bean id="sqlSessionFactory-stg" class="org.mybatis.spring.SqlSessionFactoryBean">
+    <bean id="sqlSessionFactory-stg" class="org.mybatis.spring.SqlSessionFactoryBean" primary="true">
         <property name="dataSource" ref="dataSource-stg"/>
         <property name="configLocation" value="classpath:/egovframework/batch/mapper/config/mapper-config.xml" />
         <property name="mapperLocations">


### PR DESCRIPTION
## Summary
- `sqlSessionFactory-stg` 빈에 `primary="true"`를 추가하여 기본 SqlSessionFactory로 지정

## Testing
- `mvn -q test` *(실패: Non-resolvable parent POM for egov.batch:testBatch:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ecc5aa4c832a9485c3d88285464c