### PR TITLE
ESNTL_ID 기반 사원 동기화 로직 추가

### DIFF
--- a/src/main/java/egovframework/bat/job/insa/domain/EmployeeInfo.java
+++ b/src/main/java/egovframework/bat/job/insa/domain/EmployeeInfo.java
@@ -10,7 +10,7 @@ import lombok.Data;
 @Data
 public class EmployeeInfo {
 
-    private String esntlId;             /** 고유ID */
+    private String esntlId;             /** 고유ID(ESNTL_ID, 동기화 키) */
     private String emplyrId;            /** 업무사용자ID */
     private String orgnztId;            /** 조직ID */
     private String userNm;              /** 사용자명 */

--- a/src/main/java/egovframework/bat/job/insa/tasklet/StgToLocalEmployeeTasklet.java
+++ b/src/main/java/egovframework/bat/job/insa/tasklet/StgToLocalEmployeeTasklet.java
@@ -1,0 +1,43 @@
+package egovframework.bat.job.insa.tasklet;
+
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+
+/**
+ * 스테이징 DB와 로컬 DB의 사원 정보를 동기화하는 Tasklet.
+ * ESNTL_ID로 기존 로컬 데이터를 갱신하고 존재하지 않는 사원은 신규로 추가한다.
+ */
+public class StgToLocalEmployeeTasklet implements Tasklet {
+
+    /** MyBatis SqlSessionFactory */
+    private SqlSessionFactory sqlSessionFactory;
+
+    /**
+     * SqlSessionFactory 주입
+     * @param sqlSessionFactory 로컬 DB용 SqlSessionFactory
+     */
+    public void setSqlSessionFactory(SqlSessionFactory sqlSessionFactory) {
+        this.sqlSessionFactory = sqlSessionFactory;
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        try (SqlSession session = sqlSessionFactory.openSession()) {
+            // 기존 사원 정보 갱신
+            int updateCount = session.update("insaStgToLoc.updateEmployee");
+            // 신규 사원 정보 추가
+            int insertCount = session.insert("insaStgToLoc.insertEmployeeIncremental");
+            session.commit();
+
+            // 처리 건수를 스텝 컨트리뷰션에 반영
+            int total = updateCount + insertCount;
+            contribution.incrementReadCount(total);
+            contribution.incrementWriteCount(total);
+        }
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/resources/egovframework/batch/mapper/job/insa/insa_stg_to_local.xml
+++ b/src/main/resources/egovframework/batch/mapper/job/insa/insa_stg_to_local.xml
@@ -12,9 +12,10 @@
                 FROM migstg.COMTNORGNZTINFO
         </select>
 
-        <!-- STG DB에서 로컬 DB로 이관할 사원 목록 조회 (ESNTL_ID는 로컬 적재 시 생성) -->
+        <!-- STG DB에서 로컬 DB로 이관할 사원 목록 조회 -->
         <select id="selectEmployeeList" resultType="egovframework.bat.job.insa.domain.EmployeeInfo">
                 SELECT
+                         ESNTL_ID,
                          EMPLYR_ID,
                          ORGNZT_ID,
                          USER_NM,
@@ -28,6 +29,37 @@
                          MOD_DTTM
                 FROM migstg.COMTNEMPLYRINFO
         </select>
+
+        <!-- ESNTL_ID로 기존 사원 정보를 갱신 -->
+        <update id="updateEmployee">
+                UPDATE egovlocal.COMTNEMPLYRINFO u
+                JOIN migstg.COMTNEMPLYRINFO s ON u.ESNTL_ID = s.ESNTL_ID
+                SET u.EMPLYR_ID = s.EMPLYR_ID,
+                    u.USER_NM = s.USER_NM,
+                    u.ORGNZT_ID = s.ORGNZT_ID,
+                    u.SEXDSTN_CODE = s.SEXDSTN_CODE,
+                    u.BRTHDY = s.BRTHDY,
+                    u.MBTLNUM = s.MBTLNUM,
+                    u.EMAIL_ADRES = s.EMAIL_ADRES,
+                    u.OFCPS_NM = s.OFCPS_NM,
+                    u.EMPLYR_STTUS_CODE = s.EMPLYR_STTUS_CODE,
+                    u.REG_DTTM = s.REG_DTTM,
+                    u.MOD_DTTM = s.MOD_DTTM
+        </update>
+
+        <!-- STG에만 존재하는 사원을 로컬 DB에 신규 추가 -->
+        <insert id="insertEmployeeIncremental">
+                SET @seq := (
+                  SELECT MAX(CAST(SUBSTR(ESNTL_ID, 4) AS UNSIGNED))
+                  FROM egovlocal.COMTNEMPLYRINFO
+                );
+                INSERT INTO egovlocal.COMTNEMPLYRINFO (ESNTL_ID, EMPLYR_ID, ORGNZT_ID, USER_NM, SEXDSTN_CODE, BRTHDY, MBTLNUM, EMAIL_ADRES, OFCPS_NM, EMPLYR_STTUS_CODE, REG_DTTM, MOD_DTTM)
+                SELECT CONCAT('LND', LPAD(@seq := @seq + 1, 7, '0')) AS ESNTL_ID,
+                       s.EMPLYR_ID, s.ORGNZT_ID, s.USER_NM, s.SEXDSTN_CODE, s.BRTHDY, s.MBTLNUM, s.EMAIL_ADRES, s.OFCPS_NM, s.EMPLYR_STTUS_CODE, s.REG_DTTM, s.MOD_DTTM
+                FROM migstg.COMTNEMPLYRINFO s
+                LEFT JOIN egovlocal.COMTNEMPLYRINFO u ON u.ESNTL_ID = s.ESNTL_ID
+                WHERE u.ESNTL_ID IS NULL;
+        </insert>
 
         <!-- 로컬 DB에 조직 정보 적재 -->
         <insert id="insertOrganization" parameterType="egovframework.bat.job.insa.domain.EmployeeInfo">


### PR DESCRIPTION
## Summary
- ESNTL_ID 컬럼을 이용해 STG와 로컬 사원 정보를 동기화하도록 Mapper 수정
- 사원 갱신/삽입을 수행하는 StgToLocalEmployeeTasklet과 배치 스텝 추가
- EmployeeInfo VO에 ESNTL_ID 주석 보강

## Testing
- `mvn -q test` *(실패: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5450fb78832a9c75027a93bbf052