### PR TITLE
배치 로그 조회 오류 처리 개선

### DIFF
--- a/src/main/resources/static/js/batch-log.js
+++ b/src/main/resources/static/js/batch-log.js
@@ -8,13 +8,19 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
     }
     fetch(`/api/batch/management/executions/${id}/errors`)
-        .then(res => res.json())
-        .then(lines => {
-            // 에러 로그가 없는지 확인
-            if (lines.length === 0) {
-                container.textContent = '에러 로그가 없습니다.';
-            } else {
-                container.textContent = lines.join('\n');
+        .then(res => {
+            // 응답 상태가 성공인지 확인
+            if (!res.ok) {
+                throw new Error();
             }
+            return res.json();
+        })
+        .then(lines => {
+            // 조회된 내용이 있는지 확인
+            container.textContent = lines.length ? lines.join('\n') : '조회된 내용이 없습니다';
+        })
+        .catch(() => {
+            // 요청 실패 시에도 동일한 메시지 표시
+            container.textContent = '조회된 내용이 없습니다';
         });
 });


### PR DESCRIPTION
## 요약
- fetch 응답 상태 확인 후 실패 시 예외 발생
- 로그 데이터 없거나 요청 실패 시 안내 메시지 표시

## 테스트
- `mvn -q test` *(실패: 의존성 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68ba41fd541c832abfeb286c77d96c21