### PR TITLE
fix: 불필요한 역슬래시 제거

### DIFF
--- a/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
@@ -126,7 +126,7 @@ public class BatchSchedulerConfig {
         List<SchedulerJobDto> jobDtos = jdbcTemplate.query(
                 "SELECT t.JOB_NAME, c.CRON_EXPRESSION FROM qrtz_triggers t "
                         + "JOIN qrtz_cron_triggers c ON t.TRIGGER_NAME = c.TRIGGER_NAME AND t.TRIGGER_GROUP = c.TRIGGER_GROUP",
-                (rs, rowNum) -> new SchedulerJobDto(rs.getString(\"JOB_NAME\"), rs.getString(\"CRON_EXPRESSION\"))
+                (rs, rowNum) -> new SchedulerJobDto(rs.getString("JOB_NAME"), rs.getString("CRON_EXPRESSION"))
         );
 
         for (SchedulerJobDto jobDto : jobDtos) {


### PR DESCRIPTION
## Summary
- JDBC 조회 문자열에서 불필요한 이스케이프 제거

## Testing
- `mvn -q test` (네트워크 연결 실패로 부모 POM 해석 불가)

------
https://chatgpt.com/codex/tasks/task_e_68bd658c0018832abf61d2b9f71d2e74