### PR TITLE
프런트엔드 재시작/중지 API 호출 수정

### DIFF
--- a/src/management-ui/static/js/batch-detail.js
+++ b/src/management-ui/static/js/batch-detail.js
@@ -47,16 +47,26 @@ document.addEventListener('DOMContentLoaded', () => {
             const restartBtn = document.createElement('button');
             restartBtn.textContent = '재시작';
             restartBtn.addEventListener('click', () => {
-                fetch(`/api/management/batch/executions/${exec.jobExecutionId}/restart`, { method: 'POST' })
-                    .then(() => load());
+                // 잡을 재시작하는 API 호출
+                fetch(`/api/management/batch/jobs/${jobName}/restart`, { method: 'POST' })
+                    .then(res => {
+                        if (!res.ok) throw new Error('재시작 요청 실패');
+                        load();
+                    })
+                    .catch(err => alert(`재시작 실패: ${err.message}`));
             });
             actionTd.appendChild(restartBtn);
 
             const stopBtn = document.createElement('button');
             stopBtn.textContent = '중지';
             stopBtn.addEventListener('click', () => {
-                fetch(`/api/management/batch/executions/${exec.jobExecutionId}/stop`, { method: 'POST' })
-                    .then(() => load());
+                // 실행 중인 잡을 중지하는 API 호출
+                fetch(`/api/management/batch/jobs/${jobName}/stop`, { method: 'POST' })
+                    .then(res => {
+                        if (!res.ok) throw new Error('중지 요청 실패');
+                        load();
+                    })
+                    .catch(err => alert(`중지 실패: ${err.message}`));
             });
             actionTd.appendChild(stopBtn);
 


### PR DESCRIPTION
## Summary
- 재시작/중지 버튼이 잡 단위 API(`/jobs/{jobName}/restart|stop`)를 호출하도록 변경
- API 응답 실패 시 경고창으로 오류 메시지 표시

## Testing
- `mvn -q test` *(실패: Non-resolvable parent POM. Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c02f21ea30832a9222187e202c580d