### PR TITLE
Refactor trigger list in scheduler tests

### DIFF
--- a/src/test/java/egovframework/bat/management/SchedulerManagementServiceTest.java
+++ b/src/test/java/egovframework/bat/management/SchedulerManagementServiceTest.java
@@ -48,7 +48,9 @@ public class SchedulerManagementServiceTest {
                 .withIdentity("testJobTrigger")
                 .withSchedule(CronScheduleBuilder.cronSchedule("0/5 * * * * ?"))
                 .build();
-        when(scheduler.getTriggersOfJob(jobKey)).thenReturn(Collections.singletonList(trigger));
+        // 트리거 리스트 생성
+        List<Trigger> triggers = Collections.<Trigger>singletonList(trigger);
+        when(scheduler.getTriggersOfJob(jobKey)).thenReturn(triggers);
         when(scheduler.getTriggerState(trigger.getKey())).thenReturn(Trigger.TriggerState.NORMAL);
 
         List<ScheduledJobDto> jobs = schedulerManagementService.listJobs();
@@ -71,7 +73,9 @@ public class SchedulerManagementServiceTest {
                 .withIdentity("testJobTrigger")
                 .withSchedule(CronScheduleBuilder.cronSchedule("0/5 * * * * ?"))
                 .build();
-        when(scheduler.getTriggersOfJob(jobKey)).thenReturn(Collections.singletonList(trigger));
+        // 트리거 리스트 생성
+        List<Trigger> triggers = Collections.<Trigger>singletonList(trigger);
+        when(scheduler.getTriggersOfJob(jobKey)).thenReturn(triggers);
         when(scheduler.getTriggerState(trigger.getKey())).thenReturn(Trigger.TriggerState.NORMAL);
 
         ScheduledJobDto job = schedulerManagementService.getJob("testJob");


### PR DESCRIPTION
## Summary
- refactor SchedulerManagementServiceTest to create trigger list variable before mocking

## Testing
- `mvn -q test -Dtest=SchedulerManagementServiceTest` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bd90771280832aa3c61f0d5ced9a0d