### PR TITLE
배치 통합 테스트 추가 및 ID 생성 검증

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,8 +190,24 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.batch</groupId>
+            <artifactId>spring-batch-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/egovframework/bat/job/insa/processor/InsaStgToLocalJobIntegrationTest.java
+++ b/src/test/java/egovframework/bat/job/insa/processor/InsaStgToLocalJobIntegrationTest.java
@@ -1,0 +1,105 @@
+package egovframework.bat.job.insa.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * STG와 로컬 DB 간 동기화 배치의 통합 테스트.
+ *
+ * <p>사전 데이터 세팅 후 배치를 실행하여 갱신/삽입 결과와
+ * MySQL 변수 기반 ESNTL_ID 생성이 정상 동작하는지 검증한다.</p>
+ */
+@SpringBootTest
+@SpringBatchTest
+@TestPropertySource(properties = {
+    "spring.batch.job.enabled=false"
+})
+public class InsaStgToLocalJobIntegrationTest {
+
+    /** 스테이징 DB 접근용 JdbcTemplate */
+    @Autowired
+    @Qualifier("migstgJdbcTemplate")
+    private JdbcTemplate migstgJdbcTemplate;
+
+    /** 로컬 DB 접근용 JdbcTemplate */
+    @Autowired
+    @Qualifier("jdbcTemplateLocal")
+    private JdbcTemplate jdbcTemplateLocal;
+
+    /** 잡 실행 유틸리티 */
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    /** 테스트 대상 잡 */
+    @Autowired
+    @Qualifier("insaStgToLocalJob")
+    private Job insaStgToLocalJob;
+
+    /**
+     * 매 테스트 실행 전 테이블을 생성하고 초기 데이터를 입력한다.
+     */
+    @BeforeEach
+    void setUp() {
+        jobLauncherTestUtils.setJob(insaStgToLocalJob);
+
+        // STG 테이블 초기화
+        migstgJdbcTemplate.execute("DROP TABLE IF EXISTS COMTNORGNZTINFO");
+        migstgJdbcTemplate.execute("DROP TABLE IF EXISTS COMTNEMPLYRINFO");
+        migstgJdbcTemplate.execute("CREATE TABLE COMTNORGNZTINFO (ORGNZT_ID VARCHAR(20) PRIMARY KEY, ORGNZT_NM VARCHAR(20), ORGNZT_DC VARCHAR(100))");
+        migstgJdbcTemplate.execute("CREATE TABLE COMTNEMPLYRINFO (ESNTL_ID VARCHAR(20), EMPLYR_ID VARCHAR(20) PRIMARY KEY, ORGNZT_ID CHAR(20), USER_NM VARCHAR(60), SEXDSTN_CODE CHAR(1), BRTHDY CHAR(20), MBTLNUM VARCHAR(20), EMAIL_ADRES VARCHAR(50), OFCPS_NM VARCHAR(60), EMPLYR_STTUS_CODE CHAR(1), REG_DTTM TIMESTAMP, MOD_DTTM TIMESTAMP)");
+        migstgJdbcTemplate.update("INSERT INTO COMTNORGNZTINFO (ORGNZT_ID, ORGNZT_NM, ORGNZT_DC) VALUES ('O1','조직1','설명1')");
+        migstgJdbcTemplate.update("INSERT INTO COMTNEMPLYRINFO (ESNTL_ID, EMPLYR_ID, ORGNZT_ID, USER_NM, REG_DTTM, MOD_DTTM) VALUES ('LND0000001','emp1','O1','홍길동',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)");
+        migstgJdbcTemplate.update("INSERT INTO COMTNEMPLYRINFO (ESNTL_ID, EMPLYR_ID, ORGNZT_ID, USER_NM, REG_DTTM, MOD_DTTM) VALUES (NULL,'emp2','O1','새사원1',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)");
+        migstgJdbcTemplate.update("INSERT INTO COMTNEMPLYRINFO (ESNTL_ID, EMPLYR_ID, ORGNZT_ID, USER_NM, REG_DTTM, MOD_DTTM) VALUES (NULL,'emp3','O1','새사원2',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)");
+
+        // 로컬 테이블 초기화
+        jdbcTemplateLocal.execute("DROP TABLE IF EXISTS COMTNORGNZTINFO");
+        jdbcTemplateLocal.execute("DROP TABLE IF EXISTS COMTNEMPLYRINFO");
+        jdbcTemplateLocal.execute("CREATE TABLE COMTNORGNZTINFO (ORGNZT_ID VARCHAR(20) PRIMARY KEY, ORGNZT_NM VARCHAR(20), ORGNZT_DC VARCHAR(100))");
+        jdbcTemplateLocal.execute("CREATE TABLE COMTNEMPLYRINFO (ESNTL_ID VARCHAR(20) PRIMARY KEY, EMPLYR_ID VARCHAR(20), ORGNZT_ID CHAR(20), USER_NM VARCHAR(60), SEXDSTN_CODE CHAR(1), BRTHDY CHAR(20), MBTLNUM VARCHAR(20), EMAIL_ADRES VARCHAR(50), OFCPS_NM VARCHAR(60), EMPLYR_STTUS_CODE CHAR(1), REG_DTTM TIMESTAMP, MOD_DTTM TIMESTAMP)");
+        jdbcTemplateLocal.update("INSERT INTO COMTNORGNZTINFO (ORGNZT_ID, ORGNZT_NM, ORGNZT_DC) VALUES ('O1','오래된조직','설명')");
+        jdbcTemplateLocal.update("INSERT INTO COMTNEMPLYRINFO (ESNTL_ID, EMPLYR_ID, ORGNZT_ID, USER_NM, REG_DTTM, MOD_DTTM) VALUES ('LND0000001','emp1','O1','기존이름',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)");
+    }
+
+    /**
+     * STG -> 로컬 이관 배치가 사원 정보를 갱신/삽입하고
+     * MySQL 변수 기반 ID 생성이 정상적으로 이루어지는지 검증한다.
+     */
+    @Test
+    void stgToLocalJob_updatesAndInsertsEmployees() throws Exception {
+        JobExecution execution = jobLauncherTestUtils.launchJob();
+        assertThat(execution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+
+        // 기존 사원 업데이트 확인
+        String updatedName = jdbcTemplateLocal.queryForObject(
+            "SELECT USER_NM FROM COMTNEMPLYRINFO WHERE EMPLYR_ID='emp1'",
+            String.class);
+        assertThat(updatedName).isEqualTo("홍길동");
+
+        // 신규 사원1 삽입 및 ID 생성 확인
+        Map<String, Object> emp2 = jdbcTemplateLocal.queryForMap(
+            "SELECT ESNTL_ID, USER_NM FROM COMTNEMPLYRINFO WHERE EMPLYR_ID='emp2'");
+        assertThat(emp2.get("USER_NM")).isEqualTo("새사원1");
+        assertThat(emp2.get("ESNTL_ID")).isEqualTo("LND0000002");
+
+        // 신규 사원2 삽입 및 ID 생성 확인
+        Map<String, Object> emp3 = jdbcTemplateLocal.queryForMap(
+            "SELECT ESNTL_ID, USER_NM FROM COMTNEMPLYRINFO WHERE EMPLYR_ID='emp3'");
+        assertThat(emp3.get("USER_NM")).isEqualTo("새사원2");
+        assertThat(emp3.get("ESNTL_ID")).isEqualTo("LND0000003");
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    migstg-mysql:
+      driver-class-name: org.h2.Driver
+      url: jdbc:h2:mem:stgdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false
+      username: sa
+      password:
+    egovlocal-mysql:
+      driver-class-name: org.h2.Driver
+      url: jdbc:h2:mem:localdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false
+      username: sa
+      password:
+  batch:
+    job:
+      enabled: false


### PR DESCRIPTION
## 변경 내용
- STG와 로컬 DB 간 동기화 배치 통합 테스트 작성
- 테스트용 H2 데이터소스 및 Batch 테스트 의존성 추가

## 테스트
- `mvn -q test` (실패: 네트워크 차단으로 의존성 다운로드 불가)


------
https://chatgpt.com/codex/tasks/task_e_68bc5610d980832ab25d7516a3041801