### PR TITLE
fix: resolve generic mocking compilation error

### DIFF
--- a/src/test/java/egovframework/bat/management/SchedulerManagementServiceTest.java
+++ b/src/test/java/egovframework/bat/management/SchedulerManagementServiceTest.java
@@ -44,13 +44,12 @@ public class SchedulerManagementServiceTest {
                 .build();
         when(scheduler.getJobDetail(jobKey)).thenReturn(jobDetail);
 
-        CronTrigger trigger = TriggerBuilder.newTrigger()
+        Trigger trigger = TriggerBuilder.newTrigger()
                 .withIdentity("testJobTrigger")
                 .withSchedule(CronScheduleBuilder.cronSchedule("0/5 * * * * ?"))
                 .build();
-        // 트리거 리스트 생성
-        List<Trigger> triggers = Collections.<Trigger>singletonList(trigger);
-        when(scheduler.getTriggersOfJob(jobKey)).thenReturn(triggers);
+        // 트리거 리스트 모킹
+        doReturn(Collections.singletonList(trigger)).when(scheduler).getTriggersOfJob(jobKey);
         when(scheduler.getTriggerState(trigger.getKey())).thenReturn(Trigger.TriggerState.NORMAL);
 
         List<ScheduledJobDto> jobs = schedulerManagementService.listJobs();
@@ -69,13 +68,12 @@ public class SchedulerManagementServiceTest {
                 .build();
         when(scheduler.getJobDetail(jobKey)).thenReturn(jobDetail);
 
-        CronTrigger trigger = TriggerBuilder.newTrigger()
+        Trigger trigger = TriggerBuilder.newTrigger()
                 .withIdentity("testJobTrigger")
                 .withSchedule(CronScheduleBuilder.cronSchedule("0/5 * * * * ?"))
                 .build();
-        // 트리거 리스트 생성
-        List<Trigger> triggers = Collections.<Trigger>singletonList(trigger);
-        when(scheduler.getTriggersOfJob(jobKey)).thenReturn(triggers);
+        // 트리거 리스트 모킹
+        doReturn(Collections.singletonList(trigger)).when(scheduler).getTriggersOfJob(jobKey);
         when(scheduler.getTriggerState(trigger.getKey())).thenReturn(Trigger.TriggerState.NORMAL);
 
         ScheduledJobDto job = schedulerManagementService.getJob("testJob");


### PR DESCRIPTION
## Summary
- replace CronTrigger with Trigger and use doReturn for mocking trigger lists to avoid generic capture issues

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for egov.batch:testBatch:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bd90c95aa4832a939bc247f203919a