### PR TITLE
Quartz JobDataMap 직렬화 오류 해결

### DIFF
--- a/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
@@ -61,9 +61,10 @@ public class BatchSchedulerConfig {
         factory.setDurability(durability);
 
         Map<String, Object> map = new HashMap<>();
-        map.put("job", job); // 실행할 Job 인스턴스
+        // 잡 이름만 JobDataMap에 저장하여 직렬화 문제를 방지한다
         map.put("jobName", job.getName()); // 잡 이름
         if (extraData != null) {
+            // 필요 시 추가 데이터를 포함
             map.putAll(extraData);
         }
         factory.setJobDataAsMap(map);


### PR DESCRIPTION
## Summary
- JobDetail 생성 시 Job 인스턴스를 JobDataMap에 담지 않고 이름만 저장해 Quartz 직렬화 오류 방지
- Quartz 실행기에서 JobRegistry를 통해 잡을 조회하고 존재하지 않는 잡은 예외 처리

## Testing
- `mvn -q test` *(실패: 원격 저장소에 접근할 수 없어 parent POM을 해석하지 못함)*

------
https://chatgpt.com/codex/tasks/task_e_68bc325616f8832ab30b485bc85815f7