### PR TITLE
Durable 잡 수정 방지

### DIFF
--- a/src/main/resources/static/js/scheduler-list.js
+++ b/src/main/resources/static/js/scheduler-list.js
@@ -29,16 +29,24 @@ document.addEventListener('DOMContentLoaded', () => {
                     const actionTd = document.createElement('td');
                     const btn = document.createElement('button');
                     btn.textContent = '크론 수정';
-                    btn.addEventListener('click', () => {
-                        const cron = prompt('새 크론 표현식을 입력하세요', job.cronExpression);
-                        if (cron) {
-                            fetch(`/api/scheduler/jobs/${job.jobName}`, {
-                                method: 'PUT',
-                                headers: { 'Content-Type': 'application/json' },
-                                body: JSON.stringify(cron)
-                            }).then(() => load());
-                        }
-                    });
+
+                    // Durable 잡은 수정하지 못하도록 비활성화하고 안내 문구를 제공
+                    if (job.durable === true) {
+                        btn.disabled = true;
+                        btn.title = 'Durable 잡은 수정할 수 없습니다.';
+                    } else {
+                        // Durable이 아닐 때만 클릭 이벤트를 등록
+                        btn.addEventListener('click', () => {
+                            const cron = prompt('새 크론 표현식을 입력하세요', job.cronExpression);
+                            if (cron) {
+                                fetch(`/api/scheduler/jobs/${job.jobName}`, {
+                                    method: 'PUT',
+                                    headers: { 'Content-Type': 'application/json' },
+                                    body: JSON.stringify(cron)
+                                }).then(() => load());
+                            }
+                        });
+                    }
                     actionTd.appendChild(btn);
                     tr.appendChild(actionTd);
 


### PR DESCRIPTION
## Summary
- Durable 잡은 크론 수정 버튼을 비활성화하고 안내 툴팁 추가
- Durable이 아닌 잡에만 크론 수정 이벤트 등록

## Testing
- `mvn -q test` *(실패: parent POM을 내려받지 못했습니다)*

------
https://chatgpt.com/codex/tasks/task_e_68bd93710794832abe29ce8b41e6dc0c