### PR TITLE
docs: README에 API 엔드포인트 목록 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,32 @@ public class SampleTasklet implements Tasklet {
 - **파라미터**: `sourceSystem` (선택)
 - **응답**: 실행 결과 `BatchStatus`
 
+## API 엔드포인트
+
+| 메서드 | URL | 설명 |
+| --- | --- | --- |
+| `GET` | `/api/batch/jobs` | 등록된 배치 작업 목록 조회 |
+| `POST` | `/api/batch/executions/{execId}/restart` | 지정 실행 ID의 배치 재시작 |
+| `GET` | `/api/batch/executions/{execId}` | 특정 실행 ID 상세 조회 |
+| `GET` | `/api/batch/error-log` | 배치 에러 로그 조회 |
+| `GET` | `/api/batch/jobs/{jobName}/executions` | 특정 작업의 실행 이력 조회 |
+| `DELETE` | `/api/batch/executions/{execId}` | 실행 중인 배치 중지 |
+| `POST` | `/api/batch/erp-rest-to-stg` | ERP REST → STG 전송 배치 실행 |
+| `GET` | `/api/v1/vehicles` | 차량 목록 조회 |
+| `POST` | `/api/batch/mybatis` | MyBatis 기반 배치 실행 |
+| `POST` | `/api/batch/remote1-to-stg` | Remote1 → STG 전송 배치 실행 |
+| `POST` | `/api/batch/management/executions/{jobExecutionId}/restart` | 관리용 배치 재시작 |
+| `GET` | `/api/batch/management/jobs` | 관리용 배치 작업명 목록 |
+| `GET` | `/api/batch/management/executions/{jobExecutionId}/errors` | 특정 실행 ID 에러 로그 조회 |
+| `GET` | `/api/batch/management/jobs/{jobName}/executions` | 관리용 작업 실행 이력 조회 |
+| `POST` | `/api/batch/management/executions/{jobExecutionId}/stop` | 관리용 실행 중지 |
+| `GET` | `/api/batch/progress` (SSE) | 배치 진행 상태 스트림 |
+| `GET` | `/batch/detail` | 배치 상세 페이지 |
+| `GET` | `/batch/list` | 배치 목록 페이지 |
+| `GET` | `/error` | 오류 페이지 |
+
+더 자세한 설명은 각 컨트롤러 소스 코드를 참고하세요.
+
 ## 완전 새로운 배치 작업 추가시 매뉴얼
 
 1. Job 설정 클래스 작성: `src/main/java/egovframework/bat/crm/config/NewcrmJobConfig.java` - 새 작업의 단계와 흐름을 정의합니다.


### PR DESCRIPTION
## 요약
- README에 `API 엔드포인트` 섹션을 신설하여 주요 배치 및 관리용 API를 정리했습니다.

## 테스트
- `mvn test` 실행 시 네트워크 문제로 의존성 다운로드 실패

------
https://chatgpt.com/codex/tasks/task_e_68ba38be59f0832a9c5b89f05b1584d3