### PR TITLE
feat: 잡 빈 컬렉션 자동 주입

### DIFF
--- a/src/main/java/egovframework/bat/service/BatchManagementService.java
+++ b/src/main/java/egovframework/bat/service/BatchManagementService.java
@@ -18,7 +18,6 @@ import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 /**
@@ -40,27 +39,18 @@ public class BatchManagementService {
     private final JobRepository jobRepository;
 
     /** 관리 대상 잡들을 보관하는 맵 */
-    private final Map<String, Job> jobMap = new HashMap<>();
+    private final Map<String, Job> jobMap;
 
     @Autowired
     public BatchManagementService(BatchManagementMapper batchManagementMapper,
             JobLauncher jobLauncher, JobExplorer jobExplorer, JobRepository jobRepository,
-            @Qualifier("mybatisToMybatisSampleJob") Job mybatisToMybatisSampleJob,
-            @Qualifier("erpRestToStgJob") Job erpRestToStgJob,
-            @Qualifier("erpStgToLocalJob") Job erpStgToLocalJob,
-            @Qualifier("erpStgToRestJob") Job erpStgToRestJob,
-            @Qualifier("insaRemote1ToStgJob") Job insaRemote1ToStgJob,
-            @Qualifier("insaStgToLocalJob") Job insaStgToLocalJob) {
+            Map<String, Job> jobBeans) {
         this.batchManagementMapper = batchManagementMapper;
         this.jobLauncher = jobLauncher;
         this.jobExplorer = jobExplorer;
         this.jobRepository = jobRepository;
-        jobMap.put(mybatisToMybatisSampleJob.getName(), mybatisToMybatisSampleJob);
-        jobMap.put(erpRestToStgJob.getName(), erpRestToStgJob);
-        jobMap.put(erpStgToLocalJob.getName(), erpStgToLocalJob);
-        jobMap.put(erpStgToRestJob.getName(), erpStgToRestJob);
-        jobMap.put(insaRemote1ToStgJob.getName(), insaRemote1ToStgJob);
-        jobMap.put(insaStgToLocalJob.getName(), insaStgToLocalJob);
+        // 주입받은 잡 빈들을 그대로 보관하여 자동 등록을 지원한다.
+        this.jobMap = new HashMap<>(jobBeans);
     }
 
     /**

--- a/src/test/java/egovframework/bat/service/BatchManagementServiceTest.java
+++ b/src/test/java/egovframework/bat/service/BatchManagementServiceTest.java
@@ -10,6 +10,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -70,10 +72,16 @@ public class BatchManagementServiceTest {
         when(insaRemote1ToStgJob.getName()).thenReturn("insaRemote1ToStgJob");
         when(insaStgToLocalJob.getName()).thenReturn("insaStgToLocalJob");
 
+        Map<String, Job> jobBeans = new HashMap<>();
+        jobBeans.put(mybatisJob.getName(), mybatisJob);
+        jobBeans.put(erpRestToStgJob.getName(), erpRestToStgJob);
+        jobBeans.put(erpStgToLocalJob.getName(), erpStgToLocalJob);
+        jobBeans.put(erpStgToRestJob.getName(), erpStgToRestJob);
+        jobBeans.put(insaRemote1ToStgJob.getName(), insaRemote1ToStgJob);
+        jobBeans.put(insaStgToLocalJob.getName(), insaStgToLocalJob);
+
         batchManagementService = new BatchManagementService(batchManagementMapper,
-                jobLauncher, jobExplorer, jobRepository,
-                mybatisJob, erpRestToStgJob, erpStgToLocalJob,
-                erpStgToRestJob, insaRemote1ToStgJob, insaStgToLocalJob);
+                jobLauncher, jobExplorer, jobRepository, jobBeans);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- BatchManagementService가 `Map<String, Job>`을 주입받아 자동으로 잡 맵 구성
- 단위 테스트를 새로운 생성자 시그니처에 맞게 업데이트

## Testing
- `mvn -q test` *(실패: 네트워크 문제로 의존성 다운로드 불가)*

------
https://chatgpt.com/codex/tasks/task_e_68baa7d438ac832ab2538be5aa2fb625