### PR TITLE
배치·스케줄러 관리 패키지 구조 정리

### DIFF
--- a/src/main/java/egovframework/bat/api/BatchApiController.java
+++ b/src/main/java/egovframework/bat/api/BatchApiController.java
@@ -1,6 +1,6 @@
 package egovframework.bat.api;
 
-import egovframework.bat.service.BatchManagementService;
+import egovframework.bat.management.batch.service.BatchManagementService;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/egovframework/bat/job/common/api/JobRunController.java
+++ b/src/main/java/egovframework/bat/job/common/api/JobRunController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import egovframework.bat.management.JobProgressService;
+import egovframework.bat.management.batch.service.JobProgressService;
 import egovframework.bat.service.JobLockService;
 
 /**

--- a/src/main/java/egovframework/bat/management/batch/api/BatchManagementController.java
+++ b/src/main/java/egovframework/bat/management/batch/api/BatchManagementController.java
@@ -1,4 +1,4 @@
-package egovframework.bat.management.api;
+package egovframework.bat.management.batch.api;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import egovframework.bat.repository.dto.BatchJobExecutionDto;
-import egovframework.bat.service.BatchManagementService;
+import egovframework.bat.management.batch.service.BatchManagementService;
 
 /**
  * 배치 잡 조회와 제어를 위한 REST 컨트롤러.

--- a/src/main/java/egovframework/bat/management/batch/api/JobProgressController.java
+++ b/src/main/java/egovframework/bat/management/batch/api/JobProgressController.java
@@ -1,4 +1,4 @@
-package egovframework.bat.management.api;
+package egovframework.bat.management.batch.api;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -6,8 +6,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import egovframework.bat.management.JobProgressService;
-import egovframework.bat.management.dto.JobProgress;
+import egovframework.bat.management.batch.service.JobProgressService;
+import egovframework.bat.management.batch.dto.JobProgress;
 import reactor.core.publisher.Flux;
 import org.springframework.http.codec.ServerSentEvent;
 

--- a/src/main/java/egovframework/bat/management/batch/dto/JobProgress.java
+++ b/src/main/java/egovframework/bat/management/batch/dto/JobProgress.java
@@ -1,4 +1,4 @@
-package egovframework.bat.management.dto;
+package egovframework.bat.management.batch.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/egovframework/bat/management/batch/service/BatchManagementService.java
+++ b/src/main/java/egovframework/bat/management/batch/service/BatchManagementService.java
@@ -1,6 +1,8 @@
-package egovframework.bat.service;
+package egovframework.bat.management.batch.service;
 
 import java.util.List;
+
+import egovframework.bat.service.BatchManagementMapper;
 
 import egovframework.bat.service.dto.JobExecutionDto;
 import java.time.ZoneId;

--- a/src/main/java/egovframework/bat/management/batch/service/JobProgressService.java
+++ b/src/main/java/egovframework/bat/management/batch/service/JobProgressService.java
@@ -1,9 +1,9 @@
-package egovframework.bat.management;
+package egovframework.bat.management.batch.service;
 
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.stereotype.Service;
 
-import egovframework.bat.management.dto.JobProgress;
+import egovframework.bat.management.batch.dto.JobProgress;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 

--- a/src/main/java/egovframework/bat/management/scheduler/api/SchedulerManagementController.java
+++ b/src/main/java/egovframework/bat/management/scheduler/api/SchedulerManagementController.java
@@ -1,4 +1,4 @@
-package egovframework.bat.management;
+package egovframework.bat.management.scheduler.api;
 
 import lombok.RequiredArgsConstructor;
 import org.quartz.SchedulerException;
@@ -13,10 +13,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import java.util.List;
+import egovframework.bat.management.scheduler.service.SchedulerManagementService;
 
-import egovframework.bat.management.dto.ScheduledJobDto;
-import egovframework.bat.management.dto.CronRequest;
-import egovframework.bat.management.exception.DurableJobPauseResumeNotAllowedException;
+import egovframework.bat.management.scheduler.dto.ScheduledJobDto;
+import egovframework.bat.management.scheduler.dto.CronRequest;
+import egovframework.bat.management.scheduler.exception.DurableJobPauseResumeNotAllowedException;
 
 /**
  * Quartz 스케줄러 제어를 위한 REST 컨트롤러.

--- a/src/main/java/egovframework/bat/management/scheduler/dto/CronRequest.java
+++ b/src/main/java/egovframework/bat/management/scheduler/dto/CronRequest.java
@@ -1,4 +1,4 @@
-package egovframework.bat.management.dto;
+package egovframework.bat.management.scheduler.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/src/main/java/egovframework/bat/management/scheduler/dto/ScheduledJobDto.java
+++ b/src/main/java/egovframework/bat/management/scheduler/dto/ScheduledJobDto.java
@@ -1,4 +1,4 @@
-package egovframework.bat.management.dto;
+package egovframework.bat.management.scheduler.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/egovframework/bat/management/scheduler/exception/DurableJobCronUpdateNotAllowedException.java
+++ b/src/main/java/egovframework/bat/management/scheduler/exception/DurableJobCronUpdateNotAllowedException.java
@@ -1,4 +1,4 @@
-package egovframework.bat.management.exception;
+package egovframework.bat.management.scheduler.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;

--- a/src/main/java/egovframework/bat/management/scheduler/exception/DurableJobPauseResumeNotAllowedException.java
+++ b/src/main/java/egovframework/bat/management/scheduler/exception/DurableJobPauseResumeNotAllowedException.java
@@ -1,4 +1,4 @@
-package egovframework.bat.management.exception;
+package egovframework.bat.management.scheduler.exception;
 
 /**
  * 내구성 잡의 일시 중지 또는 재개를 시도할 때 발생하는 예외.

--- a/src/main/java/egovframework/bat/management/scheduler/exception/InvalidCronExpressionException.java
+++ b/src/main/java/egovframework/bat/management/scheduler/exception/InvalidCronExpressionException.java
@@ -1,4 +1,4 @@
-package egovframework.bat.management.exception;
+package egovframework.bat.management.scheduler.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;

--- a/src/main/java/egovframework/bat/management/scheduler/service/SchedulerManagementService.java
+++ b/src/main/java/egovframework/bat/management/scheduler/service/SchedulerManagementService.java
@@ -1,4 +1,4 @@
-package egovframework.bat.management;
+package egovframework.bat.management.scheduler.service;
 
 import lombok.RequiredArgsConstructor;
 import org.quartz.*;
@@ -8,10 +8,10 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 
-import egovframework.bat.management.dto.ScheduledJobDto;
-import egovframework.bat.management.exception.InvalidCronExpressionException;
-import egovframework.bat.management.exception.DurableJobCronUpdateNotAllowedException;
-import egovframework.bat.management.exception.DurableJobPauseResumeNotAllowedException;
+import egovframework.bat.management.scheduler.dto.ScheduledJobDto;
+import egovframework.bat.management.scheduler.exception.InvalidCronExpressionException;
+import egovframework.bat.management.scheduler.exception.DurableJobCronUpdateNotAllowedException;
+import egovframework.bat.management.scheduler.exception.DurableJobPauseResumeNotAllowedException;
 
 /**
  * Quartz 스케줄러를 제어하기 위한 서비스.

--- a/src/main/java/egovframework/bat/scheduler/EgovQuartzJobLauncher.java
+++ b/src/main/java/egovframework/bat/scheduler/EgovQuartzJobLauncher.java
@@ -33,7 +33,7 @@ import org.springframework.batch.core.launch.NoSuchJobException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.quartz.QuartzJobBean;
 
-import egovframework.bat.management.JobProgressService;
+import egovframework.bat.management.batch.service.JobProgressService;
 import egovframework.bat.service.JobLockService;
 
 /**

--- a/src/test/java/egovframework/bat/management/batch/service/BatchManagementServiceTest.java
+++ b/src/test/java/egovframework/bat/management/batch/service/BatchManagementServiceTest.java
@@ -1,4 +1,4 @@
-package egovframework.bat.service;
+package egovframework.bat.management.batch.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import egovframework.bat.service.BatchManagementMapper;
 import egovframework.bat.service.dto.JobExecutionDto;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.Job;

--- a/src/test/java/egovframework/bat/management/scheduler/dto/CronRequestTest.java
+++ b/src/test/java/egovframework/bat/management/scheduler/dto/CronRequestTest.java
@@ -1,4 +1,4 @@
-package egovframework.bat.management.dto;
+package egovframework.bat.management.scheduler.dto;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;

--- a/src/test/java/egovframework/bat/management/scheduler/service/SchedulerManagementServiceTest.java
+++ b/src/test/java/egovframework/bat/management/scheduler/service/SchedulerManagementServiceTest.java
@@ -1,4 +1,4 @@
-package egovframework.bat.management;
+package egovframework.bat.management.scheduler.service;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -13,7 +13,7 @@ import org.mockito.MockitoAnnotations;
 import org.quartz.*;
 import org.quartz.jobs.NoOpJob;
 
-import egovframework.bat.management.dto.ScheduledJobDto;
+import egovframework.bat.management.scheduler.dto.ScheduledJobDto;
 
 /**
  * SchedulerManagementService의 내구성 필드 처리를 검증한다.


### PR DESCRIPTION
## 요약
- 배치 관리 컨트롤러·서비스·DTO를 management.batch 패키지로 이동하고 경로 변경에 따른 import/패키지 선언 수정
- 스케줄러 관리 모듈을 management.scheduler 하위로 분리하고 예외 및 DTO/서비스 클래스 정리
- 관련 테스트와 외부 컨트롤러의 의존성 경로를 모두 새 구조로 업데이트

## 테스트
- `mvn -q -e test` (네트워크 문제로 parent POM을 받지 못해 실패)


------
https://chatgpt.com/codex/tasks/task_e_68bedff2f3e4832abfefb7b6d8d1d843