### PR TITLE
Remove Thymeleaf dependency from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,11 +74,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
-        <!-- Thymeleaf 템플릿 엔진 추가 -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-thymeleaf</artifactId>
-        </dependency>
         <!-- Log4j2 사용을 위한 의존성 명시 -->
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- remove thymeleaf dependency from pom.xml

## Testing
- `mvn -q clean test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.7.18 from/to mvn2s (https://repo1.maven.org/maven2/): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c75c208ff0832a815d317abd234a11