### PR TITLE
feat: only register durable jobs

### DIFF
--- a/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
@@ -117,13 +117,17 @@ public class BatchSchedulerConfig {
             boolean durability = (cron == null || cron.isEmpty());
             JobDetail jobDetail = createJobDetail(job, jobLauncher, jobLockService,
                     jobProgressService, durability, extraData(jobName));
-            jobDetails.add(jobDetail);
 
-            if (!durability) {
+            if (durability) {
+                // 크론이 없으면 영속 JobDetail로만 등록
+                jobDetails.add(jobDetail);
+            } else {
+                // 크론이 있으면 트리거만 등록
                 triggers.add(cronTrigger(jobDetail, cron));
             }
         }
 
+        // 영속 잡들만 스케줄러에 직접 등록
         factory.setJobDetails(jobDetails.toArray(new JobDetail[0]));
         factory.setTriggers(triggers.toArray(new Trigger[0]));
         factory.setGlobalJobListeners(jobChainingJobListener);


### PR DESCRIPTION
## Summary
- only register cronless jobs as jobDetails

## Testing
- `mvn -q test` *(failed: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 from/to mvn2s (https://repo1.maven.org/maven2/): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bad10f4e2c832a91fa99bc5574ce2a