### PR TITLE
잡 등록 순서 및 예외 처리 개선

### DIFF
--- a/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
@@ -9,12 +9,16 @@ import org.quartz.JobDetail;
 import org.quartz.JobKey;
 import org.quartz.Trigger;
 import org.quartz.listeners.JobChainingJobListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.configuration.JobRegistry;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.NoSuchJobException;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.scheduling.quartz.CronTriggerFactoryBean;
 import org.springframework.scheduling.quartz.JobDetailFactoryBean;
 import org.springframework.scheduling.quartz.SchedulerFactoryBean;
@@ -30,6 +34,9 @@ import egovframework.bat.service.JobLockService;
 @Configuration
 @ConfigurationProperties(prefix = "scheduler")
 public class BatchSchedulerConfig {
+
+    /** 로그 기록용 로거 */
+    private static final Logger LOGGER = LoggerFactory.getLogger(BatchSchedulerConfig.class);
 
     /** 프로퍼티에서 주입받은 잡 이름과 크론 표현식 */
     private Map<String, String> jobs = new HashMap<>();
@@ -100,6 +107,7 @@ public class BatchSchedulerConfig {
      * {@code JobChainingJobListener}로 체인 처리한다.</p>
      */
     @Bean
+    @DependsOn("jobRegistryBeanPostProcessor") // 잡 등록이 완료된 후 스케줄러 생성
     public SchedulerFactoryBean schedulerFactoryBean(JobRegistry jobRegistry,
             JobLauncher jobLauncher, JobLockService jobLockService,
             JobProgressService jobProgressService,
@@ -112,7 +120,15 @@ public class BatchSchedulerConfig {
         for (Map.Entry<String, String> entry : jobs.entrySet()) {
             String jobName = entry.getKey();
             String cron = entry.getValue();
-            Job job = jobRegistry.getJob(jobName);
+
+            Job job;
+            try {
+                job = jobRegistry.getJob(jobName);
+            } catch (NoSuchJobException e) {
+                // 등록되지 않은 잡은 경고 로그 후 건너뜀
+                LOGGER.warn("등록되지 않은 잡 '{}'을(를) 건너뜁니다. 사유: {}", jobName, e.getMessage());
+                continue;
+            }
 
             boolean durability = (cron == null || cron.isEmpty());
             JobDetail jobDetail = createJobDetail(job, jobLauncher, jobLockService,


### PR DESCRIPTION
## 요약
- 스케줄러 생성이 잡 등록 후 실행되도록 @DependsOn 추가
- 미등록 잡 조회 시 경고 로그 출력 후 건너뛰도록 예외 처리

## 테스트
- `mvn -q -e test` *(네트워크 오류로 parent POM을 다운로드하지 못해 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68bae59980c4832a8d4cd6b89c04e312