### PR TITLE
StepExecution을 사용해 읽기 건수 설정

### DIFF
--- a/src/main/java/egovframework/bat/job/insa/tasklet/StgToLocalEmployeeTasklet.java
+++ b/src/main/java/egovframework/bat/job/insa/tasklet/StgToLocalEmployeeTasklet.java
@@ -35,7 +35,8 @@ public class StgToLocalEmployeeTasklet implements Tasklet {
 
             // 처리 건수를 스텝 컨트리뷰션에 반영
             int total = updateCount + insertCount;
-            contribution.incrementReadCount(total);
+            // StepExecution을 직접 사용하여 읽기 건수를 설정
+            contribution.getStepExecution().setReadCount(total);
             contribution.incrementWriteCount(total);
         }
         return RepeatStatus.FINISHED;


### PR DESCRIPTION
## Summary
- StepExecution을 직접 활용해 읽기 건수를 설정하여 처리 건수 집계 정확성 향상

## Testing
- `mvn -e -o test` *(실패: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bc58af5a10832a88ec2019338efba4