### PR TITLE
Quartz JobFactory에 스프링 빈 자동 주입 지원 추가

### DIFF
--- a/src/main/java/egovframework/bat/config/AutowiringJobFactory.java
+++ b/src/main/java/egovframework/bat/config/AutowiringJobFactory.java
@@ -1,0 +1,31 @@
+package egovframework.bat.config;
+
+import org.quartz.Job;
+import org.quartz.Scheduler;
+import org.quartz.spi.JobFactory;
+import org.quartz.spi.TriggerFiredBundle;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Quartz Job 인스턴스에 스프링 빈 주입을 지원하는 JobFactory 구현체
+ */
+@Component
+public class AutowiringJobFactory implements JobFactory {
+
+    /** 스프링 빈 생성을 위한 팩토리 */
+    private final AutowireCapableBeanFactory beanFactory;
+
+    /**
+     * 스프링 {@link AutowireCapableBeanFactory}를 주입받는다.
+     */
+    public AutowiringJobFactory(AutowireCapableBeanFactory beanFactory) {
+        this.beanFactory = beanFactory;
+    }
+
+    @Override
+    public Job newJob(TriggerFiredBundle bundle, Scheduler scheduler) throws Exception {
+        // 스프링 팩토리로부터 잡을 생성하여 의존성을 자동 주입한다.
+        return beanFactory.createBean(bundle.getJobDetail().getJobClass());
+    }
+}

--- a/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
@@ -22,7 +22,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
-import org.springframework.scheduling.quartz.AutowireCapableBeanJobFactory;
 import org.springframework.scheduling.quartz.CronTriggerFactoryBean;
 import org.springframework.scheduling.quartz.JobDetailFactoryBean;
 import org.springframework.scheduling.quartz.SchedulerFactoryBean;
@@ -108,13 +107,14 @@ public class BatchSchedulerConfig {
     public SchedulerFactoryBean schedulerFactoryBean(JobRegistry jobRegistry,
             JobChainingJobListener jobChainingJobListener,
             List<Job> jobBeans,
-            @Qualifier("dataSource-stg") DataSource quartzDataSource) throws Exception {
+            @Qualifier("dataSource-stg") DataSource quartzDataSource,
+            AutowiringJobFactory autowiringJobFactory) throws Exception {
         // jobBeans 파라미터는 모든 Job 빈을 조기 로딩하기 위한 것으로 실제로 사용하지 않는다.
         SchedulerFactoryBean factory = new SchedulerFactoryBean();
         // Quartz 스케줄러에서 사용할 데이터소스 지정
         factory.setDataSource(quartzDataSource);
         // Quartz 잡 클래스에 스프링 빈 주입을 가능하게 하는 JobFactory 설정
-        factory.setJobFactory(new AutowireCapableBeanJobFactory());
+        factory.setJobFactory(autowiringJobFactory);
 
         Properties props = new Properties();
         // Spring 제공 JobStore를 사용하여 DataSource 이름 없이도 동작하도록 설정


### PR DESCRIPTION
## 요약
- AutowireCapableBeanFactory를 활용한 `AutowiringJobFactory` 구현 추가
- `BatchSchedulerConfig`에서 기존 `AutowireCapableBeanJobFactory` 제거 후 새 구현체 주입

## 테스트
- `mvn -q test` *(네트워크 연결 불가로 부모 POM을 받을 수 없어 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2e63fc7c832ab3e34a9590287b19