### PR TITLE
fix: VEHICLE_ID 숫자 변환

### DIFF
--- a/src/main/java/egovframework/bat/job/erp/tasklet/SendErpDataTasklet.java
+++ b/src/main/java/egovframework/bat/job/erp/tasklet/SendErpDataTasklet.java
@@ -115,7 +115,7 @@ public class SendErpDataTasklet implements Tasklet {
             }
 
             // 현재 페이지의 마지막 VEHICLE_ID를 미리 확보
-            long maxId = vehicles.get(vehicles.size() - 1).getVehicleId();
+            long maxId = Long.parseLong(vehicles.get(vehicles.size() - 1).getVehicleId());
             try {
                 // 차량 정보를 Flux로 구성하여 병렬 전송
                 Flux.fromIterable(vehicles)


### PR DESCRIPTION
## 요약
- 차량 ID를 숫자로 변환하여 최대 ID 계산 오류 수정

## 테스트
- `mvn -q test` *(네트워크 문제로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68c0249f12d8832aa73c2e62cc8511d0