### PR TITLE
배치 상세에 시작/종료 시간 표시

### DIFF
--- a/src/main/resources/static/js/batch-detail.js
+++ b/src/main/resources/static/js/batch-detail.js
@@ -21,14 +21,28 @@ document.addEventListener('DOMContentLoaded', () => {
         const items = executions.slice(start, start + size);
         items.forEach(exec => {
             const tr = document.createElement('tr');
+
+            // 실행 ID 출력
             const idTd = document.createElement('td');
             idTd.textContent = exec.jobExecutionId || '';
             tr.appendChild(idTd);
 
+            // 상태 출력
             const statusTd = document.createElement('td');
             statusTd.appendChild(renderStatus(exec.status));
             tr.appendChild(statusTd);
 
+            // 시작 시간 출력
+            const startTd = document.createElement('td');
+            startTd.textContent = exec.startTime ? new Date(exec.startTime).toLocaleString() : '-';
+            tr.appendChild(startTd);
+
+            // 종료 시간 출력
+            const endTd = document.createElement('td');
+            endTd.textContent = exec.endTime ? new Date(exec.endTime).toLocaleString() : '-';
+            tr.appendChild(endTd);
+
+            // 액션 버튼들 출력 (재시작/중지/로그)
             const actionTd = document.createElement('td');
             const restartBtn = document.createElement('button');
             restartBtn.textContent = '재시작';

--- a/src/main/resources/templates/batch/detail.html
+++ b/src/main/resources/templates/batch/detail.html
@@ -14,6 +14,8 @@
             <tr>
                 <th>ID</th>
                 <th data-i18n="batch.label.status">상태</th>
+                <th>시작 시간</th>
+                <th>종료 시간</th>
                 <th data-i18n="batch.label.actions">액션</th>
             </tr>
         </thead>


### PR DESCRIPTION
## 변경 사항
- 배치 실행 목록에 시작/종료 시간 열 추가
- 실행 시간 표시 및 포맷 처리

## 테스트
- `mvn -q test` (네트워크 오류로 실패)

------
https://chatgpt.com/codex/tasks/task_e_68b5413f4294832aae9db6e5a5e380df