### PR TITLE
feat: 스케줄러 크론 변경 로그 추가

### DIFF
--- a/src/main/java/egovframework/bat/management/scheduler/api/SchedulerManagementController.java
+++ b/src/main/java/egovframework/bat/management/scheduler/api/SchedulerManagementController.java
@@ -1,6 +1,8 @@
 package egovframework.bat.management.scheduler.api;
 
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.quartz.SchedulerException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,6 +28,9 @@ import egovframework.bat.management.scheduler.exception.DurableJobPauseResumeNot
 @RequestMapping("/api/management/scheduler")
 @RequiredArgsConstructor
 public class SchedulerManagementController {
+
+    /** 로거 */
+    private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerManagementController.class);
 
     /** 스케줄러 관리 서비스 */
     private final SchedulerManagementService schedulerManagementService;
@@ -100,8 +105,15 @@ public class SchedulerManagementController {
     @PostMapping("/jobs/{jobName}/cron")
     public ResponseEntity<Void> updateJobCron(@PathVariable String jobName,
             @RequestBody CronRequest request) throws SchedulerException {
-        schedulerManagementService.updateJobCron(jobName, request.getCronExpression());
-        return ResponseEntity.ok().build();
+        LOGGER.debug("API 요청: jobName={}, cronExpression={}", jobName, request.getCronExpression());
+        try {
+            schedulerManagementService.updateJobCron(jobName, request.getCronExpression());
+            LOGGER.info("잡 {} 크론 변경 API 호출 성공", jobName);
+            return ResponseEntity.ok().build();
+        } catch (SchedulerException e) {
+            LOGGER.error("잡 {} 크론 변경 실패", jobName, e);
+            throw e;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- SchedulerManagementController에 SLF4J 로거 추가
- updateJobCron API에 디버그/정보/에러 로그 추가

## Testing
- `mvn -q test` *(실패: 네트워크에 접근할 수 없어 parent POM을 받지 못함)*

------
https://chatgpt.com/codex/tasks/task_e_68bef4e2d46c832abb553e082948b71e