### PR TITLE
feat: allow updating job cron expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,9 @@ public class SampleTasklet implements Tasklet {
 - `POST /api/scheduler/jobs` – 새 잡 등록 (`jobName`, `jobClass`, `cronExpression` 필요)
 - `POST /api/scheduler/jobs/{jobName}/pause` – 해당 잡 일시 중지
 - `POST /api/scheduler/jobs/{jobName}/resume` – 해당 잡 재개
+- `PUT /api/scheduler/jobs/{jobName}` – 해당 잡의 크론 표현식 변경 (요청 본문에 크론식 전달)
 - `DELETE /api/scheduler/jobs/{jobName}` – 해당 잡 삭제
+* 크론 표현식 변경 내용은 Quartz DB에 저장되어 재시작 후에도 유지된다.
 
 ### 개별 Job 실행 API
 - `POST /api/batch/erp-rest-to-stg` – ERP REST → STG 전송 배치 실행

--- a/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
@@ -126,6 +126,8 @@ public class BatchSchedulerConfig {
         props.setProperty("org.quartz.jobStore.tablePrefix", "QRTZ_"); // 테이블 접두사
         props.setProperty("org.quartz.threadPool.threadCount", "10"); // 스레드 풀 크기
         factory.setQuartzProperties(props);
+        // DB에 저장된 기존 스케줄 정보를 유지하기 위해 덮어쓰지 않음
+        factory.setOverwriteExistingJobs(false);
 
         List<Trigger> triggers = new ArrayList<>();
         List<JobDetail> jobDetails = new ArrayList<>();

--- a/src/main/java/egovframework/bat/management/SchedulerManagementController.java
+++ b/src/main/java/egovframework/bat/management/SchedulerManagementController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 
@@ -80,6 +82,21 @@ public class SchedulerManagementController {
     @DeleteMapping("/jobs/{jobName}")
     public ResponseEntity<Void> deleteJob(@PathVariable String jobName) throws SchedulerException {
         schedulerManagementService.deleteJob(jobName);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 등록된 잡의 크론 표현식을 변경한다.
+     *
+     * @param jobName        잡 이름
+     * @param cronExpression 새 크론 표현식
+     * @return 처리 결과
+     * @throws SchedulerException 스케줄러 작업 실패 시 발생
+     */
+    @PutMapping("/jobs/{jobName}")
+    public ResponseEntity<Void> updateJobCron(@PathVariable String jobName,
+            @RequestBody String cronExpression) throws SchedulerException {
+        schedulerManagementService.updateJobCron(jobName, cronExpression);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/egovframework/bat/management/SchedulerManagementService.java
+++ b/src/main/java/egovframework/bat/management/SchedulerManagementService.java
@@ -74,6 +74,22 @@ public class SchedulerManagementService {
     }
 
     /**
+     * 등록된 잡의 크론 표현식을 변경한다.
+     *
+     * @param jobName        잡 이름
+     * @param cronExpression 새 크론 표현식
+     * @throws SchedulerException 스케줄러 작업 실패 시 발생
+     */
+    public void updateJobCron(String jobName, String cronExpression) throws SchedulerException {
+        TriggerKey triggerKey = TriggerKey.triggerKey(jobName + "Trigger");
+        Trigger newTrigger = TriggerBuilder.newTrigger()
+                .withIdentity(triggerKey)
+                .withSchedule(CronScheduleBuilder.cronSchedule(cronExpression))
+                .build();
+        scheduler.rescheduleJob(triggerKey, newTrigger);
+    }
+
+    /**
      * 등록된 모든 잡의 정보를 조회한다.
      *
      * @return 잡 정보 목록


### PR DESCRIPTION
## Summary
- support updating existing Quartz job schedules through `updateJobCron`
- expose `PUT /api/scheduler/jobs/{jobName}` endpoint to change cron expressions
- keep DB-stored schedules by not overwriting existing Quartz jobs

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3c2df2ec832aabd0cc3df517df45