### PR TITLE
quartz-jobs 의존성에 test 범위 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz-jobs</artifactId>
+            <scope>test</scope>
         </dependency>
 		<dependency>
 			<groupId>com.googlecode.log4jdbc</groupId>


### PR DESCRIPTION
## Summary
- quartz-jobs 의존성을 테스트 범위로 지정

## Testing
- `mvn -q clean test` (네트워크 문제로 실패: Non-resolvable parent POM)


------
https://chatgpt.com/codex/tasks/task_e_68c7630eaaac832aaa2f6079d4472a07