### PR TITLE
feat: add ERP local to REST job

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,24 +139,29 @@ public class SampleTasklet implements Tasklet {
 
 ## ERP 배치 Job 구성(`erp`)
 
-`src/main/java/egovframework/bat/erp/config` 디렉터리는 ERP 관련 배치 Job 설정 클래스를 모아둔 곳입니다. 현재 포함된 Job은 다음과 같습니다.
+`src/main/java/egovframework/bat/erp/config` 디렉터리는 ERP 관련 배치 Job 설정 클래스를 모아둔 곳입니다. ERP 배치는 외부 시스템과의 양방향 연계를 지원합니다.
 
-- `erpRestToStgJob`
-- `erpStgToLocalJob`
+- 외부 → 내부: `erpRestToStgJob`, `erpStgToLocalJob`
+  - 외부 ERP REST API에서 데이터를 받아 STG를 거쳐 로컬 DB에 적재합니다.
+- 내부 → 외부: `erpLocalToRestJob`
+  - 로컬 DB에 있는 ERP 데이터를 외부 REST API로 전송합니다.
 
 다음은 관련된 주요 파일들입니다.
 
 - 잡 설정:
   - `src/main/java/egovframework/bat/erp/config/ErpRestToStgJobConfig.java`: ERP REST API에서 데이터를 조회하여 STG에 적재하는 Job 설정 클래스
   - `src/main/java/egovframework/bat/erp/config/ErpStgToLocalJobConfig.java`: STG에 적재된 ERP 데이터를 로컬 DB로 이관하는 Job 설정 클래스
+  - `src/main/java/egovframework/bat/erp/config/ErpLocalToRestJobConfig.java`: 로컬 DB 데이터를 외부 ERP API로 전송하는 Job 설정 클래스
 - 매퍼 파일:
   - `src/main/resources/egovframework/batch/mapper/erp/erp_rest_to_stg.xml`: ERP REST 데이터→STG 적재를 위한 SQL 매퍼
   - `src/main/resources/egovframework/batch/mapper/erp/erp_stg_to_local.xml`: STG→로컬 데이터 이동을 위한 SQL 매퍼
 - 공통, 도메인 및 유틸 클래스:
   - `src/main/java/egovframework/bat/erp/tasklet/FetchErpDataTasklet.java`: ERP 시스템에서 차량 정보를 조회하여 STG에 적재하는 Tasklet
+  - `src/main/java/egovframework/bat/erp/tasklet/SendErpDataTasklet.java`: 로컬 DB의 ERP 데이터를 외부 REST API로 전송하는 Tasklet
   - `src/main/java/egovframework/bat/erp/processor/VehicleInfoProcessor.java`: ERP 차량 정보를 처리하는 배치 프로세서
   - `src/main/java/egovframework/bat/erp/domain/VehicleInfo.java`: ERP 차량 정보를 담는 도메인 클래스
   - `src/main/java/egovframework/bat/erp/api/RestToStgJobController.java`: ERP REST 배치를 수동 실행하는 컨트롤러
+  - `src/main/java/egovframework/bat/erp/api/LocalToRestJobController.java`: 로컬→REST 배치를 수동 실행하는 컨트롤러
 
 ## 예제 배치 Job 구성(`example`)
 
@@ -185,7 +190,14 @@ public class SampleTasklet implements Tasklet {
 - **파라미터**: 없음
 - **응답**: 실행 결과 `BatchStatus`
 
+`LocalToRestJobController`를 통해 로컬 데이터를 ERP API로 전송하는 배치를 실행할 수 있습니다.
+
+- **URL**: `POST /api/batch/erp-local-to-rest`
+- **파라미터**: 없음
+- **응답**: 실행 결과 `BatchStatus`
+
 ### 인사 배치 잡 실행 API
+
 
 `insaRemote1ToStgJob`을 REST로 호출할 수 있습니다.
 

--- a/src/main/java/egovframework/bat/erp/api/LocalToRestJobController.java
+++ b/src/main/java/egovframework/bat/erp/api/LocalToRestJobController.java
@@ -1,0 +1,78 @@
+package egovframework.bat.erp.api;
+
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import egovframework.bat.management.JobProgressService;
+import egovframework.bat.service.JobLockService;
+
+/**
+ * 로컬 DB의 ERP 데이터를 외부 REST API로 전송하는 배치 잡을 수동 실행하기 위한 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api/batch")
+@RequiredArgsConstructor
+public class LocalToRestJobController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LocalToRestJobController.class);
+
+    // 배치 잡 실행기
+    private final JobLauncher jobLauncher;
+
+    // 로컬→REST 전송 잡
+    private final Job erpLocalToRestJob;
+
+    // 중복 실행 방지 서비스
+    private final JobLockService jobLockService;
+
+    // 진행 상황 전송 서비스
+    private final JobProgressService jobProgressService;
+
+    /**
+     * 로컬 ERP 데이터를 외부 REST API로 전송하는 배치 잡을 실행한다.
+     *
+     * @return 배치 잡 실행 결과 상태
+     */
+    @PostMapping("/erp-local-to-rest")
+    public ResponseEntity<BatchStatus> runErpLocalToRestJob() {
+        LOGGER.info("ERP 로컬→REST 배치 실행 요청 수신");
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+
+        try {
+            String jobName = erpLocalToRestJob.getName();
+            if (!jobLockService.tryLock(jobName)) {
+                LOGGER.warn("{} 작업이 이미 실행 중", jobName);
+                return ResponseEntity.status(HttpStatus.CONFLICT).body(BatchStatus.FAILED);
+            }
+            jobProgressService.send(jobName, "STARTED");
+            try {
+                JobExecution execution = jobLauncher.run(erpLocalToRestJob, jobParameters);
+                LOGGER.info("ERP 로컬→REST 배치 실행 완료: {}", execution.getStatus());
+                jobProgressService.send(jobName, execution.getStatus().toString());
+                return ResponseEntity.ok(execution.getStatus());
+            } finally {
+                jobLockService.unlock(jobName);
+            }
+        } catch (Exception e) {
+            LOGGER.error("ERP 로컬→REST 배치 실행 실패", e);
+            jobProgressService.send("erpLocalToRestJob", "FAILED");
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(BatchStatus.FAILED);
+        }
+    }
+}
+

--- a/src/main/java/egovframework/bat/erp/config/ErpLocalToRestJobConfig.java
+++ b/src/main/java/egovframework/bat/erp/config/ErpLocalToRestJobConfig.java
@@ -1,0 +1,43 @@
+package egovframework.bat.erp.config;
+
+import egovframework.bat.erp.tasklet.SendErpDataTasklet;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * 로컬 DB의 ERP 데이터를 외부 REST API로 전송하는 잡 구성.
+ */
+@Configuration
+public class ErpLocalToRestJobConfig {
+
+    /**
+     * 로컬 데이터를 외부 ERP로 전송하는 스텝 정의.
+     */
+    @Bean
+    public Step sendErpDataStep(JobRepository jobRepository,
+                                PlatformTransactionManager transactionManager,
+                                SendErpDataTasklet sendErpDataTasklet) {
+        return new StepBuilder("sendErpDataStep").repository(jobRepository)
+                .tasklet(sendErpDataTasklet)
+                .transactionManager(transactionManager)
+                .build();
+    }
+
+    /**
+     * 단일 스텝으로 구성된 로컬→ERP 전송 잡 정의.
+     */
+    @Bean
+    public Job erpLocalToRestJob(JobRepository jobRepository,
+                                 Step sendErpDataStep) {
+        return new JobBuilder("erpLocalToRestJob").repository(jobRepository)
+                .start(sendErpDataStep)
+                .build();
+    }
+}
+

--- a/src/main/java/egovframework/bat/erp/tasklet/SendErpDataTasklet.java
+++ b/src/main/java/egovframework/bat/erp/tasklet/SendErpDataTasklet.java
@@ -1,0 +1,66 @@
+package egovframework.bat.erp.tasklet;
+
+import egovframework.bat.erp.domain.VehicleInfo;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * 로컬 DB의 ERP 데이터를 외부 REST API로 전송하는 Tasklet.
+ */
+@Component
+public class SendErpDataTasklet implements Tasklet {
+
+    /** 로거 */
+    private static final Logger LOGGER = LoggerFactory.getLogger(SendErpDataTasklet.class);
+
+    /** 로컬 DB 접근용 JdbcTemplate */
+    private final JdbcTemplate jdbcTemplate;
+
+    /** 비동기 호출을 위한 WebClient */
+    private final WebClient webClient;
+
+    /** 전송 대상 ERP API URL */
+    private final String apiUrl;
+
+    public SendErpDataTasklet(
+            @Qualifier("jdbcTemplateLocal") JdbcTemplate jdbcTemplate,
+            WebClient.Builder builder,
+            @Value("${erp.api-url}") String apiUrl) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.webClient = builder.build();
+        this.apiUrl = apiUrl;
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        LOGGER.info("로컬 ERP 데이터 전송 시작");
+        // 1. 로컬 DB에서 차량 정보 조회
+        List<VehicleInfo> vehicles = jdbcTemplate.query(
+                "SELECT VEHICLE_ID, MODEL, MANUFACTURER, PRICE, REG_DTTM, MOD_DTTM FROM miglocal.erp_vehicle",
+                new BeanPropertyRowMapper<>(VehicleInfo.class)
+        );
+        // 2. 조회된 데이터를 외부 ERP API로 전송
+        for (VehicleInfo vehicle : vehicles) {
+            webClient.post()
+                    .uri(apiUrl)
+                    .bodyValue(vehicle)
+                    .retrieve()
+                    .bodyToMono(Void.class)
+                    .block(); // 배치 특성상 동기 처리
+        }
+        LOGGER.info("총 {}건의 데이터를 전송 완료", vehicles.size());
+        return RepeatStatus.FINISHED;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add SendErpDataTasklet to push local ERP data to external API
- configure ErpLocalToRestJob and REST controller for manual triggering
- document ERP batch directions and new endpoint in README

## Testing
- `mvn -DskipTests package` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b9556d8cd0832a883bb156b1a33adc