### PR TITLE
feat: 잡 생성 시 quartz 그룹 지정

### DIFF
--- a/src/main/java/egovframework/bat/management/scheduler/service/SchedulerManagementService.java
+++ b/src/main/java/egovframework/bat/management/scheduler/service/SchedulerManagementService.java
@@ -27,6 +27,9 @@ public class SchedulerManagementService {
     /** 로깅을 위한 로거 */
     private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerManagementService.class);
 
+    /** Quartz 잡 및 트리거 그룹 */
+    private static final String QUARTZ_BATCH_GROUP = "quartz-batch";
+
     /** Quartz 스케줄러 */
     private final Scheduler scheduler;
 
@@ -44,10 +47,10 @@ public class SchedulerManagementService {
         @SuppressWarnings("unchecked")
         Class<? extends Job> jobClass = (Class<? extends Job>) Class.forName(jobClassName);
         JobDetail jobDetail = JobBuilder.newJob(jobClass)
-                .withIdentity(jobName)
+                .withIdentity(jobName, QUARTZ_BATCH_GROUP)
                 .build();
         Trigger trigger = TriggerBuilder.newTrigger()
-                .withIdentity(jobName + "Trigger")
+                .withIdentity(jobName + "Trigger", QUARTZ_BATCH_GROUP)
                 .withSchedule(CronScheduleBuilder.cronSchedule(cronExpression))
                 .build();
         scheduler.scheduleJob(jobDetail, trigger);
@@ -106,7 +109,7 @@ public class SchedulerManagementService {
      * @throws SchedulerException 스케줄러 작업 실패 시 발생
      */
     public void updateJobCron(String jobName, String cronExpression) throws SchedulerException {
-        updateJobCron(jobName, cronExpression, "quartz-batch");
+        updateJobCron(jobName, cronExpression, QUARTZ_BATCH_GROUP);
     }
 
     /**


### PR DESCRIPTION
## Summary
- quartz-batch 그룹 상수화
- addJob에서 잡과 트리거에 동일 그룹 적용
- 기본 크론 변경 메서드에 그룹 상수 재사용

## Testing
- `mvn -q test` *(네트워크 문제로 부모 POM을 받지 못해 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68bf76aa8e54832a900a5ad6e01c6417