### PR TITLE
commons-dbcp2 의존성 제거

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,10 +164,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-dbcp2</artifactId>
-		</dependency>
 		<!--<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>


### PR DESCRIPTION
## Summary
- pom.xml에서 commons-dbcp2 의존성 블록 제거

## Testing
- `mvn -q clean test` *(실패: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c75d915158832aa56e4c77c0252755