### PR TITLE
관리 API용 API 키 인증 필터 추가

### DIFF
--- a/src/main/java/egovframework/bat/config/ApiKeyAuthFilter.java
+++ b/src/main/java/egovframework/bat/config/ApiKeyAuthFilter.java
@@ -1,0 +1,45 @@
+package egovframework.bat.config;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * 관리용 API 호출 시 API 키를 검증하는 필터
+ */
+@Component
+@ConditionalOnProperty(prefix = "security.api-key", name = "enabled", havingValue = "true")
+public class ApiKeyAuthFilter extends OncePerRequestFilter {
+
+    /** 기대하는 API 키 값 */
+    @Value("${security.api-key.value}")
+    private String expectedKey;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+            throws ServletException, IOException {
+        // 관리용 API 경로인지 확인
+        String uri = req.getRequestURI();
+        if (!uri.startsWith("/api/management")) {
+            chain.doFilter(req, res);
+            return;
+        }
+
+        // 헤더에서 API 키 추출
+        String key = req.getHeader("X-API-KEY");
+        if (expectedKey.equals(key)) {
+            chain.doFilter(req, res);   // 정상 흐름
+        } else {
+            res.setStatus(HttpStatus.UNAUTHORIZED.value());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 관리용 API 요청에서 X-API-KEY 헤더를 검사하는 필터 추가
- `/api/management/**` 경로에만 인증 적용

## Testing
- `mvn -q test` (네트워크 접근 불가로 의존성 해석 실패)

------
https://chatgpt.com/codex/tasks/task_e_68beebda3b38832a892c7b1c6739cab2