### PR TITLE
스케줄러 내구성 정보 제공 및 프런트 갱신

### DIFF
--- a/README_DETAILED.md
+++ b/README_DETAILED.md
@@ -23,7 +23,7 @@ JobProgressController.java : 배치 진행 상황을 SSE 스트림으로 전달
 
 ## egovframework.bat.management.dto
 JobProgress.java : 작업명과 상태를 담는 진행 상황 DTO
-ScheduledJobDto.java : 잡 이름·크론 표현식·상태를 담는 스케줄 DTO
+ScheduledJobDto.java : 잡 이름·크론 표현식·상태·내구성 여부를 담는 스케줄 DTO
 
 ## egovframework.bat.management
 JobProgressService.java : Reactor Sinks로 진행 상황을 전송하는 서비스

--- a/src/main/java/egovframework/bat/management/SchedulerManagementService.java
+++ b/src/main/java/egovframework/bat/management/SchedulerManagementService.java
@@ -109,6 +109,7 @@ public class SchedulerManagementService {
             List<? extends Trigger> triggers = scheduler.getTriggersOfJob(jobKey);
             String cronExpression = "";
             String status = "";
+            boolean durable = false;
             if (!triggers.isEmpty()) {
                 Trigger trigger = triggers.get(0);
                 if (trigger instanceof CronTrigger) {
@@ -116,7 +117,11 @@ public class SchedulerManagementService {
                 }
                 status = scheduler.getTriggerState(trigger.getKey()).name();
             }
-            jobs.add(new ScheduledJobDto(jobKey.getName(), cronExpression, status));
+            JobDetail jobDetail = scheduler.getJobDetail(jobKey);
+            if (jobDetail != null) {
+                durable = jobDetail.isDurable();
+            }
+            jobs.add(new ScheduledJobDto(jobKey.getName(), cronExpression, status, durable));
         }
         return jobs;
     }
@@ -136,6 +141,7 @@ public class SchedulerManagementService {
         List<? extends Trigger> triggers = scheduler.getTriggersOfJob(jobKey);
         String cronExpression = "";
         String status = "";
+        boolean durable = false;
         if (!triggers.isEmpty()) {
             Trigger trigger = triggers.get(0);
             if (trigger instanceof CronTrigger) {
@@ -143,7 +149,11 @@ public class SchedulerManagementService {
             }
             status = scheduler.getTriggerState(trigger.getKey()).name();
         }
-        return new ScheduledJobDto(jobName, cronExpression, status);
+        JobDetail jobDetail = scheduler.getJobDetail(jobKey);
+        if (jobDetail != null) {
+            durable = jobDetail.isDurable();
+        }
+        return new ScheduledJobDto(jobName, cronExpression, status, durable);
     }
 }
 

--- a/src/main/java/egovframework/bat/management/dto/ScheduledJobDto.java
+++ b/src/main/java/egovframework/bat/management/dto/ScheduledJobDto.java
@@ -15,4 +15,6 @@ public class ScheduledJobDto {
     private String cronExpression;
     /** 현재 상태 */
     private String status;
+    /** 내구성 여부 */
+    private boolean durable;
 }

--- a/src/main/resources/static/js/scheduler-list.js
+++ b/src/main/resources/static/js/scheduler-list.js
@@ -22,6 +22,10 @@ document.addEventListener('DOMContentLoaded', () => {
                     statusTd.textContent = job.status;
                     tr.appendChild(statusTd);
 
+                    const durableTd = document.createElement('td');
+                    durableTd.textContent = job.durable;
+                    tr.appendChild(durableTd);
+
                     const actionTd = document.createElement('td');
                     const btn = document.createElement('button');
                     btn.textContent = '크론 수정';

--- a/src/main/resources/templates/scheduler/list.html
+++ b/src/main/resources/templates/scheduler/list.html
@@ -14,6 +14,7 @@
         <th>잡 이름</th>
         <th>크론 표현식</th>
         <th>상태</th>
+        <th>Durable</th>
         <th>액션</th>
     </tr>
     </thead>

--- a/src/test/java/egovframework/bat/management/SchedulerManagementServiceTest.java
+++ b/src/test/java/egovframework/bat/management/SchedulerManagementServiceTest.java
@@ -1,0 +1,81 @@
+package egovframework.bat.management;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.*;
+
+import java.util.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.quartz.*;
+import org.quartz.jobs.NoOpJob;
+
+import egovframework.bat.management.dto.ScheduledJobDto;
+
+/**
+ * SchedulerManagementService의 내구성 필드 처리를 검증한다.
+ */
+public class SchedulerManagementServiceTest {
+
+    private SchedulerManagementService schedulerManagementService;
+
+    @Mock
+    private Scheduler scheduler;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        schedulerManagementService = new SchedulerManagementService(scheduler);
+    }
+
+    @Test
+    public void listJobsIncludesDurableFlag() throws Exception {
+        JobKey jobKey = JobKey.jobKey("testJob");
+        Set<JobKey> jobKeys = new HashSet<>();
+        jobKeys.add(jobKey);
+        when(scheduler.getJobKeys(any())).thenReturn(jobKeys);
+
+        JobDetail jobDetail = JobBuilder.newJob(NoOpJob.class)
+                .withIdentity(jobKey)
+                .storeDurably(true)
+                .build();
+        when(scheduler.getJobDetail(jobKey)).thenReturn(jobDetail);
+
+        CronTrigger trigger = TriggerBuilder.newTrigger()
+                .withIdentity("testJobTrigger")
+                .withSchedule(CronScheduleBuilder.cronSchedule("0/5 * * * * ?"))
+                .build();
+        when(scheduler.getTriggersOfJob(jobKey)).thenReturn(Collections.singletonList(trigger));
+        when(scheduler.getTriggerState(trigger.getKey())).thenReturn(Trigger.TriggerState.NORMAL);
+
+        List<ScheduledJobDto> jobs = schedulerManagementService.listJobs();
+        assertEquals(1, jobs.size());
+        assertTrue(jobs.get(0).isDurable());
+    }
+
+    @Test
+    public void getJobReturnsDurableFlag() throws Exception {
+        JobKey jobKey = JobKey.jobKey("testJob");
+        when(scheduler.checkExists(jobKey)).thenReturn(true);
+
+        JobDetail jobDetail = JobBuilder.newJob(NoOpJob.class)
+                .withIdentity(jobKey)
+                .storeDurably(false)
+                .build();
+        when(scheduler.getJobDetail(jobKey)).thenReturn(jobDetail);
+
+        CronTrigger trigger = TriggerBuilder.newTrigger()
+                .withIdentity("testJobTrigger")
+                .withSchedule(CronScheduleBuilder.cronSchedule("0/5 * * * * ?"))
+                .build();
+        when(scheduler.getTriggersOfJob(jobKey)).thenReturn(Collections.singletonList(trigger));
+        when(scheduler.getTriggerState(trigger.getKey())).thenReturn(Trigger.TriggerState.NORMAL);
+
+        ScheduledJobDto job = schedulerManagementService.getJob("testJob");
+        assertNotNull(job);
+        assertFalse(job.isDurable());
+    }
+}


### PR DESCRIPTION
## Summary
- Quartz 잡 DTO에 durable 필드를 추가해 내구성 여부를 응답
- 스케줄러 서비스에서 JobDetail의 durable 값을 읽어 DTO에 반영
- UI 테이블에 durable 컬럼을 표시하고 관련 테스트 추가

## Testing
- `mvn -q test` *(실패: parent POM을 내려받지 못함)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8e2957f4832abfed2dd71b5a4b8c