### PR TITLE
feat: 잡 일시 중지와 재개 로깅 추가

### DIFF
--- a/src/main/java/egovframework/bat/management/scheduler/api/SchedulerManagementController.java
+++ b/src/main/java/egovframework/bat/management/scheduler/api/SchedulerManagementController.java
@@ -64,8 +64,15 @@ public class SchedulerManagementController {
     @PostMapping("/jobs/{jobGroup}/{jobName}/pause")
     public ResponseEntity<Void> pauseJob(@PathVariable String jobGroup, @PathVariable String jobName)
             throws SchedulerException {
-        schedulerManagementService.pauseJob(jobName, jobGroup);
-        return ResponseEntity.ok().build();
+        LOGGER.debug("API 요청: jobGroup={}, jobName={}", jobGroup, jobName);
+        try {
+            schedulerManagementService.pauseJob(jobName, jobGroup);
+            LOGGER.info("잡 {} 그룹의 {} 일시 중지 API 호출 성공", jobGroup, jobName);
+            return ResponseEntity.ok().build();
+        } catch (SchedulerException e) {
+            LOGGER.error("잡 {} 그룹의 {} 일시 중지 실패", jobGroup, jobName, e);
+            throw e;
+        }
     }
 
     /**
@@ -79,8 +86,15 @@ public class SchedulerManagementController {
     @PostMapping("/jobs/{jobGroup}/{jobName}/resume")
     public ResponseEntity<Void> resumeJob(@PathVariable String jobGroup, @PathVariable String jobName)
             throws SchedulerException {
-        schedulerManagementService.resumeJob(jobName, jobGroup);
-        return ResponseEntity.ok().build();
+        LOGGER.debug("API 요청: jobGroup={}, jobName={}", jobGroup, jobName);
+        try {
+            schedulerManagementService.resumeJob(jobName, jobGroup);
+            LOGGER.info("잡 {} 그룹의 {} 재개 API 호출 성공", jobGroup, jobName);
+            return ResponseEntity.ok().build();
+        } catch (SchedulerException e) {
+            LOGGER.error("잡 {} 그룹의 {} 재개 실패", jobGroup, jobName, e);
+            throw e;
+        }
     }
 
     /**

--- a/src/main/java/egovframework/bat/management/scheduler/service/SchedulerManagementService.java
+++ b/src/main/java/egovframework/bat/management/scheduler/service/SchedulerManagementService.java
@@ -65,14 +65,17 @@ public class SchedulerManagementService {
      * @throws SchedulerException 스케줄러 작업 실패 시 발생
      */
     public void pauseJob(String jobName, String jobGroup) throws SchedulerException {
+        LOGGER.debug("잡 {} 그룹의 {} 일시 중지 요청", jobGroup, jobName);
         JobKey jobKey = JobKey.jobKey(jobName, jobGroup);
         JobDetail jobDetail = scheduler.getJobDetail(jobKey);
+        LOGGER.debug("JobDetail: {}, isDurable: {}", jobDetail, jobDetail != null ? jobDetail.isDurable() : null);
         // 내구성 잡은 일시 중지할 수 없도록 예외 처리
         if (jobDetail != null && jobDetail.isDurable()) {
             throw new DurableJobPauseResumeNotAllowedException(
                     "내구성 잡은 일시 중지할 수 없습니다: " + jobName);
         }
         scheduler.pauseJob(jobKey);
+        LOGGER.info("잡 {} 그룹의 {} 일시 중지 완료", jobGroup, jobName);
     }
 
     /**
@@ -83,14 +86,17 @@ public class SchedulerManagementService {
      * @throws SchedulerException 스케줄러 작업 실패 시 발생
      */
     public void resumeJob(String jobName, String jobGroup) throws SchedulerException {
+        LOGGER.debug("잡 {} 그룹의 {} 재개 요청", jobGroup, jobName);
         JobKey jobKey = JobKey.jobKey(jobName, jobGroup);
         JobDetail jobDetail = scheduler.getJobDetail(jobKey);
+        LOGGER.debug("JobDetail: {}, isDurable: {}", jobDetail, jobDetail != null ? jobDetail.isDurable() : null);
         // 내구성 잡은 재개할 수 없도록 예외 처리
         if (jobDetail != null && jobDetail.isDurable()) {
             throw new DurableJobPauseResumeNotAllowedException(
                     "내구성 잡은 재개할 수 없습니다: " + jobName);
         }
         scheduler.resumeJob(jobKey);
+        LOGGER.info("잡 {} 그룹의 {} 재개 완료", jobGroup, jobName);
     }
 
     /**


### PR DESCRIPTION
## Summary
- 서비스 계층에 잡 일시 중지/재개 요청·내구성 확인·완료 로그 추가
- API 계층에 일시 중지/재개 요청 처리 성공 및 실패 로그 추가

## Testing
- `mvn -q test` *(실패: Non-resolvable parent POM for egov.batch:testBatch:1.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c00e0324a4832ab750416a939cb566