### PR TITLE
quartz-batch 문자열을 Constant.QUARTZ_BATCH_GROUP 상수로 교체

### DIFF
--- a/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
@@ -28,6 +28,7 @@ import org.springframework.scheduling.quartz.CronTriggerFactoryBean;
 import org.springframework.scheduling.quartz.JobDetailFactoryBean;
 import org.springframework.scheduling.quartz.SchedulerFactoryBean;
 
+import egovframework.bat.common.Constant;
 import egovframework.bat.repository.dto.SchedulerJobDto;
 import egovframework.bat.scheduler.EgovQuartzJobLauncher;
 import lombok.RequiredArgsConstructor;
@@ -57,7 +58,7 @@ public class BatchSchedulerConfig {
         JobDetailFactoryBean factory = new JobDetailFactoryBean();
         factory.setName(job.getName() + "Detail");
         factory.setJobClass(EgovQuartzJobLauncher.class);
-        factory.setGroup("quartz-batch");
+        factory.setGroup(Constant.QUARTZ_BATCH_GROUP);
         factory.setDurability(durability);
 
         Map<String, Object> map = new HashMap<>();
@@ -89,10 +90,10 @@ public class BatchSchedulerConfig {
     @Bean
     public JobChainingJobListener jobChainingJobListener() {
         JobChainingJobListener listener = new JobChainingJobListener("jobChainingListener");
-        listener.addJobChainLink(new JobKey("insaRemote1ToStgJobDetail", "quartz-batch"),
-                new JobKey("insaStgToLocalJobDetail", "quartz-batch"));
-        listener.addJobChainLink(new JobKey("erpRestToStgJobDetail", "quartz-batch"),
-                new JobKey("erpStgToLocalJobDetail", "quartz-batch"));
+        listener.addJobChainLink(new JobKey("insaRemote1ToStgJobDetail", Constant.QUARTZ_BATCH_GROUP),
+                new JobKey("insaStgToLocalJobDetail", Constant.QUARTZ_BATCH_GROUP));
+        listener.addJobChainLink(new JobKey("erpRestToStgJobDetail", Constant.QUARTZ_BATCH_GROUP),
+                new JobKey("erpStgToLocalJobDetail", Constant.QUARTZ_BATCH_GROUP));
         return listener;
     }
 

--- a/src/main/java/egovframework/bat/management/scheduler/service/SchedulerManagementService.java
+++ b/src/main/java/egovframework/bat/management/scheduler/service/SchedulerManagementService.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import egovframework.bat.common.Constant;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Date;
@@ -28,9 +30,6 @@ public class SchedulerManagementService {
     /** 로깅을 위한 로거 */
     private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerManagementService.class);
 
-    /** Quartz 잡 및 트리거 그룹 */
-    private static final String QUARTZ_BATCH_GROUP = "quartz-batch";
-
     /** Quartz 스케줄러 */
     private final Scheduler scheduler;
 
@@ -48,10 +47,10 @@ public class SchedulerManagementService {
         @SuppressWarnings("unchecked")
         Class<? extends Job> jobClass = (Class<? extends Job>) Class.forName(jobClassName);
         JobDetail jobDetail = JobBuilder.newJob(jobClass)
-                .withIdentity(jobName, QUARTZ_BATCH_GROUP)
+                .withIdentity(jobName, Constant.QUARTZ_BATCH_GROUP)
                 .build();
         Trigger trigger = TriggerBuilder.newTrigger()
-                .withIdentity(jobName + "Trigger", QUARTZ_BATCH_GROUP)
+                .withIdentity(jobName + "Trigger", Constant.QUARTZ_BATCH_GROUP)
                 .withSchedule(CronScheduleBuilder.cronSchedule(cronExpression))
                 .build();
         scheduler.scheduleJob(jobDetail, trigger);

--- a/src/test/java/egovframework/bat/management/scheduler/service/SchedulerManagementServiceTest.java
+++ b/src/test/java/egovframework/bat/management/scheduler/service/SchedulerManagementServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.ArgumentCaptor;
 import org.quartz.*;
 import org.quartz.jobs.NoOpJob;
 
+import egovframework.bat.common.Constant;
 import egovframework.bat.management.scheduler.dto.ScheduledJobDto;
 import egovframework.bat.management.scheduler.exception.TriggerNotFoundException;
 
@@ -86,7 +87,7 @@ public class SchedulerManagementServiceTest {
     @Test
     public void updateJobCronWithGroupChangesCron() throws Exception {
         String jobName = "testJob";
-        String group = "quartz-batch";
+        String group = Constant.QUARTZ_BATCH_GROUP;
 
         JobDetail jobDetail = JobBuilder.newJob(NoOpJob.class)
                 .withIdentity(jobName)
@@ -113,7 +114,7 @@ public class SchedulerManagementServiceTest {
     @Test
     public void updateJobCronFindsTriggerInAnotherGroup() throws Exception {
         String jobName = "testJob";
-        String group = "quartz-batch";
+        String group = Constant.QUARTZ_BATCH_GROUP;
         String otherGroup = "other-group";
 
         JobDetail jobDetail = JobBuilder.newJob(NoOpJob.class)
@@ -144,7 +145,7 @@ public class SchedulerManagementServiceTest {
     @Test(expected = TriggerNotFoundException.class)
     public void updateJobCronThrowsTriggerNotFoundExceptionWhenMissing() throws Exception {
         String jobName = "missingJob";
-        String group = "quartz-batch";
+        String group = Constant.QUARTZ_BATCH_GROUP;
 
         JobDetail jobDetail = JobBuilder.newJob(NoOpJob.class)
                 .withIdentity(jobName)


### PR DESCRIPTION
## 요약
- 하드코딩된 "quartz-batch" 문자열을 Constant.QUARTZ_BATCH_GROUP 상수로 변경
- SchedulerManagementService와 BatchSchedulerConfig, 테스트 코드 반영

## 테스트
- `mvn -q test` (네트워크 오류로 실패)


------
https://chatgpt.com/codex/tasks/task_e_68bfae92fb14832aa4944aa7a481cd5c