### PR TITLE
테스트에서 ObjectMapper 주입 추가

### DIFF
--- a/src/test/java/egovframework/bat/erp/tasklet/FetchErpDataTaskletTest.java
+++ b/src/test/java/egovframework/bat/erp/tasklet/FetchErpDataTaskletTest.java
@@ -1,5 +1,6 @@
 package egovframework.bat.erp.tasklet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import egovframework.bat.notification.NotificationSender;
 import java.util.Collections;
 import java.util.List;
@@ -36,7 +37,8 @@ public class FetchErpDataTaskletTest {
         };
 
         List<NotificationSender> senders = Collections.emptyList();
-        FetchErpDataTasklet tasklet = new FetchErpDataTasklet(builder, jdbcTemplate, senders, "http://example.com");
+        // ObjectMapper를 추가한 생성자 호출
+        FetchErpDataTasklet tasklet = new FetchErpDataTasklet(builder, jdbcTemplate, senders, new ObjectMapper(), "http://example.com");
 
         RepeatStatus status = tasklet.execute(null, null);
         assertEquals(RepeatStatus.FINISHED, status);
@@ -62,7 +64,8 @@ public class FetchErpDataTaskletTest {
         when(jdbcTemplate.update(anyString(), any(), any())).thenReturn(1);
 
         List<NotificationSender> senders = Collections.emptyList();
-        FetchErpDataTasklet tasklet = new FetchErpDataTasklet(builder, jdbcTemplate, senders, "http://example.com");
+        // ObjectMapper를 추가한 생성자 호출
+        FetchErpDataTasklet tasklet = new FetchErpDataTasklet(builder, jdbcTemplate, senders, new ObjectMapper(), "http://example.com");
 
         RepeatStatus status = tasklet.execute(null, null);
 


### PR DESCRIPTION
## 요약
- FetchErpDataTaskletTest에 ObjectMapper 파라미터 추가
- ObjectMapper 임포트 및 생성자 호출 수정

## 테스트
- ⚠️ `mvn -q test` (네트워크 문제로 의존성 해결 실패)

------
https://chatgpt.com/codex/tasks/task_e_68b7cded8388832a934384c64c631db3