### PR TITLE
CronRequest JSON 문자열 직렬화/역직렬화 지원

### DIFF
--- a/src/main/java/egovframework/bat/management/dto/CronRequest.java
+++ b/src/main/java/egovframework/bat/management/dto/CronRequest.java
@@ -1,14 +1,38 @@
 package egovframework.bat.management.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * 크론 표현식 변경 요청을 위한 DTO.
  */
 @Data
+@NoArgsConstructor
 public class CronRequest {
     /** 크론 표현식 */
     private String cronExpression;
+
+    /**
+     * 문자열 본문 역직렬화를 위한 생성자.
+     *
+     * @param cronExpression 크론 표현식
+     */
+    @JsonCreator
+    public CronRequest(String cronExpression) {
+        setCronExpression(cronExpression);
+    }
+
+    /**
+     * JSON 직렬화를 위한 Getter.
+     *
+     * @return 크론 표현식
+     */
+    @JsonValue
+    public String getCronExpression() {
+        return cronExpression;
+    }
 
     /**
      * 크론 표현식을 trim()하고 앞뒤 따옴표와 공백을 제거한다.

--- a/src/test/java/egovframework/bat/management/dto/CronRequestTest.java
+++ b/src/test/java/egovframework/bat/management/dto/CronRequestTest.java
@@ -1,0 +1,35 @@
+package egovframework.bat.management.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * CronRequest의 JSON 직렬화/역직렬화를 검증하는 테스트.
+ */
+public class CronRequestTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /** 문자열 본문에서 역직렬화되는지 테스트 */
+    @Test
+    public void deserializeFromStringBody() throws Exception {
+        CronRequest request = mapper.readValue("\"0 2 * * * ?\"", CronRequest.class);
+        assertEquals("0 2 * * * ?", request.getCronExpression());
+    }
+
+    /** 객체 본문에서 역직렬화되는지 테스트 */
+    @Test
+    public void deserializeFromObjectBody() throws Exception {
+        CronRequest request = mapper.readValue("{\"cronExpression\":\"0 2 * * * ?\"}", CronRequest.class);
+        assertEquals("0 2 * * * ?", request.getCronExpression());
+    }
+
+    /** 직렬화 시 문자열 본문으로 변환되는지 테스트 */
+    @Test
+    public void serializeToStringBody() throws Exception {
+        CronRequest request = new CronRequest("0 2 * * * ?");
+        String json = mapper.writeValueAsString(request);
+        assertEquals("\"0 2 * * * ?\"", json);
+    }
+}


### PR DESCRIPTION
## Summary
- CronRequest에 @JsonCreator 생성자와 @JsonValue getter 추가
- 문자열 및 객체 JSON 본문을 모두 처리하는 CronRequestTest 추가

## Testing
- `mvn -q test` *(실패: 네트워크 연결 문제로 의존성을 다운로드하지 못함)*

------
https://chatgpt.com/codex/tasks/task_e_68bd890a563c832aa5a165ba5c4b2589