### PR TITLE
스케줄러 삭제·크론 수정 엔드포인트 POST로 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ public class SampleTasklet implements Tasklet {
 | StgToRestJobController | STG 데이터를 외부 REST API로 전송 | `/api/batch` | `/erp-stg-to-rest` |
 | RestToStgJobController | ERP REST 데이터를 STG 테이블로 적재 | `/api/batch` | `/erp-rest-to-stg` |
 | VehicleController | ERP 서비스용 차량 정보를 조회 | `/api/v1` | `/vehicles` |
-| SchedulerManagementController | Quartz 잡 등록·일시중지·재개·삭제·크론 수정 API 제공 | `/api/scheduler` | `/jobs`, `/jobs/{jobName}/pause`, `/jobs/{jobName}/resume`, `/jobs/{jobName}`, `/jobs/{jobName}`(PUT) |
+| SchedulerManagementController | Quartz 잡 등록·일시중지·재개·삭제·크론 수정 API 제공 | `/api/scheduler` | `/jobs`, `/jobs/{jobName}/pause`, `/jobs/{jobName}/resume`, `/jobs/{jobName}/delete`, `/jobs/{jobName}/cron` |
 | SchedulerPageController | 스케줄러 잡 목록 화면을 렌더링 | `/scheduler` | `/list` |
 
 ## API 엔드포인트
@@ -250,8 +250,8 @@ public class SampleTasklet implements Tasklet {
 - `POST /api/scheduler/jobs` – 새 잡 등록 (`jobName`, `jobClass`, `cronExpression` 필요)
 - `POST /api/scheduler/jobs/{jobName}/pause` – 해당 잡 일시 중지
 - `POST /api/scheduler/jobs/{jobName}/resume` – 해당 잡 재개
-- `PUT /api/scheduler/jobs/{jobName}` – 해당 잡의 크론 표현식 변경 (요청 본문에 크론식 전달)
-- `DELETE /api/scheduler/jobs/{jobName}` – 해당 잡 삭제
+- `POST /api/scheduler/jobs/{jobName}/cron` – 해당 잡의 크론 표현식 변경 (요청 본문에 크론식 전달)
+- `POST /api/scheduler/jobs/{jobName}/delete` – 해당 잡 삭제
 * 크론 표현식 변경 내용은 Quartz DB에 저장되어 재시작 후에도 유지된다.
 
 ### 개별 Job 실행 API

--- a/src/main/java/egovframework/bat/management/SchedulerManagementController.java
+++ b/src/main/java/egovframework/bat/management/SchedulerManagementController.java
@@ -3,14 +3,12 @@ package egovframework.bat.management;
 import lombok.RequiredArgsConstructor;
 import org.quartz.SchedulerException;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -82,7 +80,7 @@ public class SchedulerManagementController {
      * @return 처리 결과
      * @throws SchedulerException 스케줄러 작업 실패 시 발생
      */
-    @DeleteMapping("/jobs/{jobName}")
+    @PostMapping("/jobs/{jobName}/delete")
     public ResponseEntity<Void> deleteJob(@PathVariable String jobName) throws SchedulerException {
         schedulerManagementService.deleteJob(jobName);
         return ResponseEntity.ok().build();
@@ -98,7 +96,7 @@ public class SchedulerManagementController {
      * @return 처리 결과
      * @throws SchedulerException 스케줄러 작업 실패 시 발생
      */
-    @PutMapping("/jobs/{jobName}")
+    @PostMapping("/jobs/{jobName}/cron")
     public ResponseEntity<Void> updateJobCron(@PathVariable String jobName,
             @RequestBody CronRequest request) throws SchedulerException {
         schedulerManagementService.updateJobCron(jobName, request.getCronExpression());

--- a/src/main/resources/static/js/scheduler-list.js
+++ b/src/main/resources/static/js/scheduler-list.js
@@ -76,8 +76,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         cronBtn.addEventListener('click', () => {
                             const cron = prompt('새 크론 표현식을 입력하세요', job.cronExpression);
                             if (cron) {
-                                fetch(`/api/scheduler/jobs/${job.jobName}`, {
-                                    method: 'PUT',
+                                fetch(`/api/scheduler/jobs/${job.jobName}/cron`, {
+                                    method: 'POST',
                                     headers: { 'Content-Type': 'application/json' },
                                     body: JSON.stringify({ cronExpression: cron }) // 크론 표현식을 JSON으로 전송
                                 })


### PR DESCRIPTION
## Summary
- 삭제와 크론 수정 API를 POST 엔드포인트로 변환
- 프런트엔드 fetch 호출을 변경된 경로에 맞춰 POST로 수정
- 관련 README 문서 업데이트

## Testing
- `mvn -q test` *(실패: parent POM을 해석할 수 없음)*

------
https://chatgpt.com/codex/tasks/task_e_68bedd22a0f4832a9701795b7324e24c