### PR TITLE
배치 실행 DTO 도입 및 서비스 변환 로직 적용

### DIFF
--- a/src/main/java/egovframework/bat/service/BatchManagementMapper.java
+++ b/src/main/java/egovframework/bat/service/BatchManagementMapper.java
@@ -3,7 +3,7 @@ package egovframework.bat.service;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
-import org.springframework.batch.core.JobExecution;
+import egovframework.bat.service.dto.JobExecutionDto;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -26,7 +26,7 @@ public interface BatchManagementMapper {
      * @param jobName 잡 이름
      * @return 실행 이력 목록
      */
-    List<JobExecution> selectJobExecutions(String jobName);
+    List<JobExecutionDto> selectJobExecutions(String jobName);
 
     /**
      * 특정 잡 실행의 에러 로그를 조회한다.

--- a/src/main/java/egovframework/bat/service/dto/JobExecutionDto.java
+++ b/src/main/java/egovframework/bat/service/dto/JobExecutionDto.java
@@ -1,0 +1,94 @@
+package egovframework.bat.service.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 배치 잡 실행 정보를 담는 DTO.
+ */
+public class JobExecutionDto {
+
+    // 실행 ID
+    private Long id;
+    // 시작 시간
+    private LocalDateTime startTime;
+    // 종료 시간
+    private LocalDateTime endTime;
+    // 실행 상태
+    private String status;
+    // 종료 코드
+    private String exitCode;
+    // 종료 메시지
+    private String exitDescription;
+    // 생성 시간
+    private LocalDateTime createTime;
+    // 최종 수정 시간
+    private LocalDateTime lastUpdated;
+
+    /** 기본 생성자 */
+    public JobExecutionDto() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getExitCode() {
+        return exitCode;
+    }
+
+    public void setExitCode(String exitCode) {
+        this.exitCode = exitCode;
+    }
+
+    public String getExitDescription() {
+        return exitDescription;
+    }
+
+    public void setExitDescription(String exitDescription) {
+        this.exitDescription = exitDescription;
+    }
+
+    public LocalDateTime getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(LocalDateTime createTime) {
+        this.createTime = createTime;
+    }
+
+    public LocalDateTime getLastUpdated() {
+        return lastUpdated;
+    }
+
+    public void setLastUpdated(LocalDateTime lastUpdated) {
+        this.lastUpdated = lastUpdated;
+    }
+}

--- a/src/main/resources/egovframework/batch/mapper/batch/BatchManagementMapper.xml
+++ b/src/main/resources/egovframework/batch/mapper/batch/BatchManagementMapper.xml
@@ -12,13 +12,13 @@
     </select>
 
     <!-- 특정 잡의 실행 이력 조회 -->
-    <resultMap id="jobExecutionMap" type="org.springframework.batch.core.JobExecution">
+    <resultMap id="jobExecutionMap" type="egovframework.bat.service.dto.JobExecutionDto">
         <id property="id" column="JOB_EXECUTION_ID"/>
         <result property="startTime" column="START_TIME"/>
         <result property="endTime" column="END_TIME"/>
         <result property="status" column="STATUS"/>
-        <result property="exitStatus.exitCode" column="EXIT_CODE"/>
-        <result property="exitStatus.exitDescription" column="EXIT_MESSAGE"/>
+        <result property="exitCode" column="EXIT_CODE"/>
+        <result property="exitDescription" column="EXIT_MESSAGE"/>
         <result property="createTime" column="CREATE_TIME"/>
         <result property="lastUpdated" column="LAST_UPDATED"/>
     </resultMap>

--- a/src/test/java/egovframework/bat/service/BatchManagementServiceTest.java
+++ b/src/test/java/egovframework/bat/service/BatchManagementServiceTest.java
@@ -1,6 +1,7 @@
 package egovframework.bat.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -11,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import egovframework.bat.service.dto.JobExecutionDto;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.launch.JobOperator;
 
@@ -45,12 +47,18 @@ public class BatchManagementServiceTest {
 
     @Test
     public void getJobExecutionsReturnsMapperResult() {
-        List<JobExecution> executions = Arrays.asList(new JobExecution(1L), new JobExecution(2L));
-        when(batchManagementMapper.selectJobExecutions("job")).thenReturn(executions);
+        JobExecutionDto dto = new JobExecutionDto();
+        dto.setId(1L);
+        dto.setStatus("COMPLETED");
+        when(batchManagementMapper.selectJobExecutions("job")).thenReturn(Arrays.asList(dto));
 
         List<JobExecution> result = batchManagementService.getJobExecutions("job");
 
-        assertEquals(executions, result);
+        assertEquals(1, result.size());
+        JobExecution execution = result.get(0);
+        assertNotNull(execution);
+        assertEquals(Long.valueOf(1L), execution.getId());
+        assertEquals("COMPLETED", execution.getStatus().toString());
     }
 
     @Test


### PR DESCRIPTION
## 요약
- 배치 실행 정보를 담는 JobExecutionDto 추가
- MyBatis 매핑과 매퍼 인터페이스를 DTO 기반으로 수정
- 서비스에서 DTO를 JobExecution으로 변환하도록 로직 보강
- 관련 단위 테스트 업데이트

## 테스트
- `mvn -q test` (실패: parent POM을 해석하지 못함)

------
https://chatgpt.com/codex/tasks/task_e_68b531ddc3f0832ab7206bbdad553fa8