### PR TITLE
Quartz Job 빈 주입 개선 및 JobDataMap 정리

### DIFF
--- a/src/main/java/egovframework/bat/scheduler/EgovQuartzJobLauncher.java
+++ b/src/main/java/egovframework/bat/scheduler/EgovQuartzJobLauncher.java
@@ -28,6 +28,7 @@ import org.springframework.batch.core.JobExecutionException;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.quartz.QuartzJobBean;
 
 import egovframework.bat.management.JobProgressService;
@@ -59,21 +60,17 @@ public class EgovQuartzJobLauncher extends QuartzJobBean {
         /** 실행할 배치 잡 */
         private Job job;
 
+        /** 배치 잡 실행을 위한 런처 */
+        @Autowired
         private JobLauncher jobLauncher;
 
         /** 중복 실행을 방지하기 위한 락 서비스 */
+        @Autowired
         private JobLockService jobLockService;
 
         /** 진행 상황 전송을 위한 서비스 */
+        @Autowired
         private JobProgressService jobProgressService;
-
-        /**
-         * Public setter for the {@link JobLauncher}.
-         * @param jobLauncher the {@link JobLauncher} to set
-         */
-        public void setJobLauncher(JobLauncher jobLauncher) {
-                this.jobLauncher = jobLauncher;
-        }
 
         /**
          * 실행할 {@link Job} 주입.
@@ -81,22 +78,6 @@ public class EgovQuartzJobLauncher extends QuartzJobBean {
          */
         public void setJob(Job job) {
                 this.job = job;
-        }
-
-        /**
-         * {@link JobLockService} 주입.
-         * @param jobLockService 락 서비스
-         */
-        public void setJobLockService(JobLockService jobLockService) {
-                this.jobLockService = jobLockService;
-        }
-
-        /**
-         * {@link JobProgressService} 주입.
-         * @param jobProgressService 진행 상황 서비스
-         */
-        public void setJobProgressService(JobProgressService jobProgressService) {
-                this.jobProgressService = jobProgressService;
         }
 
 	@Override


### PR DESCRIPTION
## 요약
- Quartz Job 생성 시 Spring Bean 주입 방식 개선
- JobDataMap에 불필요한 의존성 제거 및 JobFactory 설정 추가

## 테스트
- `mvn -q test` (네트워크 문제로 의존성 해석 실패)


------
https://chatgpt.com/codex/tasks/task_e_68bc1cab0334832a960afb3ac6110a8c