### PR TITLE
feat: 내구성 잡 크론 변경 제한

### DIFF
--- a/src/main/java/egovframework/bat/management/SchedulerManagementController.java
+++ b/src/main/java/egovframework/bat/management/SchedulerManagementController.java
@@ -89,6 +89,7 @@ public class SchedulerManagementController {
     /**
      * 등록된 잡의 크론 표현식을 변경한다.
      * 프런트엔드는 {"cronExpression":"0 0/2 * * * ?"} 형태의 JSON으로 요청한다.
+     * 내구성 잡에 대해서는 400(Bad Request) 응답이 반환된다.
      *
      * @param jobName 잡 이름
      * @param request 크론 표현식 요청 DTO

--- a/src/main/java/egovframework/bat/management/SchedulerManagementService.java
+++ b/src/main/java/egovframework/bat/management/SchedulerManagementService.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import egovframework.bat.management.dto.ScheduledJobDto;
 import egovframework.bat.management.exception.InvalidCronExpressionException;
+import egovframework.bat.management.exception.DurableJobCronUpdateNotAllowedException;
 
 /**
  * Quartz 스케줄러를 제어하기 위한 서비스.
@@ -83,6 +84,12 @@ public class SchedulerManagementService {
      * @throws SchedulerException 스케줄러 작업 실패 시 발생
      */
     public void updateJobCron(String jobName, String cronExpression) throws SchedulerException {
+        JobDetail jobDetail = scheduler.getJobDetail(JobKey.jobKey(jobName));
+        if (jobDetail != null && jobDetail.isDurable()) {
+            throw new DurableJobCronUpdateNotAllowedException(
+                    "내구성 잡은 크론 표현식을 변경할 수 없습니다: " + jobName);
+        }
+
         // 크론 표현식 유효성 검사
         if (!CronExpression.isValidExpression(cronExpression)) {
             throw new InvalidCronExpressionException("유효하지 않은 크론 표현식입니다: " + cronExpression);

--- a/src/main/java/egovframework/bat/management/exception/DurableJobCronUpdateNotAllowedException.java
+++ b/src/main/java/egovframework/bat/management/exception/DurableJobCronUpdateNotAllowedException.java
@@ -1,0 +1,27 @@
+package egovframework.bat.management.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * 내구성 잡의 크론 표현식 변경을 시도할 때 발생하는 예외.
+ */
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class DurableJobCronUpdateNotAllowedException extends RuntimeException {
+
+    /**
+     * 기본 생성자.
+     */
+    public DurableJobCronUpdateNotAllowedException() {
+        super();
+    }
+
+    /**
+     * 예외 메시지를 포함한 생성자.
+     *
+     * @param message 예외 메시지
+     */
+    public DurableJobCronUpdateNotAllowedException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Summary
- 내구성 잡의 크론 변경 시 예외 `DurableJobCronUpdateNotAllowedException` 추가
- 서비스에서 내구성 잡 여부를 확인하고 크론 변경 차단
- 컨트롤러 문서에 내구성 잡 요청 시 400 응답 안내

## Testing
- `mvn -q test` *(실패: org.springframework.boot:spring-boot-starter-parent 의존성 해석 불가, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8e09b158832aab8320cb74b4cb9b