### PR TITLE
FetchErpDataTasklet에서 Globals 주석 제거

### DIFF
--- a/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
+++ b/src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java
@@ -48,7 +48,6 @@ public class FetchErpDataTasklet implements Tasklet {
                                @Qualifier("migstgJdbcTemplate") JdbcTemplate jdbcTemplate,
                                List<NotificationSender> notificationSenders,
                                @Value("${erp.api-url}") String apiUrl) {
-                               //@Value("${Globals.Erp.ApiUrl}") String apiUrl) {
         // WebClient 생성
         this.webClient = builder.build();
         this.jdbcTemplate = jdbcTemplate;


### PR DESCRIPTION
## Summary
- FetchErpDataTasklet 생성자에서 불필요한 `Globals.Erp.ApiUrl` 주석 제거
- `Globals.*` 키워드 검색을 통해 잔존 사용 사례 미발견 확인

## Testing
- `mvn test` *(네트워크 문제로 의존성 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68b5346136fc832abaa7142def2b616a