### PR TITLE
feat: MyBatis 설정 및 매퍼 경로 수정

### DIFF
--- a/src/main/java/egovframework/bat/config/MyBatisConfig.java
+++ b/src/main/java/egovframework/bat/config/MyBatisConfig.java
@@ -7,6 +7,7 @@ import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
 /**
@@ -18,7 +19,7 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 public class MyBatisConfig {
 
     /**
-     * SqlSessionFactoryBean을 생성하여 매퍼 XML 위치만 지정한다.
+     * SqlSessionFactoryBean을 생성하여 설정 파일과 매퍼 XML 위치를 지정한다.
      *
      * @param dataSource 기본 데이터소스
      * @return 설정된 SqlSessionFactoryBean
@@ -28,10 +29,12 @@ public class MyBatisConfig {
     public SqlSessionFactoryBean sqlSessionFactory(@Qualifier("dataSource") DataSource dataSource) throws Exception {
         SqlSessionFactoryBean factoryBean = new SqlSessionFactoryBean();
         factoryBean.setDataSource(dataSource);
-        // 매퍼 XML 경로 지정
+        // MyBatis 설정 파일 위치 지정
+        factoryBean.setConfigLocation(new ClassPathResource("egovframework/batch/mapper/config/mapper-config.xml"));
+        // 매퍼 XML 경로 지정 (config 디렉터리 제외)
         factoryBean.setMapperLocations(
             new PathMatchingResourcePatternResolver()
-                .getResources("classpath:/egovframework/batch/mapper/**/*.xml"));
+                .getResources("classpath:/egovframework/batch/mapper/*/*.xml"));
         return factoryBean;
     }
 }


### PR DESCRIPTION
## Summary
- MyBatis 설정 파일을 명시적으로 로딩하도록 SqlSessionFactoryBean에 config 위치 추가
- config 디렉터리를 제외한 매퍼 XML 경로로 수정하여 불필요한 중복 로딩 방지

## Testing
- `mvn -e test` *(실패: spring-boot-starter-parent 의존성 해석 실패, 네트워크 미연결)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ee9ba7e4832a8fc073fc447d2660