### PR TITLE
fix: compare employee by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ mvn -Pprod package    # 운영 환경 빌드
 
 ## STG 환경용 DDL 스크립트
 
-migstg 데이터베이스 초기화 시 `src/script/mysql/test/2.stg_ddl-mysql.sql`을 실행해 테이블 구조를 생성합니다. STG 연결 정보는 각 환경별 `application-<프로필>.yml` 파일의 관련 항목을 참고하세요. 
+migstg 데이터베이스 초기화 시 `src/script/mysql/test/2.stg_ddl-mysql.sql`을 실행해 테이블 구조를 생성합니다. STG 연결 정보는 각 환경별 `application-<프로필>.yml` 파일의 관련 항목을 참고하세요.
 해당 스크립트에는 REST 호출 실패 로그 테이블(`erp_api_fail_log`)과 DB 적재 실패 로그 테이블(`erp_db_fail_log`) DDL이 포함되어 있으며, `FetchErpDataTasklet`이 DB 적재 실패 시 이 테이블에 로그를 남깁니다.
+
+> **참고**: 증분 이관은 `EMPLYR_ID`로 중복 여부를 판단하므로 STG의 `COMTNEMPLYRINFO` 테이블에는 `ESNTL_ID` 컬럼이 필수는 아닙니다. 반면 로컬 DB는 `src/script/mysql/test/3.local_ddl-mysql.sql`에서처럼 `ESNTL_ID`를 기본 키로 사용하므로 컬럼을 반드시 유지해야 합니다.
 
 ## Quartz 스키마 초기화
 

--- a/src/main/resources/egovframework/batch/mapper/job/insa/insa_stg_to_local.xml
+++ b/src/main/resources/egovframework/batch/mapper/job/insa/insa_stg_to_local.xml
@@ -61,8 +61,9 @@
                SELECT CONCAT('LND', LPAD(@seq := @seq + 1, 7, '0')) AS ESNTL_ID,
                       s.EMPLYR_ID, s.ORGNZT_ID, s.USER_NM, s.SEXDSTN_CODE, s.BRTHDY, s.MBTLNUM, s.EMAIL_ADRES, s.OFCPS_NM, s.EMPLYR_STTUS_CODE, s.REG_DTTM, s.MOD_DTTM
                FROM migstg.COMTNEMPLYRINFO s
-               LEFT JOIN egovlocal.COMTNEMPLYRINFO u ON u.ESNTL_ID = s.ESNTL_ID
-               WHERE u.ESNTL_ID IS NULL
+               -- EMPLYR_ID를 기준으로 로컬 DB 존재 여부 확인
+               LEFT JOIN egovlocal.COMTNEMPLYRINFO u ON u.EMPLYR_ID = s.EMPLYR_ID
+               WHERE u.EMPLYR_ID IS NULL
        </insert>
 
         <!-- 로컬 DB에 조직 정보 적재 -->


### PR DESCRIPTION
## Summary
- switch incremental insert to compare by `EMPLYR_ID`
- document that local `COMTNEMPLYRINFO` still requires `ESNTL_ID` as primary key

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5ffc20ac832a823de7d896649493