### PR TITLE
조회 ID 미존재 시 에러 로그 조회 방어 로직 추가

### DIFF
--- a/src/main/java/egovframework/bat/management/api/BatchManagementController.java
+++ b/src/main/java/egovframework/bat/management/api/BatchManagementController.java
@@ -2,6 +2,7 @@ package egovframework.bat.management.api;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -75,7 +76,11 @@ public class BatchManagementController {
      * @return 에러 로그 목록
      */
     @GetMapping("/executions/{jobExecutionId}/errors")
-    public ResponseEntity<List<String>> getErrorLogs(@PathVariable Long jobExecutionId) {
+    public ResponseEntity<List<String>> getErrorLogs(@PathVariable(required = false) Long jobExecutionId) {
+        // jobExecutionId가 없으면 빈 리스트 반환
+        if (jobExecutionId == null) {
+            return ResponseEntity.ok(Collections.emptyList());
+        }
         return ResponseEntity.ok(batchManagementService.getErrorLogs(jobExecutionId));
     }
 

--- a/src/main/resources/static/js/batch-log.js
+++ b/src/main/resources/static/js/batch-log.js
@@ -2,6 +2,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const params = new URLSearchParams(location.search);
     const id = params.get('executionId');
     const container = document.getElementById('logContainer');
+    // id가 없으면 조회된 내용이 없다고 표시하고 서버 호출을 하지 않음
+    if (!id) {
+        container.textContent = '조회된 내용이 없습니다';
+        return;
+    }
     fetch(`/api/batch/management/executions/${id}/errors`)
         .then(res => res.json())
         .then(lines => {


### PR DESCRIPTION
## Summary
- ID가 없을 때 프런트엔드에서 조회 중단 및 안내 문구 출력
- jobExecutionId가 없으면 서버에서 빈 리스트 반환

## Testing
- `mvn -q test` *(실패: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4163122c832aa4d4d29eaede5025