### PR TITLE
환경별 SQL 초기화 스크립트 비활성화

### DIFF
--- a/src/main/resources/application/env/dev/application.yml
+++ b/src/main/resources/application/env/dev/application.yml
@@ -1,7 +1,8 @@
 spring:
   sql:
     init:
-      mode: always # 외부 DB에서도 스크립트 실행
+      mode: never # 스크립트를 실행하지 않음
+      continue-on-error: true # 이미 존재하는 테이블이 있어도 계속 실행
       schema-locations: classpath:schema-quartz.sql
   main:
     # Spring Framework 5.*에서 같은 이름의 빈을 등록할 때 발생하는 BeanDefinitionOverrideException 방지

--- a/src/main/resources/application/env/local/application.yml
+++ b/src/main/resources/application/env/local/application.yml
@@ -1,7 +1,8 @@
 spring:
   sql:
     init:
-      mode: always # 외부 DB에서도 스크립트 실행
+      mode: never # 스크립트를 실행하지 않음
+      continue-on-error: true # 이미 존재하는 테이블이 있어도 계속 실행
       schema-locations: classpath:schema-quartz.sql
   main:
     # Spring Framework 5.*에서 같은 이름의 빈을 등록할 때 발생하는 BeanDefinitionOverrideException 방지

--- a/src/main/resources/application/env/prod/application.yml
+++ b/src/main/resources/application/env/prod/application.yml
@@ -1,7 +1,8 @@
 spring:
   sql:
     init:
-      mode: always # 외부 DB에서도 스크립트 실행
+      mode: never # 스크립트를 실행하지 않음
+      continue-on-error: true # 이미 존재하는 테이블이 있어도 계속 실행
       schema-locations: classpath:schema-quartz.sql
   main:
     # Spring Framework 5.*에서 같은 이름의 빈을 등록할 때 발생하는 BeanDefinitionOverrideException 방지


### PR DESCRIPTION
## Summary
- SQL 초기화 스크립트를 실행하지 않도록 각 환경 설정 수정
- 기존 테이블이 있어도 예외가 발생하지 않도록 continue-on-error 옵션 추가

## Testing
- `mvn -q test` *(실패: parent POM을 다운로드할 수 없음)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1330a7e8832ab8fc146edd750672