### PR TITLE
JobOperator 제거 및 JobLauncher 기반 배치 관리 전환

### DIFF
--- a/src/main/java/egovframework/bat/api/BatchApiController.java
+++ b/src/main/java/egovframework/bat/api/BatchApiController.java
@@ -89,28 +89,27 @@ public class BatchApiController {
     }
 
     /**
-     * 실패한 잡 실행을 재시작한다.
+     * 주어진 잡을 재시작한다.
      *
-     * @param execId 재실행할 잡 실행 ID
+     * @param jobName 재실행할 잡 이름
      * @return 성공 여부
-     * @throws Exception JobOperator에서 발생한 예외
+     * @throws Exception 잡 실행 중 예외 발생 시
      */
-    @PostMapping("/executions/{execId}/restart")
-    public ResponseEntity<Void> restart(@PathVariable Long execId) throws Exception {
-        batchManagementService.restart(execId);
+    @PostMapping("/jobs/{jobName}/restart")
+    public ResponseEntity<Void> restart(@PathVariable String jobName) throws Exception {
+        batchManagementService.restart(jobName);
         return ResponseEntity.ok().build();
     }
 
     /**
      * 실행 중인 잡을 중지한다.
      *
-     * @param execId 중지할 잡 실행 ID
+     * @param jobName 중지할 잡 이름
      * @return 성공 여부
-     * @throws Exception JobOperator에서 발생한 예외
      */
-    @DeleteMapping("/executions/{execId}")
-    public ResponseEntity<Void> stop(@PathVariable Long execId) throws Exception {
-        batchManagementService.stop(execId);
+    @DeleteMapping("/jobs/{jobName}")
+    public ResponseEntity<Void> stop(@PathVariable String jobName) {
+        batchManagementService.stop(jobName);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/egovframework/bat/config/BatchJobLauncherConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchJobLauncherConfig.java
@@ -2,19 +2,13 @@ package egovframework.bat.config;
 
 import javax.sql.DataSource;
 
-import org.egovframe.rte.bat.core.launch.support.EgovBatchRunner;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
-import org.springframework.batch.core.configuration.support.JobRegistryBeanPostProcessor;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.explore.support.JobExplorerFactoryBean;
 import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.batch.core.launch.JobOperator;
 import org.springframework.batch.core.launch.support.SimpleJobLauncher;
-import org.springframework.batch.core.launch.support.SimpleJobOperator;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
-import org.springframework.batch.core.configuration.JobRegistry;
-import org.springframework.batch.core.configuration.support.MapJobRegistry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportResource;
@@ -33,15 +27,6 @@ import org.springframework.transaction.PlatformTransactionManager;
 public class BatchJobLauncherConfig {
 
     /**
-     * 배치 실행을 돕는 러너 빈 정의
-     */
-    @Bean
-    public EgovBatchRunner eGovBatchRunner(JobOperator jobOperator,
-            JobExplorer jobExplorer, JobRepository jobRepository) {
-        return new EgovBatchRunner(jobOperator, jobExplorer, jobRepository);
-    }
-
-    /**
      * 단순 잡 런처 설정
      */
     @Bean
@@ -49,16 +34,6 @@ public class BatchJobLauncherConfig {
         SimpleJobLauncher launcher = new SimpleJobLauncher();
         launcher.setJobRepository(jobRepository);
         return launcher;
-    }
-
-    /**
-     * 잡 레지스트리 후처리기 등록
-     */
-    @Bean
-    public JobRegistryBeanPostProcessor jobRegistryBeanPostProcessor(JobRegistry jobRegistry) {
-        JobRegistryBeanPostProcessor processor = new JobRegistryBeanPostProcessor();
-        processor.setJobRegistry(jobRegistry);
-        return processor;
     }
 
     /**
@@ -77,20 +52,6 @@ public class BatchJobLauncherConfig {
     }
 
     /**
-     * 잡 오퍼레이터 설정
-     */
-    @Bean
-    public JobOperator jobOperator(JobLauncher jobLauncher, JobExplorer jobExplorer,
-            JobRepository jobRepository, JobRegistry jobRegistry) {
-        SimpleJobOperator operator = new SimpleJobOperator();
-        operator.setJobLauncher(jobLauncher);
-        operator.setJobExplorer(jobExplorer);
-        operator.setJobRepository(jobRepository);
-        operator.setJobRegistry(jobRegistry);
-        return operator;
-    }
-
-    /**
      * 잡 탐색기 설정
      */
     @Bean
@@ -99,14 +60,6 @@ public class BatchJobLauncherConfig {
         factory.setDataSource(dataSource);
         factory.afterPropertiesSet();
         return factory.getObject();
-    }
-
-    /**
-     * 잡 레지스트리 빈 정의
-     */
-    @Bean
-    public JobRegistry jobRegistry() {
-        return new MapJobRegistry();
     }
 
     /**

--- a/src/main/java/egovframework/bat/management/api/BatchManagementController.java
+++ b/src/main/java/egovframework/bat/management/api/BatchManagementController.java
@@ -85,28 +85,27 @@ public class BatchManagementController {
     }
 
     /**
-     * 실패한 잡 실행을 재실행한다.
+     * 실패한 잡을 재실행한다.
      *
-     * @param jobExecutionId 잡 실행 ID
+     * @param jobName 잡 이름
      * @return 처리 결과
      * @throws Exception 재실행 중 예외 발생 시
      */
-    @PostMapping("/executions/{jobExecutionId}/restart")
-    public ResponseEntity<Void> restart(@PathVariable Long jobExecutionId) throws Exception {
-        batchManagementService.restart(jobExecutionId);
+    @PostMapping("/jobs/{jobName}/restart")
+    public ResponseEntity<Void> restart(@PathVariable String jobName) throws Exception {
+        batchManagementService.restart(jobName);
         return ResponseEntity.ok().build();
     }
 
     /**
      * 실행 중인 잡을 중지한다.
      *
-     * @param jobExecutionId 잡 실행 ID
+     * @param jobName 잡 이름
      * @return 처리 결과
-     * @throws Exception 중지 중 예외 발생 시
      */
-    @PostMapping("/executions/{jobExecutionId}/stop")
-    public ResponseEntity<Void> stop(@PathVariable Long jobExecutionId) throws Exception {
-        batchManagementService.stop(jobExecutionId);
+    @PostMapping("/jobs/{jobName}/stop")
+    public ResponseEntity<Void> stop(@PathVariable String jobName) {
+        batchManagementService.stop(jobName);
         return ResponseEntity.ok().build();
     }
 }


### PR DESCRIPTION
## 요약
- JobOperator 및 JobRegistry 관련 빈 제거
- JobLauncher와 개별 Job 빈을 활용해 배치 재시작/중지 서비스 재구현
- API 및 관리 컨트롤러를 Job 이름 기반 호출로 수정
- 단위 테스트를 JobLauncher 흐름에 맞게 업데이트

## 테스트
- `mvn -q test` *(네트워크 문제로 의존성 해소 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68baa2dc6870832a99be35b34bab4f56