### PR TITLE
SqlSessionFactory 기본 빈 지정

### DIFF
--- a/src/main/resources/egovframework/batch/context-batch-mapper.xml
+++ b/src/main/resources/egovframework/batch/context-batch-mapper.xml
@@ -5,8 +5,8 @@
     <!-- 실행환경에서 빈이름 참조(EgovAbstractDAO) -->
     <bean id="egov.lobHandler" class="org.springframework.jdbc.support.lob.DefaultLobHandler" lazy-init="true" />
 
-    <!-- 운영 MySQL용 SqlSessionFactory -->
-    <bean id="sqlSessionFactory-local" class="org.mybatis.spring.SqlSessionFactoryBean">
+    <!-- 운영 MySQL용 SqlSessionFactory (기본 Bean) -->
+    <bean id="sqlSessionFactory-local" class="org.mybatis.spring.SqlSessionFactoryBean" primary="true">
         <property name="dataSource" ref="dataSource-local"/>
         <property name="configLocation" value="classpath:/egovframework/batch/mapper/config/mapper-config.xml" />
         <property name="mapperLocations">


### PR DESCRIPTION
## Summary
- 운영 DB용 SqlSessionFactory를 기본 빈으로 설정하여 명시적 주입 없이 사용 가능하도록 수정

## Testing
- `mvn -q test` *(네트워크 문제로 부모 POM을 다운로드하지 못해 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ed04a440832aa0b75f2a17342185