### PR TITLE
배치 목록에 실행 시간 열 추가

### DIFF
--- a/src/main/resources/static/css/batch.css
+++ b/src/main/resources/static/css/batch.css
@@ -15,3 +15,8 @@ th, td {
 .status-failed { color: red; }
 .status-started { color: blue; }
 .status-stopped { color: gray; }
+
+/* 시간 열 폭 조정 */
+th.time-column, td.time-column {
+    width: 20%;
+}

--- a/src/main/resources/static/js/batch-list.js
+++ b/src/main/resources/static/js/batch-list.js
@@ -31,19 +31,40 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const statusTd = document.createElement('td');
             statusTd.textContent = '조회중';
-            // 실행 이력 조회 후 상태 표시
+            tr.appendChild(statusTd);
+
+            // 최근 실행의 시작/종료 시간 셀 추가
+            const startTd = document.createElement('td');
+            startTd.textContent = '조회중';
+            startTd.classList.add('time-column');
+            tr.appendChild(startTd);
+
+            const endTd = document.createElement('td');
+            endTd.textContent = '조회중';
+            endTd.classList.add('time-column');
+            tr.appendChild(endTd);
+
+            // 실행 이력 조회 후 상태와 시간 표시
             fetch(`/api/batch/management/jobs/${jobName}/executions`)
                 .then(res => res.json())
                 .then(exec => {
                     if (exec.length > 0) {
+                        const latest = exec[0];
                         statusTd.textContent = '';
-                        statusTd.appendChild(renderStatus(exec[0].status));
+                        statusTd.appendChild(renderStatus(latest.status));
+                        startTd.textContent = latest.startTime ? new Date(latest.startTime).toLocaleString() : '-';
+                        endTd.textContent = latest.endTime ? new Date(latest.endTime).toLocaleString() : '-';
                     } else {
                         statusTd.textContent = '-';
+                        startTd.textContent = '-';
+                        endTd.textContent = '-';
                     }
                 })
-                .catch(() => statusTd.textContent = '-');
-            tr.appendChild(statusTd);
+                .catch(() => {
+                    statusTd.textContent = '-';
+                    startTd.textContent = '-';
+                    endTd.textContent = '-';
+                });
 
             const actionTd = document.createElement('td');
             const detailBtn = document.createElement('a');

--- a/src/main/resources/templates/batch/list.html
+++ b/src/main/resources/templates/batch/list.html
@@ -18,6 +18,8 @@
             <tr>
                 <th data-i18n="batch.label.jobName">잡 이름</th>
                 <th data-i18n="batch.label.status">상태</th>
+                <th data-i18n="batch.label.startTime" class="time-column">시작 시간</th>
+                <th data-i18n="batch.label.endTime" class="time-column">종료 시간</th>
                 <th data-i18n="batch.label.actions">액션</th>
             </tr>
         </thead>


### PR DESCRIPTION
## 요약
- 배치 목록 테이블에 시작/종료 시간 열을 추가했습니다.
- 최근 실행 정보를 가져와 상태와 함께 시작/종료 시간을 표시하도록 JS를 수정했습니다.
- 시간 열의 가독성을 위해 CSS 폭을 조정했습니다.

## 테스트
- `mvn -q test` *(실패: 네트워크 연결 불가로 의존성을 받지 못함)*

------
https://chatgpt.com/codex/tasks/task_e_68b5413839e4832a95be0bfffc44fb19