### PR TITLE
ESNTL_ID 시퀀스 초기값 처리

### DIFF
--- a/src/main/resources/egovframework/batch/mapper/job/insa/insa_stg_to_local.xml
+++ b/src/main/resources/egovframework/batch/mapper/job/insa/insa_stg_to_local.xml
@@ -50,7 +50,7 @@
        <!-- 신규 사원 추가 전에 ESNTL_ID 시퀀스 초기화 -->
        <update id="initEmployeeSeq">
                SET @seq := (
-                 SELECT MAX(CAST(SUBSTR(ESNTL_ID, 4) AS UNSIGNED))
+                 SELECT IFNULL(MAX(CAST(SUBSTR(ESNTL_ID, 4) AS UNSIGNED)), 0)
                  FROM egovlocal.COMTNEMPLYRINFO
                )
        </update>


### PR DESCRIPTION
## Summary
- ESNTL_ID 시퀀스 조회 시 NULL이면 0으로 초기화하도록 수정해 신규 사원 ID 생성이 1부터 시작되도록 보장합니다.

## Testing
- `mvn -q -Dtest=egovframework.bat.job.insa.processor.InsaStgToLocalInitSeqTest test` *(실패: 원격 저장소 접근 불가로 의존성 해결 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6087adb0832aabfb720c510e952e