### PR TITLE
fix: truncateStgTablesStep transactionManager 설정 방식 수정

### DIFF
--- a/src/main/java/egovframework/bat/insa/config/InsaRemote1ToStgJobConfig.java
+++ b/src/main/java/egovframework/bat/insa/config/InsaRemote1ToStgJobConfig.java
@@ -104,7 +104,8 @@ public class InsaRemote1ToStgJobConfig {
             TruncateStgTablesTasklet truncateStgTablesTasklet,
             StepCountLogger stepCountLogger) {
         return new StepBuilder("truncateStgTablesStep").repository(jobRepository)
-                .tasklet(truncateStgTablesTasklet, transactionManager)
+                .tasklet(truncateStgTablesTasklet)
+                .transactionManager(transactionManager)
                 .listener(stepCountLogger)
                 .build();
     }


### PR DESCRIPTION
## Summary
- truncateStgTablesStep에서 Tasklet과 트랜잭션 매니저 설정 분리

## Testing
- `mvn -q -e compile` *(실패: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f8ec43f0832a8a1072e742175cd7