### PR TITLE
RestToStgJobController에 Job Qualifier 명시

### DIFF
--- a/src/main/java/egovframework/bat/job/erp/api/RestToStgJobController.java
+++ b/src/main/java/egovframework/bat/job/erp/api/RestToStgJobController.java
@@ -9,6 +9,7 @@ import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,6 +33,7 @@ public class RestToStgJobController {
     private final JobLauncher jobLauncher;
 
     // ERP REST 데이터를 STG 테이블에 적재하는 배치 잡
+    @Qualifier("erpRestToStgJob")
     private final Job erpRestToStgJob;
 
     // 중복 실행 방지를 위한 락 서비스


### PR DESCRIPTION
## Summary
- RestToStgJobController에 `@Qualifier("erpRestToStgJob")` 추가하여 Job 빈을 명확히 주입

## Testing
- `mvn -q -e test` *(실패: 네트워크에 연결할 수 없어 parent POM을 해석하지 못함)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8a463e40832a968167924b563982