### PR TITLE
관리 API 경로 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ public class SampleTasklet implements Tasklet {
 | 컨트롤러 | 역할 요약 | 기본 URL | 주요 하위 경로 |
 | --- | --- | --- | --- |
 | BatchApiController | 배치 잡 목록 조회, 실행 이력/상세, 에러 로그, 재시작·중지 등 관리 API 제공 | `/api/batch` | `/jobs`, `/jobs/{jobName}/executions`, `/executions/{execId}`, `/error-log`, `/jobs/{jobName}/restart`, `/jobs/{jobName}` |
-| BatchManagementController | DTO 기반 관리용 API로 잡 목록·이력·에러 로그·재시작/중지 기능 제공 | `/api/batch/management` | `/jobs`, `/jobs/{jobName}/executions`, `/executions/{jobExecutionId}/errors`, `/jobs/{jobName}/restart`, `/jobs/{jobName}/stop` |
-| JobProgressController | 배치 진행 상황을 SSE 스트림으로 전송 | `/api/batch` | `/progress` |
+| BatchManagementController | DTO 기반 관리용 API로 잡 목록·이력·에러 로그·재시작/중지 기능 제공 | `/api/management/batch` | `/jobs`, `/jobs/{jobName}/executions`, `/executions/{jobExecutionId}/errors`, `/jobs/{jobName}/restart`, `/jobs/{jobName}/stop` |
+| JobProgressController | 배치 진행 상황을 SSE 스트림으로 전송 | `/api/management/batch` | `/progress` |
 | BatchPageController | 배치 작업 리스트·상세·로그 화면을 렌더링 | `/batch` | `/list`, `/detail`, `/log` |
 | JobRunController | 공통 잡 실행 엔드포인트로 지정된 잡을 실행 | `/api/batch` | `/run` |
 | Remote1ToStgJobController | Remote1 데이터를 STG로 적재하는 배치 실행 | `/api/batch` | `/remote1-to-stg` |
@@ -229,7 +229,7 @@ public class SampleTasklet implements Tasklet {
 | StgToRestJobController | STG 데이터를 외부 REST API로 전송 | `/api/batch` | `/erp-stg-to-rest` |
 | RestToStgJobController | ERP REST 데이터를 STG 테이블로 적재 | `/api/batch` | `/erp-rest-to-stg` |
 | VehicleController | ERP 서비스용 차량 정보를 조회 | `/api/v1` | `/vehicles` |
-| SchedulerManagementController | Quartz 잡 등록·일시중지·재개·삭제·크론 수정 API 제공 | `/api/scheduler` | `/jobs`, `/jobs/{jobName}/pause`, `/jobs/{jobName}/resume`, `/jobs/{jobName}/delete`, `/jobs/{jobName}/cron` |
+| SchedulerManagementController | Quartz 잡 등록·일시중지·재개·삭제·크론 수정 API 제공 | `/api/management/scheduler` | `/jobs`, `/jobs/{jobName}/pause`, `/jobs/{jobName}/resume`, `/jobs/{jobName}/delete`, `/jobs/{jobName}/cron` |
 | SchedulerPageController | 스케줄러 잡 목록 화면을 렌더링 | `/scheduler` | `/list` |
 
 ## API 엔드포인트
@@ -244,14 +244,14 @@ public class SampleTasklet implements Tasklet {
 - `POST /api/batch/run` – jobName 파라미터로 지정한 배치 실행
 - `POST /api/batch/jobs/{jobName}/restart` – 지정 작업 재시작
 - `DELETE /api/batch/jobs/{jobName}` – 지정 작업 중지
-- `GET /api/batch/progress` (SSE) – 배치 진행 상태 스트림
+- `GET /api/management/batch/progress` (SSE) – 배치 진행 상태 스트림
 
 ### 스케줄러 관리 API
-- `POST /api/scheduler/jobs` – 새 잡 등록 (`jobName`, `jobClass`, `cronExpression` 필요)
-- `POST /api/scheduler/jobs/{jobName}/pause` – 해당 잡 일시 중지
-- `POST /api/scheduler/jobs/{jobName}/resume` – 해당 잡 재개
-- `POST /api/scheduler/jobs/{jobName}/cron` – 해당 잡의 크론 표현식 변경 (요청 본문에 크론식 전달)
-- `POST /api/scheduler/jobs/{jobName}/delete` – 해당 잡 삭제
+- `POST /api/management/scheduler/jobs` – 새 잡 등록 (`jobName`, `jobClass`, `cronExpression` 필요)
+- `POST /api/management/scheduler/jobs/{jobName}/pause` – 해당 잡 일시 중지
+- `POST /api/management/scheduler/jobs/{jobName}/resume` – 해당 잡 재개
+- `POST /api/management/scheduler/jobs/{jobName}/cron` – 해당 잡의 크론 표현식 변경 (요청 본문에 크론식 전달)
+- `POST /api/management/scheduler/jobs/{jobName}/delete` – 해당 잡 삭제
 * 크론 표현식 변경 내용은 Quartz DB에 저장되어 재시작 후에도 유지된다.
 
 ### 개별 Job 실행 API
@@ -261,11 +261,11 @@ public class SampleTasklet implements Tasklet {
 - `POST /api/batch/remote1-to-stg` – Remote1 → STG 전송 배치 실행
 
 ### 관리용 배치 API
-- `GET /api/batch/management/jobs` – 관리용 배치 작업명 목록
-- `GET /api/batch/management/jobs/{jobName}/executions` – 관리용 작업 실행 이력 조회
-- `GET /api/batch/management/executions/{jobExecutionId}/errors` – 특정 실행 ID 에러 로그 조회
-- `POST /api/batch/management/jobs/{jobName}/restart` – 관리용 작업 재시작
-- `POST /api/batch/management/jobs/{jobName}/stop` – 관리용 작업 중지
+- `GET /api/management/batch/jobs` – 관리용 배치 작업명 목록
+- `GET /api/management/batch/jobs/{jobName}/executions` – 관리용 작업 실행 이력 조회
+- `GET /api/management/batch/executions/{jobExecutionId}/errors` – 특정 실행 ID 에러 로그 조회
+- `POST /api/management/batch/jobs/{jobName}/restart` – 관리용 작업 재시작
+- `POST /api/management/batch/jobs/{jobName}/stop` – 관리용 작업 중지
 
 ### 도메인 데이터 조회 API
 - `GET /api/v1/vehicles` – 차량 목록 조회

--- a/README_MANAGEMENT.md
+++ b/README_MANAGEMENT.md
@@ -1,22 +1,22 @@
 관리(Management) 관련 HTTP 주소
-BatchManagementController – 공통 경로 /api/batch/management
-GET /api/batch/management/jobs – 등록된 배치 잡 이름 목록 조회
-GET /api/batch/management/jobs/{jobName}/executions – 특정 잡의 실행 이력 조회
-GET /api/batch/management/executions/{jobExecutionId}/errors – 특정 실행 ID의 에러 로그 조회
-POST /api/batch/management/jobs/{jobName}/restart – 실패한 잡 재실행
-POST /api/batch/management/jobs/{jobName}/stop – 실행 중인 잡 중지
+BatchManagementController – 공통 경로 /api/management/batch
+GET /api/management/batch/jobs – 등록된 배치 잡 이름 목록 조회
+GET /api/management/batch/jobs/{jobName}/executions – 특정 잡의 실행 이력 조회
+GET /api/management/batch/executions/{jobExecutionId}/errors – 특정 실행 ID의 에러 로그 조회
+POST /api/management/batch/jobs/{jobName}/restart – 실패한 잡 재실행
+POST /api/management/batch/jobs/{jobName}/stop – 실행 중인 잡 중지
 
-SchedulerManagementController – 공통 경로 /api/scheduler
-POST /api/scheduler/jobs – 새로운 잡 추가
-POST /api/scheduler/jobs/{jobName}/pause – 지정한 잡 일시 중지
-POST /api/scheduler/jobs/{jobName}/resume – 일시 중지된 잡 재개
-POST /api/scheduler/jobs/{jobName}/delete – 등록된 잡 삭제
-POST /api/scheduler/jobs/{jobName}/cron – 잡의 크론 표현식 변경
-GET /api/scheduler/jobs – 모든 잡 정보 조회
-GET /api/scheduler/jobs/{jobName} – 특정 잡 정보 조회
+SchedulerManagementController – 공통 경로 /api/management/scheduler
+POST /api/management/scheduler/jobs – 새로운 잡 추가
+POST /api/management/scheduler/jobs/{jobName}/pause – 지정한 잡 일시 중지
+POST /api/management/scheduler/jobs/{jobName}/resume – 일시 중지된 잡 재개
+POST /api/management/scheduler/jobs/{jobName}/delete – 등록된 잡 삭제
+POST /api/management/scheduler/jobs/{jobName}/cron – 잡의 크론 표현식 변경
+GET /api/management/scheduler/jobs – 모든 잡 정보 조회
+GET /api/management/scheduler/jobs/{jobName} – 특정 잡 정보 조회
 
-JobProgressController – 공통 경로 /api/batch
-GET /api/batch/progress – 배치 진행 상황 SSE 스트림 제공
+JobProgressController – 공통 경로 /api/management/batch
+GET /api/management/batch/progress – 배치 진행 상황 SSE 스트림 제공
 
 관리 관련 Java 패키지/폴더 구조
 src/main/java/egovframework/bat/management

--- a/src/main/java/egovframework/bat/management/batch/api/BatchManagementController.java
+++ b/src/main/java/egovframework/bat/management/batch/api/BatchManagementController.java
@@ -21,7 +21,7 @@ import egovframework.bat.management.batch.service.BatchManagementService;
  * 배치 잡 조회와 제어를 위한 REST 컨트롤러.
  */
 @RestController
-@RequestMapping("/api/batch/management")
+@RequestMapping("/api/management/batch")
 @RequiredArgsConstructor
 public class BatchManagementController {
 

--- a/src/main/java/egovframework/bat/management/batch/api/JobProgressController.java
+++ b/src/main/java/egovframework/bat/management/batch/api/JobProgressController.java
@@ -15,7 +15,7 @@ import org.springframework.http.codec.ServerSentEvent;
  * 배치 진행 상황을 SSE로 제공하는 컨트롤러.
  */
 @RestController
-@RequestMapping("/api/batch")
+@RequestMapping("/api/management/batch")
 @RequiredArgsConstructor
 public class JobProgressController {
 

--- a/src/main/java/egovframework/bat/management/scheduler/api/SchedulerManagementController.java
+++ b/src/main/java/egovframework/bat/management/scheduler/api/SchedulerManagementController.java
@@ -23,7 +23,7 @@ import egovframework.bat.management.scheduler.exception.DurableJobPauseResumeNot
  * Quartz 스케줄러 제어를 위한 REST 컨트롤러.
  */
 @RestController
-@RequestMapping("/api/scheduler")
+@RequestMapping("/api/management/scheduler")
 @RequiredArgsConstructor
 public class SchedulerManagementController {
 

--- a/src/management-ui/static/js/batch-detail.js
+++ b/src/management-ui/static/js/batch-detail.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('pageTitle').textContent = `잡 상세 - ${jobName}`;
 
     function load() {
-        fetch(`/api/batch/management/jobs/${jobName}/executions`)
+        fetch(`/api/management/batch/jobs/${jobName}/executions`)
             .then(res => res.json())
             .then(data => { executions = data; render(); });
     }
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const restartBtn = document.createElement('button');
             restartBtn.textContent = '재시작';
             restartBtn.addEventListener('click', () => {
-                fetch(`/api/batch/management/executions/${exec.jobExecutionId}/restart`, { method: 'POST' })
+                fetch(`/api/management/batch/executions/${exec.jobExecutionId}/restart`, { method: 'POST' })
                     .then(() => load());
             });
             actionTd.appendChild(restartBtn);
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const stopBtn = document.createElement('button');
             stopBtn.textContent = '중지';
             stopBtn.addEventListener('click', () => {
-                fetch(`/api/batch/management/executions/${exec.jobExecutionId}/stop`, { method: 'POST' })
+                fetch(`/api/management/batch/executions/${exec.jobExecutionId}/stop`, { method: 'POST' })
                     .then(() => load());
             });
             actionTd.appendChild(stopBtn);
@@ -72,7 +72,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // SSE 구독: 해당 잡의 상태가 변경되면 목록을 갱신
-    const eventSource = new EventSource('/api/batch/progress');
+    const eventSource = new EventSource('/api/management/batch/progress');
     eventSource.onmessage = e => {
         const data = JSON.parse(e.data);
         if (data.jobName === jobName) {

--- a/src/management-ui/static/js/batch-list.js
+++ b/src/management-ui/static/js/batch-list.js
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // 잡 이름 목록을 로드
     function loadJobs() {
-        fetch('/api/batch/management/jobs')
+        fetch('/api/management/batch/jobs')
             .then(res => res.json())
             .then(data => {
                 jobs = data;
@@ -45,7 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
             tr.appendChild(endTd);
 
             // 실행 이력 조회 후 상태와 시간 표시
-            fetch(`/api/batch/management/jobs/${jobName}/executions`)
+            fetch(`/api/management/batch/jobs/${jobName}/executions`)
                 .then(res => res.json())
                 .then(exec => {
                     if (exec.length > 0) {

--- a/src/management-ui/static/js/batch-log.js
+++ b/src/management-ui/static/js/batch-log.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
         container.textContent = '조회된 내용이 없습니다';
         return;
     }
-    fetch(`/api/batch/management/executions/${id}/errors`)
+    fetch(`/api/management/batch/executions/${id}/errors`)
         .then(res => {
             // 응답 상태가 성공인지 확인
             if (!res.ok) {

--- a/src/management-ui/static/js/scheduler-list.js
+++ b/src/management-ui/static/js/scheduler-list.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // 잡 목록을 로드
     function load() {
-        fetch('/api/scheduler/jobs')
+        fetch('/api/management/scheduler/jobs')
             .then(res => res.json())
             .then(data => {
                 tbody.innerHTML = '';
@@ -38,7 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     } else {
                         if (job.status === 'PAUSED') {
                             pauseBtn.addEventListener('click', () => {
-                                fetch(`/api/scheduler/jobs/${job.jobName}/resume`, { method: 'POST' })
+                                fetch(`/api/management/scheduler/jobs/${job.jobName}/resume`, { method: 'POST' })
                                     .then(res => {
                                         if (res.ok) {
                                             load(); // 성공 시 목록 갱신
@@ -50,7 +50,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             });
                         } else {
                             pauseBtn.addEventListener('click', () => {
-                                fetch(`/api/scheduler/jobs/${job.jobName}/pause`, { method: 'POST' })
+                                fetch(`/api/management/scheduler/jobs/${job.jobName}/pause`, { method: 'POST' })
                                     .then(res => {
                                         if (res.ok) {
                                             load(); // 성공 시 목록 갱신
@@ -76,7 +76,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         cronBtn.addEventListener('click', () => {
                             const cron = prompt('새 크론 표현식을 입력하세요', job.cronExpression);
                             if (cron) {
-                                fetch(`/api/scheduler/jobs/${job.jobName}/cron`, {
+                                fetch(`/api/management/scheduler/jobs/${job.jobName}/cron`, {
                                     method: 'POST',
                                     headers: { 'Content-Type': 'application/json' },
                                     body: JSON.stringify({ cronExpression: cron }) // 크론 표현식을 JSON으로 전송


### PR DESCRIPTION
## Summary
- 관리용 Batch/Scheduler 컨트롤러와 진행상황 SSE의 기본 경로를 `/api/management/*`로 변경
- 정적 JS에서 수정된 경로로 API 호출하도록 업데이트
- README 문서의 관련 API 경로 갱신

## Testing
- `mvn -q test` *(실패: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bee366f950832aa6c4a265d760e9ee