### PR TITLE
MyBatis 설정 파일 분리 및 매퍼 경로 정리

### DIFF
--- a/src/main/java/egovframework/bat/config/MyBatisConfig.java
+++ b/src/main/java/egovframework/bat/config/MyBatisConfig.java
@@ -2,12 +2,15 @@ package egovframework.bat.config;
 
 import javax.sql.DataSource;
 
+import java.util.Arrays;
+
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
 /**
@@ -31,10 +34,12 @@ public class MyBatisConfig {
         factoryBean.setDataSource(dataSource);
         // MyBatis 설정 파일 위치 지정
         factoryBean.setConfigLocation(new ClassPathResource("egovframework/batch/mapper/config/mapper-config.xml"));
-        // 매퍼 XML 경로 지정 (config 디렉터리 제외)
-        factoryBean.setMapperLocations(
-            new PathMatchingResourcePatternResolver()
-                .getResources("classpath:/egovframework/batch/mapper/*/*.xml"));
+        // 매퍼 XML 경로 지정 (config 디렉터리를 제외하기 위해 필터링)
+        PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+        Resource[] mapperLocations = Arrays.stream(resolver.getResources("classpath:/egovframework/batch/mapper/*/*.xml"))
+            .filter(resource -> !resource.getURL().getPath().contains("/config/"))
+            .toArray(Resource[]::new);
+        factoryBean.setMapperLocations(mapperLocations);
         return factoryBean;
     }
 }


### PR DESCRIPTION
## Summary
- MyBatis 설정 파일을 `configLocation`으로 지정하고 매퍼 경로에서 `config` 디렉터리를 제외하도록 필터링

## Testing
- `mvn -q test` *(실패: 원격 저장소 접근 불가로 부모 POM을 해석하지 못함)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f031c288832abbc4bcba57a1850a