### PR TITLE
Quartz 스케줄러 데이터소스 설정 오류 수정

### DIFF
--- a/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
@@ -124,10 +124,13 @@ public class BatchSchedulerConfig {
         factory.setDataSource(quartzDataSource);
 
         Properties props = new Properties();
-        props.setProperty("org.quartz.jobStore.class", "org.quartz.impl.jdbcjobstore.JobStoreTX"); // JDBC JobStore 사용
-        props.setProperty("org.quartz.jobStore.driverDelegateClass", "org.quartz.impl.jdbcjobstore.StdJDBCDelegate"); // MySQL용 delegate
-        props.setProperty("org.quartz.jobStore.tablePrefix", "QRTZ_"); // 테이블 prefix
-        props.setProperty("org.quartz.threadPool.threadCount", "10"); // 풀 사이즈
+        // Spring 제공 JobStore를 사용하여 DataSource 이름 없이도 동작하도록 설정
+        props.setProperty("org.quartz.jobStore.class",
+                "org.springframework.scheduling.quartz.LocalDataSourceJobStore"); // Spring 전용 JobStore
+        props.setProperty("org.quartz.jobStore.driverDelegateClass",
+                "org.quartz.impl.jdbcjobstore.StdJDBCDelegate"); // MySQL용 델리게이트
+        props.setProperty("org.quartz.jobStore.tablePrefix", "QRTZ_"); // 테이블 접두사
+        props.setProperty("org.quartz.threadPool.threadCount", "10"); // 스레드 풀 크기
         factory.setQuartzProperties(props);
 
         List<Trigger> triggers = new ArrayList<>();


### PR DESCRIPTION
## Summary
- Spring의 `LocalDataSourceJobStore`로 교체하여 Quartz가 DataSource 이름 없이도 초기화되도록 수정
- MySQL 델리게이트 및 스레드 풀 등 Quartz 관련 속성 주석 정비

## Testing
- `mvn -q test` *(네트워크 문제로 부모 POM을 받을 수 없어 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0df617ac832ab361fd5740a024bd