### PR TITLE
스케줄러 잡 조회 API 추가

### DIFF
--- a/src/main/java/egovframework/bat/management/SchedulerManagementController.java
+++ b/src/main/java/egovframework/bat/management/SchedulerManagementController.java
@@ -4,11 +4,16 @@ import lombok.RequiredArgsConstructor;
 import org.quartz.SchedulerException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import egovframework.bat.management.dto.ScheduledJobDto;
 
 /**
  * Quartz 스케줄러 제어를 위한 REST 컨트롤러.
@@ -76,6 +81,33 @@ public class SchedulerManagementController {
     public ResponseEntity<Void> deleteJob(@PathVariable String jobName) throws SchedulerException {
         schedulerManagementService.deleteJob(jobName);
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 등록된 모든 잡의 정보를 조회한다.
+     *
+     * @return 잡 정보 목록
+     * @throws SchedulerException 스케줄러 작업 실패 시 발생
+     */
+    @GetMapping("/jobs")
+    public ResponseEntity<List<ScheduledJobDto>> listJobs() throws SchedulerException {
+        return ResponseEntity.ok(schedulerManagementService.listJobs());
+    }
+
+    /**
+     * 특정 잡의 정보를 조회한다.
+     *
+     * @param jobName 잡 이름
+     * @return 잡 정보
+     * @throws SchedulerException 스케줄러 작업 실패 시 발생
+     */
+    @GetMapping("/jobs/{jobName}")
+    public ResponseEntity<ScheduledJobDto> getJob(@PathVariable String jobName) throws SchedulerException {
+        ScheduledJobDto job = schedulerManagementService.getJob(jobName);
+        if (job == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(job);
     }
 }
 

--- a/src/main/java/egovframework/bat/management/dto/ScheduledJobDto.java
+++ b/src/main/java/egovframework/bat/management/dto/ScheduledJobDto.java
@@ -1,0 +1,18 @@
+package egovframework.bat.management.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * 스케줄된 잡 정보를 전달하기 위한 DTO.
+ */
+@Data
+@AllArgsConstructor
+public class ScheduledJobDto {
+    /** 잡 이름 */
+    private String jobName;
+    /** 크론 표현식 */
+    private String cronExpression;
+    /** 현재 상태 */
+    private String status;
+}


### PR DESCRIPTION
## 요약
- 스케줄된 잡 정보를 담는 DTO 추가
- 서비스에 잡 목록/단일 조회 로직 구현
- 컨트롤러에 `/jobs` 및 `/jobs/{jobName}` 조회 엔드포인트 추가

## 테스트
- `mvn -q test` (실패: 원격 저장소 접근 불가로 parent POM을 해석하지 못함)


------
https://chatgpt.com/codex/tasks/task_e_68bc3a979b60832ab06cdfb01076c45c