### PR TITLE
트리거 검색 및 예외 처리 개선

### DIFF
--- a/src/main/java/egovframework/bat/management/scheduler/exception/TriggerNotFoundException.java
+++ b/src/main/java/egovframework/bat/management/scheduler/exception/TriggerNotFoundException.java
@@ -1,0 +1,27 @@
+package egovframework.bat.management.scheduler.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * 특정 잡의 트리거를 찾을 수 없을 때 발생하는 예외.
+ */
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class TriggerNotFoundException extends RuntimeException {
+
+    /**
+     * 기본 생성자.
+     */
+    public TriggerNotFoundException() {
+        super();
+    }
+
+    /**
+     * 예외 메시지를 포함한 생성자.
+     *
+     * @param message 예외 메시지
+     */
+    public TriggerNotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## 요약
- 트리거 검색 시 그룹 미일치 상황에서 모든 그룹을 조회하도록 로직 개선
- 트리거를 찾을 수 없을 때 `TriggerNotFoundException`을 발생시켜 404 응답 제공
- 관련 단위 테스트 추가로 크론 변경 기능의 동작과 예외 처리 검증

## 테스트
- `mvn -q test` (네트워크 미연결로 의존성 확인 실패)


------
https://chatgpt.com/codex/tasks/task_e_68bf77a21c44832ab9e9d630ebe8faab