### PR TITLE
StepBuilder에서 TransactionManager 설정 분리

### DIFF
--- a/src/main/java/egovframework/bat/erp/config/ErpRestToStgJobConfig.java
+++ b/src/main/java/egovframework/bat/erp/config/ErpRestToStgJobConfig.java
@@ -41,7 +41,8 @@ public class ErpRestToStgJobConfig {
             PlatformTransactionManager transactionManager,
             TruncateErpVehicleTasklet truncateErpVehicleTasklet) {
         return new StepBuilder("truncateErpVehicleStep").repository(jobRepository)
-                .tasklet(truncateErpVehicleTasklet, transactionManager)
+                .tasklet(truncateErpVehicleTasklet)
+                .transactionManager(transactionManager)
                 .build();
     }
 
@@ -53,7 +54,8 @@ public class ErpRestToStgJobConfig {
             PlatformTransactionManager transactionManager,
             FetchErpDataTasklet fetchErpDataTasklet) {
         return new StepBuilder("fetchErpDataStep").repository(jobRepository)
-                .tasklet(fetchErpDataTasklet, transactionManager)
+                .tasklet(fetchErpDataTasklet)
+                .transactionManager(transactionManager)
                 .build();
     }
 


### PR DESCRIPTION
## 요약
- StepBuilder에서 tasklet 설정 후 transactionManager를 분리하여 지정

## 테스트
- `mvn -q test` (네트워크 연결 문제로 실패)

------
https://chatgpt.com/codex/tasks/task_e_68b4f8e8ee74832a8090d52e101f8d10