### PR TITLE
feat: 크론 표현식 유효성 검사 추가

### DIFF
--- a/src/main/java/egovframework/bat/management/SchedulerManagementService.java
+++ b/src/main/java/egovframework/bat/management/SchedulerManagementService.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import egovframework.bat.management.dto.ScheduledJobDto;
+import egovframework.bat.management.exception.InvalidCronExpressionException;
 
 /**
  * Quartz 스케줄러를 제어하기 위한 서비스.
@@ -82,6 +83,11 @@ public class SchedulerManagementService {
      * @throws SchedulerException 스케줄러 작업 실패 시 발생
      */
     public void updateJobCron(String jobName, String cronExpression) throws SchedulerException {
+        // 크론 표현식 유효성 검사
+        if (!CronExpression.isValidExpression(cronExpression)) {
+            throw new InvalidCronExpressionException("유효하지 않은 크론 표현식입니다: " + cronExpression);
+        }
+
         TriggerKey triggerKey = TriggerKey.triggerKey(jobName + "Trigger");
         Trigger newTrigger = TriggerBuilder.newTrigger()
                 .withIdentity(triggerKey)

--- a/src/main/java/egovframework/bat/management/exception/InvalidCronExpressionException.java
+++ b/src/main/java/egovframework/bat/management/exception/InvalidCronExpressionException.java
@@ -1,0 +1,27 @@
+package egovframework.bat.management.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * 잘못된 크론 표현식 사용 시 발생하는 예외.
+ */
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class InvalidCronExpressionException extends RuntimeException {
+
+    /**
+     * 기본 생성자.
+     */
+    public InvalidCronExpressionException() {
+        super();
+    }
+
+    /**
+     * 예외 메시지를 포함한 생성자.
+     *
+     * @param message 예외 메시지
+     */
+    public InvalidCronExpressionException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Summary
- 크론 변경 시 유효하지 않은 표현식을 검사하도록 개선
- 잘못된 크론 표현식에 대해 400 오류를 반환하는 예외 추가

## Testing
- `mvn -q test` *(실패: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bd875498a0832abdc68bb689c613c0