### PR TITLE
빈 Map 지원을 위한 스케줄러 기본값 추가

### DIFF
--- a/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
@@ -44,8 +44,8 @@ public class BatchSchedulerConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(BatchSchedulerConfig.class);
 
     /** application.yml에서 읽어 온 잡 정보 (잡 이름: 크론 표현식) */
-    @Value("#{${scheduler.jobs}}")
-    private final Map<String, String> jobs;
+    @Value("#{${scheduler.jobs:{}}}")
+    private final Map<String, String> jobs; // 설정이 없으면 빈 Map 주입
 
 
     /**


### PR DESCRIPTION
## Summary
- scheduler.jobs 속성이 없을 때 빈 Map을 주입하여 NPE 방지

## Testing
- `mvn -q test` *(실패: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6a6309d0832aa4db5ceba89aa079