### PR TITLE
feat: JobRegistry 자동 등록 빈 추가

### DIFF
--- a/src/main/java/egovframework/bat/config/BatchJobLauncherConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchJobLauncherConfig.java
@@ -2,7 +2,9 @@ package egovframework.bat.config;
 
 import javax.sql.DataSource;
 
+import org.springframework.batch.core.configuration.JobRegistry;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.support.JobRegistryBeanPostProcessor;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.explore.support.JobExplorerFactoryBean;
 import org.springframework.batch.core.launch.JobLauncher;
@@ -60,6 +62,17 @@ public class BatchJobLauncherConfig {
         factory.setDataSource(dataSource);
         factory.afterPropertiesSet();
         return factory.getObject();
+    }
+
+    /**
+     * 잡을 {@link JobRegistry}에 자동 등록하는 빈
+     */
+    @Bean
+    public JobRegistryBeanPostProcessor jobRegistryBeanPostProcessor(
+            JobRegistry jobRegistry) {
+        JobRegistryBeanPostProcessor processor = new JobRegistryBeanPostProcessor();
+        processor.setJobRegistry(jobRegistry);
+        return processor;
     }
 
     /**


### PR DESCRIPTION
## Summary
- JobRegistryBeanPostProcessor 빈을 등록하여 배치 잡이 JobRegistry에 자동 등록되도록 구성

## Testing
- ⚠️ `mvn -q test` (parent POM을 내려받지 못해 빌드 실패)
- ⚠️ `mvn -q spring-boot:run` (parent POM을 내려받지 못해 실행 실패)

------
https://chatgpt.com/codex/tasks/task_e_68baceffabb8832a9c6f62da95dfde29