### PR TITLE
스케줄러 잡 그룹 정보 표시 추가

### DIFF
--- a/src/main/java/egovframework/bat/management/scheduler/dto/ScheduledJobDto.java
+++ b/src/main/java/egovframework/bat/management/scheduler/dto/ScheduledJobDto.java
@@ -5,12 +5,16 @@ import lombok.Data;
 
 /**
  * 스케줄된 잡 정보를 전달하기 위한 DTO.
+ *
+ * <p>잡 이름, 그룹, 크론 표현식, 상태, 내구성 여부를 포함한다.</p>
  */
 @Data
 @AllArgsConstructor
 public class ScheduledJobDto {
     /** 잡 이름 */
     private String jobName;
+    /** 잡 그룹 */
+    private String jobGroup;
     /** 크론 표현식 */
     private String cronExpression;
     /** 현재 상태 */

--- a/src/main/java/egovframework/bat/management/scheduler/service/SchedulerManagementService.java
+++ b/src/main/java/egovframework/bat/management/scheduler/service/SchedulerManagementService.java
@@ -222,7 +222,7 @@ public class SchedulerManagementService {
             if (jobDetail != null) {
                 durable = jobDetail.isDurable();
             }
-            jobs.add(new ScheduledJobDto(jobKey.getName(), cronExpression, status, durable));
+            jobs.add(new ScheduledJobDto(jobKey.getName(), jobKey.getGroup(), cronExpression, status, durable));
         }
         return jobs;
     }
@@ -254,7 +254,7 @@ public class SchedulerManagementService {
         if (jobDetail != null) {
             durable = jobDetail.isDurable();
         }
-        return new ScheduledJobDto(jobName, cronExpression, status, durable);
+        return new ScheduledJobDto(jobName, jobKey.getGroup(), cronExpression, status, durable);
     }
 }
 

--- a/src/management-ui/static/js/scheduler-list.js
+++ b/src/management-ui/static/js/scheduler-list.js
@@ -14,6 +14,11 @@ document.addEventListener('DOMContentLoaded', () => {
                     nameTd.textContent = job.jobName;
                     tr.appendChild(nameTd);
 
+                    const groupTd = document.createElement('td');
+                    // 잡 그룹 표시
+                    groupTd.textContent = job.jobGroup;
+                    tr.appendChild(groupTd);
+
                     const cronTd = document.createElement('td');
                     cronTd.textContent = job.cronExpression;
                     tr.appendChild(cronTd);

--- a/src/management-ui/templates/scheduler/list.html
+++ b/src/management-ui/templates/scheduler/list.html
@@ -12,6 +12,7 @@
     <thead>
     <tr>
         <th>잡 이름</th>
+        <th>그룹</th>
         <th>크론 표현식</th>
         <th>상태</th>
         <th>Durable</th>


### PR DESCRIPTION
## 요약
- ScheduledJobDto에 잡 그룹 필드 추가
- 서비스와 UI에서 그룹 정보를 조회 및 표시

## 테스트
- `mvn -q test` *(실패: 원격 저장소에 접근할 수 없어 의존성 확인 불가)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa5ccc490832a8aafa3534fbd262b