### PR TITLE
로그 조회 시 공백 라인 제거 및 빈 결과 안내

### DIFF
--- a/src/main/resources/static/js/batch-log.js
+++ b/src/main/resources/static/js/batch-log.js
@@ -16,8 +16,9 @@ document.addEventListener('DOMContentLoaded', () => {
             return res.json();
         })
         .then(lines => {
-            // 조회된 내용이 있는지 확인
-            container.textContent = lines.length ? lines.join('\n') : '조회된 내용이 없습니다';
+            // 공백 행을 제거한 후 조회된 내용이 있는지 확인
+            const filteredLines = lines.filter(line => line.trim() !== '');
+            container.textContent = filteredLines.length ? filteredLines.join('\n') : '조회된 내용이 없습니다';
         })
         .catch(() => {
             // 요청 실패 시에도 동일한 메시지 표시


### PR DESCRIPTION
## 요약
- 오류 로그에서 공백 라인 제거 후 표시
- 조회 결과가 없을 경우 안내 메시지 출력

## 테스트
- `mvn -q test` (네트워크 문제로 실패: Non-resolvable parent POM)

------
https://chatgpt.com/codex/tasks/task_e_68ba4a1ad100832aa4a302c8dc6bf0bb