### PR TITLE
환경별 API 키 설정 추가

### DIFF
--- a/src/main/resources/application/env/dev/application.yml
+++ b/src/main/resources/application/env/dev/application.yml
@@ -76,6 +76,11 @@ logging:
   # POM.xml에서 활성 프로파일에 따라 log4j2.xml파일을 루트 폴더로 복사하고 있음
   config: classpath:log4j2.xml
 
+security:
+  api-key:
+    enabled: true    # 개발 환경 API 키 사용
+    value: dev-1234567890
+
 erp:
   # ERP 시스템 API URL
   api-url: http://127.0.0.1:8080/api/v1/vehicles

--- a/src/main/resources/application/env/local/application.yml
+++ b/src/main/resources/application/env/local/application.yml
@@ -73,6 +73,11 @@ logging:
   # POM.xml에서 활성 프로파일에 따라 log4j2.xml파일을 루트 폴더로 복사하고 있음
   config: classpath:log4j2.xml
 
+security:
+  api-key:
+    enabled: false    # 기본값
+    value: change-me
+
 erp:
   # ERP 시스템 API URL
   api-url: http://127.0.0.1:8080/api/v1/vehicles

--- a/src/main/resources/application/env/prod/application.yml
+++ b/src/main/resources/application/env/prod/application.yml
@@ -76,6 +76,11 @@ logging:
   # POM.xml에서 활성 프로파일에 따라 log4j2.xml파일을 루트 폴더로 복사하고 있음
   config: classpath:log4j2.xml
 
+security:
+  api-key:
+    enabled: true    # 운영 환경 API 키 사용
+    value: prod-0987654321
+
 erp:
   # ERP 시스템 API URL
   api-url: http://127.0.0.1:8080/api/v1/vehicles


### PR DESCRIPTION
## Summary
- 각 환경별 application.yml에 security.api-key 설정 추가
- 로컬은 기본값으로 비활성화, 개발/운영은 샘플 키 적용 후 활성화

## Testing
- `mvn -q test` *(실패: 원격 저장소에 연결할 수 없음)*

------
https://chatgpt.com/codex/tasks/task_e_68beebed215c832aad92e56774d05ff4