### PR TITLE
feat: SendErpDataTasklet에 페이지 조회 및 스트리밍 처리 도입

### DIFF
--- a/src/main/java/egovframework/bat/job/erp/tasklet/SendErpDataTasklet.java
+++ b/src/main/java/egovframework/bat/job/erp/tasklet/SendErpDataTasklet.java
@@ -1,6 +1,8 @@
 package egovframework.bat.job.erp.tasklet;
 
+import java.sql.PreparedStatement;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,16 +44,24 @@ public class SendErpDataTasklet implements Tasklet {
     /** 외부 ERP API URL */
     private final String apiUrl;
 
+    /**
+     * 한 번에 조회할 데이터 건수.
+     * 기본값은 100이며, Job 파라미터로 "pageSize"를 전달하면 그 값을 사용한다.
+     */
+    private final int defaultPageSize;
+
     public SendErpDataTasklet(WebClient.Builder builder,
                               @Qualifier("migstgJdbcTemplate") JdbcTemplate jdbcTemplate,
                               @Qualifier("emailNotificationSender") NotificationSender emailNotificationSender,
                               @Qualifier("smsNotificationSender") NotificationSender smsNotificationSender,
-                              @Value("${erp.outbound-api-url}") String apiUrl) {
+                              @Value("${erp.outbound-api-url}") String apiUrl,
+                              @Value("${erp.fetch-page-size:100}") int defaultPageSize) {
         this.webClient = builder.build();
         this.jdbcTemplate = jdbcTemplate;
         // 주입받은 알림 전송기를 리스트로 구성
         this.notificationSenders = List.of(emailNotificationSender, smsNotificationSender);
         this.apiUrl = apiUrl;
+        this.defaultPageSize = defaultPageSize;
     }
 
     /** 현재 설정된 외부 API URL 반환 */
@@ -62,27 +72,43 @@ public class SendErpDataTasklet implements Tasklet {
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
         LOGGER.info("ERP 데이터 외부 전송 시작");
-        List<VehicleInfo> vehicles;
-        try {
-            vehicles = fetchVehicles();
-        } catch (DataAccessException e) {
-            LOGGER.error("STG 데이터 조회 실패", e);
-            notifyFailure("STG 데이터 조회 실패: " + e.getMessage());
-            throw e;
-        }
 
-        if (vehicles.isEmpty()) {
-            LOGGER.info("전송할 데이터가 없습니다.");
-            return RepeatStatus.FINISHED;
-        }
-
-        for (VehicleInfo vehicle : vehicles) {
+        // Job 파라미터로 전달된 pageSize가 있으면 우선 적용
+        Map<String, Object> params = chunkContext.getStepContext().getJobParameters();
+        int pageSize = this.defaultPageSize;
+        Object pageSizeParam = params.get("pageSize");
+        if (pageSizeParam != null) {
             try {
-                sendVehicle(vehicle);
-            } catch (ErpApiException e) {
-                LOGGER.error("차량 전송 실패: {}", vehicle.getVehicleId(), e);
-                notifyFailure("차량 전송 실패: " + e.getMessage());
+                pageSize = Integer.parseInt(pageSizeParam.toString());
+            } catch (NumberFormatException e) {
+                LOGGER.warn("잘못된 pageSize 파라미터: {}", pageSizeParam);
+            }
+        }
+
+        long lastId = 0L;
+        while (true) {
+            List<VehicleInfo> vehicles;
+            try {
+                vehicles = fetchVehicles(lastId, pageSize);
+            } catch (DataAccessException e) {
+                LOGGER.error("STG 데이터 조회 실패", e);
+                notifyFailure("STG 데이터 조회 실패: " + e.getMessage());
                 throw e;
+            }
+
+            if (vehicles.isEmpty()) {
+                break;
+            }
+
+            for (VehicleInfo vehicle : vehicles) {
+                try {
+                    sendVehicle(vehicle);
+                    lastId = vehicle.getVehicleId(); // 다음 페이지 조회를 위한 마지막 ID 갱신
+                } catch (ErpApiException e) {
+                    LOGGER.error("차량 전송 실패: {}", vehicle.getVehicleId(), e);
+                    notifyFailure("차량 전송 실패: " + e.getMessage());
+                    throw e;
+                }
             }
         }
 
@@ -90,10 +116,22 @@ public class SendErpDataTasklet implements Tasklet {
         return RepeatStatus.FINISHED;
     }
 
-    /** STG DB에서 전송 대상 차량 목록 조회 */
-    private List<VehicleInfo> fetchVehicles() {
-        String sql = "SELECT VEHICLE_ID, MODEL, MANUFACTURER, PRICE, REG_DTTM, MOD_DTTM FROM MIGSTG.ERP_VEHICLE";
-        return jdbcTemplate.query(sql, new BeanPropertyRowMapper<>(VehicleInfo.class));
+    /**
+     * STG DB에서 전송 대상 차량 목록 조회.
+     * VEHICLE_ID를 기준으로 key-based 커서를 적용하며, 한 번에 pageSize만큼만 조회한다.
+     * ResultSet의 fetchSize를 지정하여 메모리 사용량을 줄인다.
+     */
+    private List<VehicleInfo> fetchVehicles(long lastId, int pageSize) {
+        String sql = "SELECT VEHICLE_ID, MODEL, MANUFACTURER, PRICE, REG_DTTM, MOD_DTTM "
+                   + "FROM MIGSTG.ERP_VEHICLE "
+                   + "WHERE VEHICLE_ID > ? ORDER BY VEHICLE_ID LIMIT ?";
+        return jdbcTemplate.query(con -> {
+            PreparedStatement ps = con.prepareStatement(sql);
+            ps.setLong(1, lastId);
+            ps.setInt(2, pageSize);
+            ps.setFetchSize(pageSize); // 스트리밍 처리를 위한 fetchSize 설정
+            return ps;
+        }, new BeanPropertyRowMapper<>(VehicleInfo.class));
     }
 
     /** 단건 차량 정보를 외부 ERP API로 전송 */


### PR DESCRIPTION
## Summary
- SendErpDataTasklet에서 차량 조회 시 key 기반 커서와 LIMIT을 적용해 페이징 처리
- pageSize를 설정 파일 혹은 Job 파라미터로 지정 가능하도록 추가
- fetchSize를 지정해 전체 데이터 스트리밍 처리 및 메모리 사용량 절감

## Testing
- `mvn -q test` *(실패: 의존성 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68c01d8e9b6c832a9c0d50143a5dfbe5