### PR TITLE
페이지 엔드포인트 문서에 스케줄러 목록 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ public class SampleTasklet implements Tasklet {
 ### 페이지(HTML) 엔드포인트
 - `GET /batch/detail` – 배치 상세 페이지
 - `GET /batch/list` – 배치 목록 페이지
+- `GET /scheduler/list` – 스케줄러 잡 목록 페이지
 - `GET /error` – 오류 페이지
 
 더 자세한 설명은 각 컨트롤러 소스 코드를 참고하세요.


### PR DESCRIPTION
## Summary
- README의 페이지(HTML) 엔드포인트 목록에 `GET /scheduler/list` 항목을 추가했습니다.

## Testing
- `mvn -q test` *(실패: org.springframework.boot:spring-boot-starter-parent 의존성을 받지 못했습니다)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7db38ae4832ab5ecf443feec8a05