### PR TITLE
feat: 원격1 DB CUBRID 설정 복원

### DIFF
--- a/src/main/resources/application/env/local/application.yml
+++ b/src/main/resources/application/env/local/application.yml
@@ -24,11 +24,9 @@ spring:
 
     # 원격1 CUBRID
     egovremote1-cubrid:
-#      driver-class-name: cubrid.jdbc.driver.CUBRIDDriver
-#      url: "jdbc:cubrid:192.168.0.10:33000:egovremote1:::"
-      driver-class-name: com.mysql.cj.jdbc.Driver
-      url: jdbc:mysql://localhost:3306/migstg?useSSL=false&serverTimezone=UTC
-      username: readuser
+      driver-class-name: cubrid.jdbc.driver.CUBRIDDriver   # CUBRID JDBC 드라이버
+      url: "jdbc:cubrid:192.168.0.10:33000:egovremote1:::" # 원격1 DB 접속 URL
+      username: readuser                                  # 읽기 전용 계정
       password: read!1234
 
 logging:


### PR DESCRIPTION
## 개요
- 원격1 데이터소스의 MySQL 설정을 CUBRID 설정으로 복원

## 변경 사항
- CUBRID 드라이버와 URL로 `egovremote1` 접속 정보 수정
- `readuser` 계정 주석 추가

## 테스트
- `mvn -q test` (네트워크 문제로 부모 POM을 받지 못해 실패)
- `mvn -q spring-boot:run` (네트워크 문제로 부모 POM을 받지 못해 실패)


------
https://chatgpt.com/codex/tasks/task_e_68b5261a43f4832a8571b0b9e85b0d36