### PR TITLE
잡 제어 API에 그룹 경로 추가

### DIFF
--- a/src/main/java/egovframework/bat/management/scheduler/api/SchedulerManagementController.java
+++ b/src/main/java/egovframework/bat/management/scheduler/api/SchedulerManagementController.java
@@ -56,39 +56,45 @@ public class SchedulerManagementController {
     /**
      * 지정한 잡을 일시 중지한다.
      *
-     * @param jobName 잡 이름
+     * @param jobGroup 잡 그룹
+     * @param jobName  잡 이름
      * @return 처리 결과
      * @throws SchedulerException 스케줄러 작업 실패 시 발생
      */
-    @PostMapping("/jobs/{jobName}/pause")
-    public ResponseEntity<Void> pauseJob(@PathVariable String jobName) throws SchedulerException {
-        schedulerManagementService.pauseJob(jobName);
+    @PostMapping("/jobs/{jobGroup}/{jobName}/pause")
+    public ResponseEntity<Void> pauseJob(@PathVariable String jobGroup, @PathVariable String jobName)
+            throws SchedulerException {
+        schedulerManagementService.pauseJob(jobName, jobGroup);
         return ResponseEntity.ok().build();
     }
 
     /**
      * 일시 중지된 잡을 재개한다.
      *
-     * @param jobName 잡 이름
+     * @param jobGroup 잡 그룹
+     * @param jobName  잡 이름
      * @return 처리 결과
      * @throws SchedulerException 스케줄러 작업 실패 시 발생
      */
-    @PostMapping("/jobs/{jobName}/resume")
-    public ResponseEntity<Void> resumeJob(@PathVariable String jobName) throws SchedulerException {
-        schedulerManagementService.resumeJob(jobName);
+    @PostMapping("/jobs/{jobGroup}/{jobName}/resume")
+    public ResponseEntity<Void> resumeJob(@PathVariable String jobGroup, @PathVariable String jobName)
+            throws SchedulerException {
+        schedulerManagementService.resumeJob(jobName, jobGroup);
         return ResponseEntity.ok().build();
     }
 
     /**
      * 등록된 잡을 삭제한다.
      *
-     * @param jobName 잡 이름
+     * @param jobGroup 잡 그룹
+     * @param jobName  잡 이름
      * @return 처리 결과
      * @throws SchedulerException 스케줄러 작업 실패 시 발생
      */
-    @PostMapping("/jobs/{jobName}/delete")
-    public ResponseEntity<Void> deleteJob(@PathVariable String jobName) throws SchedulerException {
-        schedulerManagementService.deleteJob(jobName);
+    @PostMapping("/jobs/{jobGroup}/{jobName}/delete")
+    public ResponseEntity<Void> deleteJob(@PathVariable String jobGroup, @PathVariable String jobName)
+            throws SchedulerException {
+        schedulerManagementService.deleteJob(jobName, jobGroup);
         return ResponseEntity.ok().build();
     }
 
@@ -97,21 +103,23 @@ public class SchedulerManagementController {
      * 프런트엔드는 {"cronExpression":"0 0/2 * * * ?"} 형태의 JSON으로 요청한다.
      * 내구성 잡에 대해서는 400(Bad Request) 응답이 반환된다.
      *
-     * @param jobName 잡 이름
+     * @param jobGroup 잡 그룹
+     * @param jobName  잡 이름
      * @param request 크론 표현식 요청 DTO
      * @return 처리 결과
      * @throws SchedulerException 스케줄러 작업 실패 시 발생
      */
-    @PostMapping("/jobs/{jobName}/cron")
-    public ResponseEntity<Void> updateJobCron(@PathVariable String jobName,
+    @PostMapping("/jobs/{jobGroup}/{jobName}/cron")
+    public ResponseEntity<Void> updateJobCron(@PathVariable String jobGroup, @PathVariable String jobName,
             @RequestBody CronRequest request) throws SchedulerException {
-        LOGGER.debug("API 요청: jobName={}, cronExpression={}", jobName, request.getCronExpression());
+        LOGGER.debug("API 요청: jobGroup={}, jobName={}, cronExpression={}", jobGroup, jobName,
+                request.getCronExpression());
         try {
-            schedulerManagementService.updateJobCron(jobName, request.getCronExpression());
-            LOGGER.info("잡 {} 크론 변경 API 호출 성공", jobName);
+            schedulerManagementService.updateJobCron(jobName, jobGroup, request.getCronExpression());
+            LOGGER.info("잡 {} 그룹의 {} 크론 변경 API 호출 성공", jobGroup, jobName);
             return ResponseEntity.ok().build();
         } catch (SchedulerException e) {
-            LOGGER.error("잡 {} 크론 변경 실패", jobName, e);
+            LOGGER.error("잡 {} 그룹의 {} 크론 변경 실패", jobGroup, jobName, e);
             throw e;
         }
     }

--- a/src/management-ui/static/js/scheduler-list.js
+++ b/src/management-ui/static/js/scheduler-list.js
@@ -43,7 +43,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     } else {
                         if (job.status === 'PAUSED') {
                             pauseBtn.addEventListener('click', () => {
-                                fetch(`/api/management/scheduler/jobs/${job.jobName}/resume`, { method: 'POST' })
+                                // 잡 그룹과 이름을 포함한 URI로 재개 요청
+                                fetch(`/api/management/scheduler/jobs/${job.jobGroup}/${job.jobName}/resume`, { method: 'POST' })
                                     .then(res => {
                                         if (res.ok) {
                                             load(); // 성공 시 목록 갱신
@@ -55,7 +56,8 @@ document.addEventListener('DOMContentLoaded', () => {
                             });
                         } else {
                             pauseBtn.addEventListener('click', () => {
-                                fetch(`/api/management/scheduler/jobs/${job.jobName}/pause`, { method: 'POST' })
+                                // 잡 그룹과 이름을 포함한 URI로 일시 중지 요청
+                                fetch(`/api/management/scheduler/jobs/${job.jobGroup}/${job.jobName}/pause`, { method: 'POST' })
                                     .then(res => {
                                         if (res.ok) {
                                             load(); // 성공 시 목록 갱신
@@ -81,7 +83,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         cronBtn.addEventListener('click', () => {
                             const cron = prompt('새 크론 표현식을 입력하세요', job.cronExpression);
                             if (cron) {
-                                fetch(`/api/management/scheduler/jobs/${job.jobName}/cron`, {
+                                // 잡 그룹과 이름을 포함한 URI로 크론 수정 요청
+                                fetch(`/api/management/scheduler/jobs/${job.jobGroup}/${job.jobName}/cron`, {
                                     method: 'POST',
                                     headers: { 'Content-Type': 'application/json' },
                                     body: JSON.stringify({ cronExpression: cron }) // 크론 표현식을 JSON으로 전송

--- a/src/test/java/egovframework/bat/management/scheduler/service/SchedulerManagementServiceTest.java
+++ b/src/test/java/egovframework/bat/management/scheduler/service/SchedulerManagementServiceTest.java
@@ -92,7 +92,7 @@ public class SchedulerManagementServiceTest {
                 .withIdentity(jobName)
                 .storeDurably(false)
                 .build();
-        when(scheduler.getJobDetail(JobKey.jobKey(jobName))).thenReturn(jobDetail);
+        when(scheduler.getJobDetail(JobKey.jobKey(jobName, group))).thenReturn(jobDetail);
 
         TriggerKey triggerKey = TriggerKey.triggerKey(jobName + "Trigger", group);
         CronTrigger oldTrigger = TriggerBuilder.newTrigger()
@@ -103,7 +103,7 @@ public class SchedulerManagementServiceTest {
 
         ArgumentCaptor<Trigger> captor = ArgumentCaptor.forClass(Trigger.class);
 
-        schedulerManagementService.updateJobCron(jobName, "0/5 * * * * ?", group);
+        schedulerManagementService.updateJobCron(jobName, group, "0/5 * * * * ?");
 
         verify(scheduler).rescheduleJob(eq(triggerKey), captor.capture());
         CronTrigger newTrigger = (CronTrigger) captor.getValue();
@@ -120,7 +120,7 @@ public class SchedulerManagementServiceTest {
                 .withIdentity(jobName)
                 .storeDurably(false)
                 .build();
-        when(scheduler.getJobDetail(JobKey.jobKey(jobName))).thenReturn(jobDetail);
+        when(scheduler.getJobDetail(JobKey.jobKey(jobName, group))).thenReturn(jobDetail);
 
         TriggerKey initialTriggerKey = TriggerKey.triggerKey(jobName + "Trigger", group);
         when(scheduler.getTrigger(initialTriggerKey)).thenReturn(null);
@@ -130,11 +130,11 @@ public class SchedulerManagementServiceTest {
                 .withIdentity(foundTriggerKey)
                 .withSchedule(CronScheduleBuilder.cronSchedule("0 0 * * * ?"))
                 .build();
-        doReturn(Collections.singletonList(oldTrigger)).when(scheduler).getTriggersOfJob(JobKey.jobKey(jobName));
+        doReturn(Collections.singletonList(oldTrigger)).when(scheduler).getTriggersOfJob(JobKey.jobKey(jobName, group));
 
         ArgumentCaptor<Trigger> captor = ArgumentCaptor.forClass(Trigger.class);
 
-        schedulerManagementService.updateJobCron(jobName, "0/5 * * * * ?", group);
+        schedulerManagementService.updateJobCron(jobName, group, "0/5 * * * * ?");
 
         verify(scheduler).rescheduleJob(eq(foundTriggerKey), captor.capture());
         CronTrigger newTrigger = (CronTrigger) captor.getValue();
@@ -150,12 +150,12 @@ public class SchedulerManagementServiceTest {
                 .withIdentity(jobName)
                 .storeDurably(false)
                 .build();
-        when(scheduler.getJobDetail(JobKey.jobKey(jobName))).thenReturn(jobDetail);
+        when(scheduler.getJobDetail(JobKey.jobKey(jobName, group))).thenReturn(jobDetail);
 
         TriggerKey triggerKey = TriggerKey.triggerKey(jobName + "Trigger", group);
         when(scheduler.getTrigger(triggerKey)).thenReturn(null);
-        doReturn(Collections.emptyList()).when(scheduler).getTriggersOfJob(JobKey.jobKey(jobName));
+        doReturn(Collections.emptyList()).when(scheduler).getTriggersOfJob(JobKey.jobKey(jobName, group));
 
-        schedulerManagementService.updateJobCron(jobName, "0/5 * * * * ?", group);
+        schedulerManagementService.updateJobCron(jobName, group, "0/5 * * * * ?");
     }
 }


### PR DESCRIPTION
## 요약
- 스케줄러 잡 제어 엔드포인트를 `/jobs/{jobGroup}/{jobName}/...` 형태로 변경
- 서비스 계층과 테스트에 jobGroup 파라미터를 도입하여 그룹 기반 제어 구현
- 프런트엔드에서 새 URI 구조에 맞게 호출 경로 수정

## 테스트
- `mvn -q test` (네트워크 차단으로 의존성 다운로드 실패)


------
https://chatgpt.com/codex/tasks/task_e_68bfa6e2a098832a8cbae9d8b69a3743