### PR TITLE
데이터소스 사용자 계정 통일

### DIFF
--- a/src/main/resources/application/env/dev/application.yml
+++ b/src/main/resources/application/env/dev/application.yml
@@ -12,21 +12,21 @@ spring:
     migstg-mysql:
       driver-class-name: com.mysql.cj.jdbc.Driver
       url: jdbc:mysql://dev.mysql.example.com:3306/migstg?useSSL=false&serverTimezone=UTC
-      username: migdev
+      username: miguser
       password: dev!1234
 
     # 운영 서버 MySQL
     egovlocal-mysql:
       driver-class-name: com.mysql.cj.jdbc.Driver
       url: jdbc:mysql://dev.mysql.example.com:3306/egovdev?useSSL=false&serverTimezone=UTC
-      username: devuser
+      username: miguser
       password: devpass
 
     # 원격1 CUBRID
     egovremote1-cubrid:
       driver-class-name: cubrid.jdbc.driver.CUBRIDDriver
       url: "jdbc:cubrid:192.168.10.10:33000:egovremote1_dev:::"
-      username: devread
+      username: readuser
       password: devread!1234
 
 logging:

--- a/src/main/resources/application/env/prod/application.yml
+++ b/src/main/resources/application/env/prod/application.yml
@@ -12,21 +12,21 @@ spring:
     migstg-mysql:
       driver-class-name: com.mysql.cj.jdbc.Driver
       url: jdbc:mysql://prod.mysql.example.com:3306/migstg?useSSL=false&serverTimezone=UTC
-      username: migprod
+      username: miguser
       password: prod!1234
 
     # 운영 서버 MySQL
     egovlocal-mysql:
       driver-class-name: com.mysql.cj.jdbc.Driver
       url: jdbc:mysql://prod.mysql.example.com:3306/egovprod?useSSL=false&serverTimezone=UTC
-      username: produser
+      username: miguser
       password: prodpass
 
     # 원격1 CUBRID
     egovremote1-cubrid:
       driver-class-name: cubrid.jdbc.driver.CUBRIDDriver
       url: "jdbc:cubrid:192.168.20.20:33000:egovremote1_prod:::"
-      username: prodread
+      username: readuser
       password: prodread!1234
 
 logging:


### PR DESCRIPTION
## 요약
- dev/prod 환경의 datasource 사용자명을 miguser/readuser로 변경
- 기존 globals.properties는 이미 원하는 사용자명으로 설정되어 있음을 확인

## 테스트
- `mvn -q test` *(네트워크 문제로 의존성 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fbb5d1d4832ab00384c962d8216c