### PR TITLE
락 해제 후 맵에서 제거

### DIFF
--- a/src/main/java/egovframework/bat/service/JobLockService.java
+++ b/src/main/java/egovframework/bat/service/JobLockService.java
@@ -33,7 +33,10 @@ public class JobLockService {
     public void unlock(String jobName) {
         ReentrantLock lock = locks.get(jobName);
         if (lock != null && lock.isHeldByCurrentThread()) {
+            // 현재 스레드가 보유한 락을 해제한다
             lock.unlock();
+            // 사용이 끝난 락은 맵에서 제거한다
+            locks.remove(jobName, lock);
         }
     }
 


### PR DESCRIPTION
## 요약
- `JobLockService`의 `unlock` 메서드에서 락 해제 후 맵에서 제거하도록 수정

## 테스트
- `mvn -q test` *(실패: 외부 Maven 리포지토리에 접근할 수 없음)*

------
https://chatgpt.com/codex/tasks/task_e_68bae61c3444832aafd688d09460025e