### PR TITLE
직원 업데이트 조인 수정 및 STG 테이블 컬럼 추가

### DIFF
--- a/src/main/resources/egovframework/batch/mapper/job/insa/insa_stg_to_local.xml
+++ b/src/main/resources/egovframework/batch/mapper/job/insa/insa_stg_to_local.xml
@@ -30,10 +30,10 @@
                 FROM migstg.COMTNEMPLYRINFO
         </select>
 
-        <!-- ESNTL_ID로 기존 사원 정보를 갱신 -->
+        <!-- EMPLYR_ID를 기준으로 기존 사원 정보를 갱신 -->
         <update id="updateEmployee">
                 UPDATE egovlocal.COMTNEMPLYRINFO u
-                JOIN migstg.COMTNEMPLYRINFO s ON u.ESNTL_ID = s.ESNTL_ID
+                JOIN migstg.COMTNEMPLYRINFO s ON u.EMPLYR_ID = s.EMPLYR_ID
                 SET u.EMPLYR_ID = s.EMPLYR_ID,
                     u.USER_NM = s.USER_NM,
                     u.ORGNZT_ID = s.ORGNZT_ID,

--- a/src/script/mysql/test/2.stg_ddl-mysql.sql
+++ b/src/script/mysql/test/2.stg_ddl-mysql.sql
@@ -16,6 +16,7 @@ CREATE TABLE `comtnorgnztinfo` (
 
 -- 직원 테이블
 CREATE TABLE `comtnemplyrinfo` (
+  `ESNTL_ID` varchar(20) DEFAULT NULL COMMENT '고유ID',
   `EMPLYR_ID` varchar(20) NOT NULL COMMENT '업무사용자ID',
   `ORGNZT_ID` char(20) DEFAULT NULL COMMENT '조직ID',
   `USER_NM` varchar(60) NOT NULL COMMENT '사용자명',
@@ -29,6 +30,7 @@ CREATE TABLE `comtnemplyrinfo` (
   `MOD_DTTM` datetime DEFAULT NULL COMMENT '수정일자',
   PRIMARY KEY (`EMPLYR_ID`),
   UNIQUE KEY `COMTNEMPLYRINFO_PK` (`EMPLYR_ID`),
+  UNIQUE KEY `COMTNEMPLYRINFO_u01` (`ESNTL_ID`),
   KEY `COMTNEMPLYRINFO_i01` (`ORGNZT_ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='업무사용자정보';
 


### PR DESCRIPTION
## Summary
- updateEmployee 쿼리의 조인을 ESNTL_ID에서 EMPLYR_ID 기준으로 변경
- STG DDL에 ESNTL_ID 컬럼과 고유 인덱스를 추가하여 로컬 스키마와 호환

## Testing
- `mvn -q test` *(실패: 의존성 해석 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a937e18832aa6a469851b9ae784