### PR TITLE
BatchManagementMapper를 STG 세션 팩토리로 제한

### DIFF
--- a/src/main/java/com/springboot/main/EgovBootApplication.java
+++ b/src/main/java/com/springboot/main/EgovBootApplication.java
@@ -37,7 +37,8 @@ import org.mybatis.spring.annotation.MapperScan;
     "classpath:/egovframework/batch/context-batch-scheduler.xml"
 })
 @ComponentScan(basePackages = {"com.springboot.main", "egovframework.bat"})
-@MapperScan("egovframework.bat.service")
+// BatchManagementMapper가 STG 데이터소스를 사용하도록 SqlSessionFactory 지정
+@MapperScan(basePackages = "egovframework.bat.service", sqlSessionFactoryRef = "sqlSessionFactory-stg")
 public class EgovBootApplication implements CommandLineRunner {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EgovBootApplication.class);

--- a/src/main/resources/egovframework/batch/context-batch-mapper.xml
+++ b/src/main/resources/egovframework/batch/context-batch-mapper.xml
@@ -13,7 +13,6 @@
             <list>
                 <value>classpath:/egovframework/batch/mapper/insa/insa_stg_to_local.xml</value>
                 <value>classpath:/egovframework/batch/mapper/erp/erp_stg_to_local.xml</value>
-                <value>classpath:/egovframework/batch/mapper/batch/BatchManagementMapper.xml</value>
             </list>
         </property>
     </bean>


### PR DESCRIPTION
## Summary
- sqlSessionFactory-local에서 BatchManagementMapper 매퍼 제거
- BatchManagementMapper가 STG SqlSessionFactory만 사용하도록 설정

## Testing
- `mvn -q test` *(실패: org.springframework.boot:spring-boot-starter-parent:pom:2.7.18: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b528c61f78832ab84b0a8f11145302