### PR TITLE
로그가 없을 때 안내 문구 표시

### DIFF
--- a/src/main/resources/static/js/batch-log.js
+++ b/src/main/resources/static/js/batch-log.js
@@ -5,6 +5,11 @@ document.addEventListener('DOMContentLoaded', () => {
     fetch(`/api/batch/management/executions/${id}/errors`)
         .then(res => res.json())
         .then(lines => {
-            container.textContent = lines.join('\n');
+            // 에러 로그가 없는지 확인
+            if (lines.length === 0) {
+                container.textContent = '에러 로그가 없습니다.';
+            } else {
+                container.textContent = lines.join('\n');
+            }
         });
 });


### PR DESCRIPTION
## Summary
- 배치 에러 로그가 없을 경우 안내 문구를 표시하도록 개선

## Testing
- `mvn test` *(실패: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68ba40f7f618832a90ab074a5225dab9