### PR TITLE
BatchManagementService 생성자 Autowired 추가

### DIFF
--- a/src/main/java/egovframework/bat/service/BatchManagementService.java
+++ b/src/main/java/egovframework/bat/service/BatchManagementService.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 
-import lombok.RequiredArgsConstructor;
 import egovframework.bat.service.dto.JobExecutionDto;
 import java.time.ZoneId;
 import java.util.Date;
@@ -18,6 +17,7 @@ import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
@@ -25,7 +25,6 @@ import org.springframework.stereotype.Service;
  * 배치 잡 관리 기능을 제공하는 서비스.
  */
 @Service
-@RequiredArgsConstructor
 public class BatchManagementService {
 
     /** 배치 메타데이터 조회를 위한 매퍼 */
@@ -43,6 +42,7 @@ public class BatchManagementService {
     /** 관리 대상 잡들을 보관하는 맵 */
     private final Map<String, Job> jobMap = new HashMap<>();
 
+    @Autowired
     public BatchManagementService(BatchManagementMapper batchManagementMapper,
             JobLauncher jobLauncher, JobExplorer jobExplorer, JobRepository jobRepository,
             @Qualifier("mybatisToMybatisSampleJob") Job mybatisToMybatisSampleJob,


### PR DESCRIPTION
## Summary
- BatchManagementService에서 lombok `@RequiredArgsConstructor` 제거
- 명시적 생성자에 `@Autowired` 추가하여 스프링이 해당 생성자를 사용하도록 명시

## Testing
- `mvn -e package` *(네트워크 오류로 의존성 다운로드 실패)*
- `mvn -e spring-boot:run` *(네트워크 오류로 의존성 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68baa5cb5284832a9c0c17d76a5ac52b