### PR TITLE
Remove ANTLR dependency from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,11 +148,6 @@
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz-jobs</artifactId>
         </dependency>
-                <dependency>
-                        <groupId>org.antlr</groupId>
-                        <artifactId>antlr</artifactId>
-                        <version>3.5</version>
-                </dependency>
 		<dependency>
 			<groupId>com.googlecode.log4jdbc</groupId>
 			<artifactId>log4jdbc</artifactId>


### PR DESCRIPTION
## Summary
- remove obsolete ANTLR dependency from pom.xml

## Testing
- `mvn -q clean test` *(fails: Could not resolve parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c75f3504f0832a99672eb8104387d3