### PR TITLE
명시적 알림 전송기 빈 주입

### DIFF
--- a/src/main/java/egovframework/bat/config/NotificationConfig.java
+++ b/src/main/java/egovframework/bat/config/NotificationConfig.java
@@ -3,6 +3,7 @@ package egovframework.bat.config;
 import egovframework.bat.notification.EmailNotificationSender;
 import egovframework.bat.notification.NotificationSender;
 import egovframework.bat.notification.SmsNotificationSender;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -18,6 +19,7 @@ public class NotificationConfig {
      * @return EmailNotificationSender 인스턴스
      */
     @Bean
+    @Qualifier("emailNotificationSender")
     public NotificationSender emailNotificationSender() {
         return new EmailNotificationSender();
     }
@@ -28,6 +30,7 @@ public class NotificationConfig {
      * @return SmsNotificationSender 인스턴스
      */
     @Bean
+    @Qualifier("smsNotificationSender")
     public NotificationSender smsNotificationSender() {
         return new SmsNotificationSender();
     }

--- a/src/main/java/egovframework/bat/job/erp/tasklet/FetchErpDataTasklet.java
+++ b/src/main/java/egovframework/bat/job/erp/tasklet/FetchErpDataTasklet.java
@@ -51,14 +51,16 @@ public class FetchErpDataTasklet implements Tasklet {
 
     public FetchErpDataTasklet(WebClient.Builder builder,
                                @Qualifier("jdbcTemplateLocal") JdbcTemplate jdbcTemplate,
-                               List<NotificationSender> notificationSenders,
+                               @Qualifier("emailNotificationSender") NotificationSender emailNotificationSender,
+                               @Qualifier("smsNotificationSender") NotificationSender smsNotificationSender,
                                ObjectMapper objectMapper,
                                @Value("${erp.api-url}") String apiUrl) {
                                //@Value("${Globals.Erp.ApiUrl}") String apiUrl) {
         // WebClient 생성
         this.webClient = builder.build();
         this.jdbcTemplate = jdbcTemplate;
-        this.notificationSenders = notificationSenders;
+        // 주입받은 알림 전송기를 리스트로 구성
+        this.notificationSenders = List.of(emailNotificationSender, smsNotificationSender);
         this.objectMapper = objectMapper;
         this.apiUrl = apiUrl;
     }

--- a/src/main/java/egovframework/bat/job/erp/tasklet/SendErpDataTasklet.java
+++ b/src/main/java/egovframework/bat/job/erp/tasklet/SendErpDataTasklet.java
@@ -44,11 +44,13 @@ public class SendErpDataTasklet implements Tasklet {
 
     public SendErpDataTasklet(WebClient.Builder builder,
                               @Qualifier("migstgJdbcTemplate") JdbcTemplate jdbcTemplate,
-                              List<NotificationSender> notificationSenders,
+                              @Qualifier("emailNotificationSender") NotificationSender emailNotificationSender,
+                              @Qualifier("smsNotificationSender") NotificationSender smsNotificationSender,
                               @Value("${erp.outbound-api-url}") String apiUrl) {
         this.webClient = builder.build();
         this.jdbcTemplate = jdbcTemplate;
-        this.notificationSenders = notificationSenders;
+        // 주입받은 알림 전송기를 리스트로 구성
+        this.notificationSenders = List.of(emailNotificationSender, smsNotificationSender);
         this.apiUrl = apiUrl;
     }
 

--- a/src/test/java/egovframework/bat/job/erp/tasklet/FetchErpDataTaskletPropertyInjectionTest.java
+++ b/src/test/java/egovframework/bat/job/erp/tasklet/FetchErpDataTaskletPropertyInjectionTest.java
@@ -1,12 +1,11 @@
 package egovframework.bat.job.erp.tasklet;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Properties;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -53,14 +52,23 @@ public class FetchErpDataTaskletPropertyInjectionTest {
         }
 
         // Tasklet이 기대하는 이름과 동일하게 빈을 등록
-        @Bean(name = "migstgJdbcTemplate")
+        @Bean(name = "jdbcTemplateLocal")
         public JdbcTemplate jdbcTemplate() {
             return new JdbcTemplate();
         }
 
+        // 이메일 알림 전송기 빈
         @Bean
-        public List<NotificationSender> notificationSenders() {
-            return Collections.emptyList();
+        @Qualifier("emailNotificationSender")
+        public NotificationSender emailNotificationSender() {
+            return message -> {};
+        }
+
+        // SMS 알림 전송기 빈
+        @Bean
+        @Qualifier("smsNotificationSender")
+        public NotificationSender smsNotificationSender() {
+            return message -> {};
         }
     }
 

--- a/src/test/java/egovframework/bat/job/erp/tasklet/FetchErpDataTaskletTest.java
+++ b/src/test/java/egovframework/bat/job/erp/tasklet/FetchErpDataTaskletTest.java
@@ -2,8 +2,6 @@ package egovframework.bat.job.erp.tasklet;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import egovframework.bat.notification.NotificationSender;
-import java.util.Collections;
-import java.util.List;
 import org.junit.Test;
 import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.dao.DataAccessResourceFailureException;
@@ -36,9 +34,10 @@ public class FetchErpDataTaskletTest {
             }
         };
 
-        List<NotificationSender> senders = Collections.emptyList();
+        NotificationSender emailSender = message -> {};
+        NotificationSender smsSender = message -> {};
         // ObjectMapper를 추가한 생성자 호출
-        FetchErpDataTasklet tasklet = new FetchErpDataTasklet(builder, jdbcTemplate, senders, new ObjectMapper(), "http://example.com");
+        FetchErpDataTasklet tasklet = new FetchErpDataTasklet(builder, jdbcTemplate, emailSender, smsSender, new ObjectMapper(), "http://example.com");
 
         RepeatStatus status = tasklet.execute(null, null);
         assertEquals(RepeatStatus.FINISHED, status);
@@ -63,9 +62,10 @@ public class FetchErpDataTaskletTest {
             .thenThrow(new DataAccessResourceFailureException("insert fail"));
         when(jdbcTemplate.update(anyString(), any(), any())).thenReturn(1);
 
-        List<NotificationSender> senders = Collections.emptyList();
+        NotificationSender emailSender = message -> {};
+        NotificationSender smsSender = message -> {};
         // ObjectMapper를 추가한 생성자 호출
-        FetchErpDataTasklet tasklet = new FetchErpDataTasklet(builder, jdbcTemplate, senders, new ObjectMapper(), "http://example.com");
+        FetchErpDataTasklet tasklet = new FetchErpDataTasklet(builder, jdbcTemplate, emailSender, smsSender, new ObjectMapper(), "http://example.com");
 
         RepeatStatus status = tasklet.execute(null, null);
 


### PR DESCRIPTION
## 요약
- NotificationConfig의 알림 전송기 빈에 `@Qualifier` 추가
- Fetch/Send ERP Tasklet에서 `@Qualifier`로 이메일·SMS 전송기 명시적 주입
- 관련 테스트 구성 수정

## 테스트
- `mvn -q test` *(네트워크 오류로 부모 POM을 내려받지 못해 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68bae5f4c404832a9aafb27272f3adf3