### PR TITLE
feat: add warning log for API key mismatch

### DIFF
--- a/src/main/java/egovframework/bat/config/ApiKeyAuthFilter.java
+++ b/src/main/java/egovframework/bat/config/ApiKeyAuthFilter.java
@@ -12,10 +12,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 관리용 API 호출 시 API 키를 검증하는 필터
  */
+@Slf4j
 @Component
 @ConditionalOnProperty(prefix = "security.api-key", name = "enabled", havingValue = "true")
 public class ApiKeyAuthFilter extends OncePerRequestFilter {
@@ -39,6 +41,8 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
         if (expectedKey.equals(key)) {
             chain.doFilter(req, res);   // 정상 흐름
         } else {
+            // API 키가 없거나 일치하지 않는 경우 경고 로그 출력
+            log.warn("API 키 불일치 - URI: {}", uri);
             res.setStatus(HttpStatus.UNAUTHORIZED.value());
         }
     }


### PR DESCRIPTION
## Summary
- warn when API key is missing or invalid in management API filter

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0348be860832aaa9586205296f21d