### PR TITLE
docs: 정리된 컨트롤러 역할과 주소

### DIFF
--- a/README_DETAILED.md
+++ b/README_DETAILED.md
@@ -1,32 +1,15 @@
-배치 관리 컨트롤러 상세 설명
-컨트롤러별 역할과 주소
-BatchApiController
-배치 잡 목록 조회, 실행 이력/상세, 에러 로그, 재시작·중지 등 핵심 배치 관리 API를 /api/batch 하위에서 제공한다.
+# 컨트롤러별 역할과 주소
 
-BatchManagementController
-관리용 DTO를 사용해 잡 목록·실행 이력·에러 로그·재시작/중지 기능을 /api/batch/management 경로로 제공한다.
+| 컨트롤러 | 역할 요약 | 기본 URL | 주요 하위 경로 |
+| --- | --- | --- | --- |
+| BatchApiController | 배치 잡 목록 조회, 실행 이력/상세, 에러 로그, 재시작·중지 등 관리 API 제공 | `/api/batch` | `/jobs`, `/jobs/{jobName}/executions`, `/executions/{execId}`, `/error-log`, `/jobs/{jobName}/restart`, `/jobs/{jobName}` |
+| BatchManagementController | DTO 기반 관리용 API로 잡 목록·이력·에러 로그·재시작/중지 기능 제공 | `/api/batch/management` | `/jobs`, `/jobs/{jobName}/executions`, `/executions/{jobExecutionId}/errors`, `/jobs/{jobName}/restart`, `/jobs/{jobName}/stop` |
+| JobProgressController | 배치 진행 상황을 SSE 스트림으로 전송 | `/api/batch` | `/progress` |
+| BatchPageController | 배치 작업 리스트·상세·로그 화면을 렌더링 | `/batch` | `/list`, `/detail`, `/log` |
+| JobRunController | 공통 잡 실행 엔드포인트로 지정된 잡을 실행 | `/api/batch` | `/run` |
+| Remote1ToStgJobController | Remote1 데이터를 STG로 적재하는 배치 실행 | `/api/batch` | `/remote1-to-stg` |
+| ExampleJobController | 마이바티스 예제 배치 잡을 실행 | `/api/batch` | `/mybatis` |
+| StgToRestJobController | STG 데이터를 외부 REST API로 전송 | `/api/batch` | `/erp-stg-to-rest` |
+| RestToStgJobController | ERP REST 데이터를 STG 테이블로 적재 | `/api/batch` | `/erp-rest-to-stg` |
+| VehicleController | ERP 서비스용 차량 정보를 조회 | `/api/v1` | `/vehicles` |
 
-JobProgressController
-배치 작업의 실시간 진행 상황을 SSE(Server‑Sent Events) 스트림으로 /api/batch/progress에 노출한다.
-
-BatchPageController
-배치 작업 리스트·상세·로그 화면을 /batch 경로에서 렌더링하는 페이지 전용 컨트롤러다.
-
-왜 네 개로 나뉘어 있나?
-BatchApiController: 배치 잡 상태 관리의 기본 REST API.
-
-BatchManagementController: DTO 기반 관리 기능(관리 UI 등에 최적화).
-
-JobProgressController: 실시간 진행률 전송(SSE) 전용.
-
-BatchPageController: 배치 작업 화면 렌더링 전용.
-
-기능별 책임을 분리하기 위해 컨트롤러가 나뉘어 있으며, BatchApiController와 BatchManagementController는 일부 기능이 중복되지만 반환 형식과 목적이 다르다. JobProgressController는 실시간 스트리밍만 담당하고, BatchPageController는 UI 화면을 제공한다.
-
-주소(엔드포인트) 정리
-컨트롤러        기본 경로       주요 하위 경로 예시
-BatchApiController      /api/batch      /jobs, /jobs/{jobName}/executions, /executions/{execId}, /error-log, /executions/{execId}/restart, /executions/{execId}(DELETE)
-BatchManagementController       /api/batch/management   /jobs, /jobs/{jobName}/executions, /executions/{jobExecutionId}/errors, /executions/{jobExecutionId}/restart, /executions/{jobExecutionId}/stop
-JobProgressController   /api/batch      /progress (SSE 스트림)
-BatchPageController     /batch          /list, /detail, /log
-BatchApiController와 JobProgressController는 같은 기본 경로(/api/batch)를 공유하지만 하위 경로가 달라 충돌 없이 공존하며, BatchManagementController는 별도의 하위 경로(/api/batch/management)를 사용한다. BatchPageController는 API가 아닌 화면 렌더링을 위해 /batch 경로를 사용한다. 따라서 모두 배치 관리와 관련된 기능을 제공하되, 접근 경로는 명확하게 구분되어 있다.


### PR DESCRIPTION
## Summary
- 문서에 배치 및 예제 컨트롤러 10개의 역할과 URL/하위 경로를 표로 정리

## Testing
- `mvn -q test` *(실패: 원격 저장소 접근 불가)*

------
https://chatgpt.com/codex/tasks/task_e_68baea1581d4832a8f1b7cda7b0797c1