### PR TITLE
fix: jobName 변수를 예외 처리까지 사용하도록 개선

### DIFF
--- a/src/main/java/egovframework/bat/job/erp/api/RestToStgJobController.java
+++ b/src/main/java/egovframework/bat/job/erp/api/RestToStgJobController.java
@@ -53,9 +53,10 @@ public class RestToStgJobController {
         JobParameters jobParameters = new JobParametersBuilder()
             .addLong("timestamp", System.currentTimeMillis())
             .toJobParameters();
+        // 예외 처리에서도 사용할 수 있도록 잡 이름을 미리 정의
+        String jobName = erpRestToStgJob.getName();
 
         try {
-            String jobName = erpRestToStgJob.getName();
             if (!jobLockService.tryLock(jobName)) {
                 LOGGER.warn("{} 작업이 이미 실행 중", jobName);
                 return ResponseEntity.status(HttpStatus.CONFLICT).body(BatchStatus.FAILED);
@@ -71,7 +72,7 @@ public class RestToStgJobController {
             }
         } catch (Exception e) {
             LOGGER.error("ERP REST 배치 실행 실패", e);
-            jobProgressService.send("erpRestToStgJob", "FAILED");
+            jobProgressService.send(jobName, "FAILED");
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(BatchStatus.FAILED);
         }

--- a/src/main/java/egovframework/bat/job/example/api/ExampleJobController.java
+++ b/src/main/java/egovframework/bat/job/example/api/ExampleJobController.java
@@ -60,10 +60,11 @@ public class ExampleJobController {
         }
 
         JobParameters jobParameters = builder.toJobParameters();
+        // 잡 이름은 예외 처리에서도 사용되므로 try 블록 밖에서 정의
+        String jobName = mybatisToMybatisSampleJob.getName();
 
         try {
             // @Qualifier로 주입된 잡 실행
-            String jobName = mybatisToMybatisSampleJob.getName();
             if (!jobLockService.tryLock(jobName)) {
                 LOGGER.warn("{} 작업이 이미 실행 중", jobName);
                 return ResponseEntity.status(HttpStatus.CONFLICT).body(BatchStatus.FAILED);
@@ -78,7 +79,7 @@ public class ExampleJobController {
             }
         } catch (Exception e) {
             LOGGER.error("마이바티스 배치 실행 실패", e);
-            jobProgressService.send("mybatisToMybatisSampleJob", "FAILED");
+            jobProgressService.send(jobName, "FAILED");
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(BatchStatus.FAILED);
         }

--- a/src/main/java/egovframework/bat/job/insa/api/Remote1ToStgJobController.java
+++ b/src/main/java/egovframework/bat/job/insa/api/Remote1ToStgJobController.java
@@ -60,10 +60,11 @@ public class Remote1ToStgJobController {
         }
 
         JobParameters jobParameters = builder.toJobParameters();
+        // 예외 처리까지 동일한 잡 이름을 사용하기 위해 밖에서 정의
+        String jobName = insaRemote1ToStgJob.getName();
 
         try {
             // @Qualifier로 주입된 잡 실행
-            String jobName = insaRemote1ToStgJob.getName();
             if (!jobLockService.tryLock(jobName)) {
                 LOGGER.warn("{} 작업이 이미 실행 중", jobName);
                 return ResponseEntity.status(HttpStatus.CONFLICT).body(BatchStatus.FAILED);
@@ -78,7 +79,7 @@ public class Remote1ToStgJobController {
             }
         } catch (Exception e) {
             LOGGER.error("Remote1 배치 실행 실패", e);
-            jobProgressService.send("insaRemote1ToStgJob", "FAILED");
+            jobProgressService.send(jobName, "FAILED");
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(BatchStatus.FAILED);
         }


### PR DESCRIPTION
## Summary
- runMybatisJob 등 REST API 컨트롤러에서 jobName 변수를 try 밖으로 이동
- 예외 처리 및 진행 상황 전송 시 문자열 리터럴 대신 jobName 변수 활용

## Testing
- `mvn -q test` *(실패: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bac18eff84832a92e44131db198ffe