### PR TITLE
스케줄러 초기화 시 Job 빈 조기 로딩

### DIFF
--- a/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
@@ -111,7 +111,9 @@ public class BatchSchedulerConfig {
     public SchedulerFactoryBean schedulerFactoryBean(JobRegistry jobRegistry,
             JobLauncher jobLauncher, JobLockService jobLockService,
             JobProgressService jobProgressService,
-            JobChainingJobListener jobChainingJobListener) throws Exception {
+            JobChainingJobListener jobChainingJobListener,
+            List<Job> jobBeans) throws Exception {
+        // jobBeans 파라미터는 모든 Job 빈을 조기 로딩하기 위한 것으로 실제로 사용하지 않는다.
         SchedulerFactoryBean factory = new SchedulerFactoryBean();
 
         List<Trigger> triggers = new ArrayList<>();


### PR DESCRIPTION
## Summary
- SchedulerFactoryBean 생성 시 `List<Job>` 파라미터를 추가하여 Job 빈을 조기 로딩

## Testing
- `mvn -q test` *(실패: org.springframework.boot:spring-boot-starter-parent:pom:2.7.18, Network is unreachable)*
- `mvn -q spring-boot:run` *(실패: org.springframework.boot:spring-boot-starter-parent:pom:2.7.18, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bae8554bcc832a825186898d757b61