### PR TITLE
feat: 스케줄러 관리 서비스와 컨트롤러 추가

### DIFF
--- a/src/main/java/egovframework/bat/management/SchedulerManagementController.java
+++ b/src/main/java/egovframework/bat/management/SchedulerManagementController.java
@@ -1,0 +1,81 @@
+package egovframework.bat.management;
+
+import lombok.RequiredArgsConstructor;
+import org.quartz.SchedulerException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Quartz 스케줄러 제어를 위한 REST 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api/scheduler")
+@RequiredArgsConstructor
+public class SchedulerManagementController {
+
+    /** 스케줄러 관리 서비스 */
+    private final SchedulerManagementService schedulerManagementService;
+
+    /**
+     * 새로운 잡을 추가한다.
+     *
+     * @param jobName        잡 이름
+     * @param jobClass       실행할 Job 클래스의 이름
+     * @param cronExpression 크론 표현식
+     * @return 처리 결과
+     * @throws Exception 스케줄러 작업 실패 시 발생
+     */
+    @PostMapping("/jobs")
+    public ResponseEntity<Void> addJob(
+            @RequestParam String jobName,
+            @RequestParam String jobClass,
+            @RequestParam String cronExpression) throws Exception {
+        schedulerManagementService.addJob(jobName, jobClass, cronExpression);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 지정한 잡을 일시 중지한다.
+     *
+     * @param jobName 잡 이름
+     * @return 처리 결과
+     * @throws SchedulerException 스케줄러 작업 실패 시 발생
+     */
+    @PostMapping("/jobs/{jobName}/pause")
+    public ResponseEntity<Void> pauseJob(@PathVariable String jobName) throws SchedulerException {
+        schedulerManagementService.pauseJob(jobName);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 일시 중지된 잡을 재개한다.
+     *
+     * @param jobName 잡 이름
+     * @return 처리 결과
+     * @throws SchedulerException 스케줄러 작업 실패 시 발생
+     */
+    @PostMapping("/jobs/{jobName}/resume")
+    public ResponseEntity<Void> resumeJob(@PathVariable String jobName) throws SchedulerException {
+        schedulerManagementService.resumeJob(jobName);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 등록된 잡을 삭제한다.
+     *
+     * @param jobName 잡 이름
+     * @return 처리 결과
+     * @throws SchedulerException 스케줄러 작업 실패 시 발생
+     */
+    @DeleteMapping("/jobs/{jobName}")
+    public ResponseEntity<Void> deleteJob(@PathVariable String jobName) throws SchedulerException {
+        schedulerManagementService.deleteJob(jobName);
+        return ResponseEntity.ok().build();
+    }
+}
+

--- a/src/main/java/egovframework/bat/management/SchedulerManagementService.java
+++ b/src/main/java/egovframework/bat/management/SchedulerManagementService.java
@@ -1,0 +1,70 @@
+package egovframework.bat.management;
+
+import lombok.RequiredArgsConstructor;
+import org.quartz.*;
+import org.springframework.stereotype.Service;
+
+/**
+ * Quartz 스케줄러를 제어하기 위한 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+public class SchedulerManagementService {
+
+    /** Quartz 스케줄러 */
+    private final Scheduler scheduler;
+
+    /**
+     * 새로운 잡을 추가한다.
+     *
+     * @param jobName        잡 이름
+     * @param jobClassName   실행할 Job 클래스의 이름
+     * @param cronExpression 실행 주기를 나타내는 크론 표현식
+     * @throws ClassNotFoundException 클래스 로딩 실패 시 발생
+     * @throws SchedulerException     스케줄러 작업 실패 시 발생
+     */
+    public void addJob(String jobName, String jobClassName, String cronExpression)
+            throws ClassNotFoundException, SchedulerException {
+        @SuppressWarnings("unchecked")
+        Class<? extends Job> jobClass = (Class<? extends Job>) Class.forName(jobClassName);
+        JobDetail jobDetail = JobBuilder.newJob(jobClass)
+                .withIdentity(jobName)
+                .build();
+        Trigger trigger = TriggerBuilder.newTrigger()
+                .withIdentity(jobName + "Trigger")
+                .withSchedule(CronScheduleBuilder.cronSchedule(cronExpression))
+                .build();
+        scheduler.scheduleJob(jobDetail, trigger);
+    }
+
+    /**
+     * 등록된 잡을 일시 중지한다.
+     *
+     * @param jobName 잡 이름
+     * @throws SchedulerException 스케줄러 작업 실패 시 발생
+     */
+    public void pauseJob(String jobName) throws SchedulerException {
+        scheduler.pauseJob(JobKey.jobKey(jobName));
+    }
+
+    /**
+     * 일시 중지된 잡을 재개한다.
+     *
+     * @param jobName 잡 이름
+     * @throws SchedulerException 스케줄러 작업 실패 시 발생
+     */
+    public void resumeJob(String jobName) throws SchedulerException {
+        scheduler.resumeJob(JobKey.jobKey(jobName));
+    }
+
+    /**
+     * 등록된 잡을 삭제한다.
+     *
+     * @param jobName 잡 이름
+     * @throws SchedulerException 스케줄러 작업 실패 시 발생
+     */
+    public void deleteJob(String jobName) throws SchedulerException {
+        scheduler.deleteJob(JobKey.jobKey(jobName));
+    }
+}
+


### PR DESCRIPTION
## Summary
- Quartz 스케줄러 제어용 서비스 추가
- 스케줄러 관리 REST 컨트롤러 구현

## Testing
- `mvn -q test` *(실패: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0f6759d8832aa2f5ce92bb86c248