### PR TITLE
사원 이관 시 SET과 INSERT 분리

### DIFF
--- a/src/main/java/egovframework/bat/job/insa/tasklet/StgToLocalEmployeeTasklet.java
+++ b/src/main/java/egovframework/bat/job/insa/tasklet/StgToLocalEmployeeTasklet.java
@@ -29,6 +29,8 @@ public class StgToLocalEmployeeTasklet implements Tasklet {
         try (SqlSession session = sqlSessionFactory.openSession()) {
             // 기존 사원 정보 갱신
             int updateCount = session.update("insaStgToLoc.updateEmployee");
+            // ESNTL_ID 시퀀스 초기화
+            session.update("insaStgToLoc.initEmployeeSeq");
             // 신규 사원 정보 추가
             int insertCount = session.insert("insaStgToLoc.insertEmployeeIncremental");
             session.commit();

--- a/src/main/resources/egovframework/batch/mapper/job/insa/insa_stg_to_local.xml
+++ b/src/main/resources/egovframework/batch/mapper/job/insa/insa_stg_to_local.xml
@@ -47,19 +47,23 @@
                     u.MOD_DTTM = s.MOD_DTTM
         </update>
 
-        <!-- STG에만 존재하는 사원을 로컬 DB에 신규 추가 -->
-        <insert id="insertEmployeeIncremental">
-                SET @seq := (
-                  SELECT MAX(CAST(SUBSTR(ESNTL_ID, 4) AS UNSIGNED))
-                  FROM egovlocal.COMTNEMPLYRINFO
-                );
-                INSERT INTO egovlocal.COMTNEMPLYRINFO (ESNTL_ID, EMPLYR_ID, ORGNZT_ID, USER_NM, SEXDSTN_CODE, BRTHDY, MBTLNUM, EMAIL_ADRES, OFCPS_NM, EMPLYR_STTUS_CODE, REG_DTTM, MOD_DTTM)
-                SELECT CONCAT('LND', LPAD(@seq := @seq + 1, 7, '0')) AS ESNTL_ID,
-                       s.EMPLYR_ID, s.ORGNZT_ID, s.USER_NM, s.SEXDSTN_CODE, s.BRTHDY, s.MBTLNUM, s.EMAIL_ADRES, s.OFCPS_NM, s.EMPLYR_STTUS_CODE, s.REG_DTTM, s.MOD_DTTM
-                FROM migstg.COMTNEMPLYRINFO s
-                LEFT JOIN egovlocal.COMTNEMPLYRINFO u ON u.ESNTL_ID = s.ESNTL_ID
-                WHERE u.ESNTL_ID IS NULL;
-        </insert>
+       <!-- 신규 사원 추가 전에 ESNTL_ID 시퀀스 초기화 -->
+       <update id="initEmployeeSeq">
+               SET @seq := (
+                 SELECT MAX(CAST(SUBSTR(ESNTL_ID, 4) AS UNSIGNED))
+                 FROM egovlocal.COMTNEMPLYRINFO
+               )
+       </update>
+
+       <!-- STG에만 존재하는 사원을 로컬 DB에 신규 추가 -->
+       <insert id="insertEmployeeIncremental">
+               INSERT INTO egovlocal.COMTNEMPLYRINFO (ESNTL_ID, EMPLYR_ID, ORGNZT_ID, USER_NM, SEXDSTN_CODE, BRTHDY, MBTLNUM, EMAIL_ADRES, OFCPS_NM, EMPLYR_STTUS_CODE, REG_DTTM, MOD_DTTM)
+               SELECT CONCAT('LND', LPAD(@seq := @seq + 1, 7, '0')) AS ESNTL_ID,
+                      s.EMPLYR_ID, s.ORGNZT_ID, s.USER_NM, s.SEXDSTN_CODE, s.BRTHDY, s.MBTLNUM, s.EMAIL_ADRES, s.OFCPS_NM, s.EMPLYR_STTUS_CODE, s.REG_DTTM, s.MOD_DTTM
+               FROM migstg.COMTNEMPLYRINFO s
+               LEFT JOIN egovlocal.COMTNEMPLYRINFO u ON u.ESNTL_ID = s.ESNTL_ID
+               WHERE u.ESNTL_ID IS NULL
+       </insert>
 
         <!-- 로컬 DB에 조직 정보 적재 -->
         <insert id="insertOrganization" parameterType="egovframework.bat.job.insa.domain.EmployeeInfo">


### PR DESCRIPTION
## Summary
- STG 사원 이관 쿼리에서 SET과 INSERT를 분리해 다중 쿼리 의존 제거
- 사원 Tasklet에서 분리된 시퀀스 초기화 쿼리 호출 추가

## Testing
- `mvn -q test` *(실패: 네트워크 문제로 부모 POM을 다운로드하지 못함)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5d313d48832a93cc27a1c90f4572