### PR TITLE
ERP STG→REST 잡 실행 로직 단순화

### DIFF
--- a/src/main/java/egovframework/bat/job/erp/api/StgToRestJobController.java
+++ b/src/main/java/egovframework/bat/job/erp/api/StgToRestJobController.java
@@ -1,7 +1,5 @@
 package egovframework.bat.job.erp.api;
 
-import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.BatchStatus;
@@ -36,9 +34,6 @@ public class StgToRestJobController {
     @Qualifier("erpStgToRestJob")
     private final Job erpStgToRestJob;
 
-    /** 여러 잡을 이름으로 주입받기 위한 맵 */
-    private final Map<String, Job> jobs;
-
     /**
      * ERP STG 데이터를 외부 REST API로 전송하는 잡을 실행한다.
      *
@@ -51,8 +46,8 @@ public class StgToRestJobController {
             .addLong("timestamp", System.currentTimeMillis())
             .toJobParameters();
         try {
-            Job job = jobs.getOrDefault("erpStgToRestJob", erpStgToRestJob);
-            JobExecution execution = jobLauncher.run(job, jobParameters);
+            // 주입된 잡 실행
+            JobExecution execution = jobLauncher.run(erpStgToRestJob, jobParameters);
             LOGGER.info("ERP STG→REST 배치 실행 완료: {}", execution.getStatus());
             return ResponseEntity.ok(execution.getStatus());
         } catch (Exception e) {


### PR DESCRIPTION
## 요약
- StgToRestJobController에서 잡 맵 의존성 제거
- runErpStgToRestJob에서 주입된 `erpStgToRestJob`만 실행하도록 수정

## 테스트
- `mvn -q test` *(네트워크 연결 불가로 부모 POM을 가져오지 못해 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9e8e4ccc832aba4fa88c03b14721