### PR TITLE
hibernate-validator 의존성 제거

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,11 +111,6 @@
             <artifactId>org.egovframe.rte.fdl.property</artifactId>
             <version>${org.egovframe.rte.version}</version>
         </dependency>
-        <!-- Bean Validation을 위한 Hibernate Validator 의존성 추가 -->
-        <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-        </dependency>
         <!-- JPA 엔티티를 사용하기 위한 의존성 추가 -->
         <dependency>
             <groupId>javax.persistence</groupId>


### PR DESCRIPTION
## Summary
- pom.xml에서 hibernate-validator 의존성 제거

## Testing
- `mvn -q clean test` *(실패: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c771c9a8c8832a8f580a8aeb6dd047