### PR TITLE
스케줄러 Durable 작업 버튼 처리 개선

### DIFF
--- a/src/main/resources/static/js/scheduler-list.js
+++ b/src/main/resources/static/js/scheduler-list.js
@@ -28,34 +28,39 @@ document.addEventListener('DOMContentLoaded', () => {
 
                     const actionTd = document.createElement('td');
 
-                    // 상태에 따라 일시 중지 또는 재개 버튼을 생성
+                    // 일시 중지/재개 버튼 생성 후 상태에 따라 텍스트 설정
                     const pauseBtn = document.createElement('button');
-                    if (job.status === 'PAUSED') {
-                        pauseBtn.textContent = '재개';
-                        pauseBtn.addEventListener('click', () => {
-                            fetch(`/api/scheduler/jobs/${job.jobName}/resume`, { method: 'POST' })
-                                .then(res => {
-                                    if (res.ok) {
-                                        load(); // 성공 시 목록 갱신
-                                    } else {
-                                        res.text().then(text => alert(text || '재개에 실패했습니다.'));
-                                    }
-                                })
-                                .catch(() => alert('재개 중 오류가 발생했습니다.'));
-                        });
+                    pauseBtn.textContent = job.status === 'PAUSED' ? '재개' : '일시 중지';
+
+                    if (job.durable === true) {
+                        pauseBtn.disabled = true;
+                        pauseBtn.title = 'Durable 잡은 일시 중지/재개할 수 없습니다.';
                     } else {
-                        pauseBtn.textContent = '일시 중지';
-                        pauseBtn.addEventListener('click', () => {
-                            fetch(`/api/scheduler/jobs/${job.jobName}/pause`, { method: 'POST' })
-                                .then(res => {
-                                    if (res.ok) {
-                                        load(); // 성공 시 목록 갱신
-                                    } else {
-                                        res.text().then(text => alert(text || '일시 중지에 실패했습니다.'));
-                                    }
-                                })
-                                .catch(() => alert('일시 중지 중 오류가 발생했습니다.'));
-                        });
+                        if (job.status === 'PAUSED') {
+                            pauseBtn.addEventListener('click', () => {
+                                fetch(`/api/scheduler/jobs/${job.jobName}/resume`, { method: 'POST' })
+                                    .then(res => {
+                                        if (res.ok) {
+                                            load(); // 성공 시 목록 갱신
+                                        } else {
+                                            res.text().then(text => alert(text || '재개에 실패했습니다.'));
+                                        }
+                                    })
+                                    .catch(() => alert('재개 중 오류가 발생했습니다.'));
+                            });
+                        } else {
+                            pauseBtn.addEventListener('click', () => {
+                                fetch(`/api/scheduler/jobs/${job.jobName}/pause`, { method: 'POST' })
+                                    .then(res => {
+                                        if (res.ok) {
+                                            load(); // 성공 시 목록 갱신
+                                        } else {
+                                            res.text().then(text => alert(text || '일시 중지에 실패했습니다.'));
+                                        }
+                                    })
+                                    .catch(() => alert('일시 중지 중 오류가 발생했습니다.'));
+                            });
+                        }
                     }
                     actionTd.appendChild(pauseBtn);
 


### PR DESCRIPTION
## Summary
- Durable 잡 처리 시 일시 중지/재개 버튼 상태와 안내 문구를 추가했습니다.
- Durable이 아닌 경우에만 pause/resume 이벤트를 등록하도록 조건을 재구성했습니다.

## Testing
- ⚠️ `mvn -q test` (부모 POM을 받을 수 없어 실패: Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68bed7d7e560832aac38c3be15a6df3d