### PR TITLE
Add risk data migration batch jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,37 @@ public class SampleTasklet implements Tasklet {
     - `src/test/java/egovframework/bat/job/erp/tasklet/FetchErpDataTaskletTest.java`
     - `src/test/java/egovframework/bat/job/erp/tasklet/FetchErpDataTaskletPropertyInjectionTest.java`
     - `src/test/java/egovframework/bat/job/erp/api/VehicleControllerTest.java`
+
+## 리스크 배치 잡 디렉터리(`risk`)
+
+`src/main/java/egovframework/bat/job/risk` 디렉터리는 리스크 관리 업무 배치를 위한 구성을 모아둔 공간입니다. 주요 Job은 다음과 같습니다.
+
+- `riskRemote1ToStgJob`: 원격 리스크 DB에서 스테이징으로 카테고리/사건 정보를 이관합니다.
+- `riskStgToLocalJob`: 스테이징 데이터를 로컬 운영 DB와 동기화합니다.
+
+### 관련 소스 위치
+
+- 잡 설정 클래스
+  - `src/main/java/egovframework/bat/job/risk/config/RiskRemote1ToStgJobConfig.java`
+  - `src/main/java/egovframework/bat/job/risk/config/RiskStgToLocalJobConfig.java`
+- API 컨트롤러
+  - `src/main/java/egovframework/bat/job/risk/api/RiskRemote1ToStgJobController.java`
+- 도메인 및 태스크릿
+  - `src/main/java/egovframework/bat/job/risk/domain/RiskCategory.java`
+  - `src/main/java/egovframework/bat/job/risk/domain/RiskIncident.java`
+  - `src/main/java/egovframework/bat/job/risk/tasklet/TruncateRiskStgTablesTasklet.java`
+  - `src/main/java/egovframework/bat/job/risk/tasklet/RiskStgToLocalIncidentTasklet.java`
+- 매퍼 파일
+  - `src/main/resources/egovframework/batch/mapper/job/risk/risk_remote1_to_stg.xml`
+  - `src/main/resources/egovframework/batch/mapper/job/risk/risk_stg_to_local.xml`
+- 테스트 코드
+  - `src/test/java/egovframework/bat/job/risk/processor/RiskStgToLocalJobIntegrationTest.java`
+
+### 실행 방법과 설정 요약
+
+- REST 엔드포인트: `POST /api/batch/risk/remote1-to-stg`
+- 스케줄러: `scheduler.jobs` 맵에 `riskRemote1ToStgJob`, `riskStgToLocalJob`이 등록되어 있으며, `BatchSchedulerConfig`에서 체인 실행되도록 구성되어 있습니다.
+- 데이터소스 설정: `spring.datasource.risk-remote-mysql` 키로 원격 리스크 DB 접속 정보를 환경별 `application.yml`에 정의합니다.
     - `src/test/java/egovframework/bat/job/erp/api/DummyErpApiInfoTest.java`
 
 ### ERP 실패 로그 테이블 미사용 시

--- a/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
@@ -96,6 +96,8 @@ public class BatchSchedulerConfig {
                 new JobKey("insaStgToLocalJobDetail", Constant.QUARTZ_BATCH_GROUP));
         listener.addJobChainLink(new JobKey("erpRestToStgJobDetail", Constant.QUARTZ_BATCH_GROUP),
                 new JobKey("erpStgToLocalJobDetail", Constant.QUARTZ_BATCH_GROUP));
+        listener.addJobChainLink(new JobKey("riskRemote1ToStgJobDetail", Constant.QUARTZ_BATCH_GROUP),
+                new JobKey("riskStgToLocalJobDetail", Constant.QUARTZ_BATCH_GROUP));
         return listener;
     }
 

--- a/src/main/java/egovframework/bat/config/MultiDataSourceConfig.java
+++ b/src/main/java/egovframework/bat/config/MultiDataSourceConfig.java
@@ -63,8 +63,21 @@ public class MultiDataSourceConfig {
     @Bean(name = "egovremote1CubridJdbcTemplate")
     //JdbcTemplate egovremote1CubridJdbcTemplate(@Qualifier("egovremote1CubridDataSource") DataSource ds) {
     JdbcTemplate egovremote1CubridJdbcTemplate(@Qualifier("dataSource-remote1") DataSource ds) {
-    	//return new JdbcTemplate(ds);
+        //return new JdbcTemplate(ds);
         // LazyConnectionDataSourceProxy로 실제 커넥션 생성을 지연
+        return new JdbcTemplate(new LazyConnectionDataSourceProxy(ds));
+    }
+
+    // 리스크 원격 MySQL용 데이타소스
+    @Bean(name = "dataSource-risk-remote")
+    @ConfigurationProperties("spring.datasource.risk-remote-mysql")
+    DataSource riskRemoteDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    // 리스크 원격 MySQL용 JdbcTemplate
+    @Bean(name = "riskRemoteJdbcTemplate")
+    JdbcTemplate riskRemoteJdbcTemplate(@Qualifier("dataSource-risk-remote") DataSource ds) {
         return new JdbcTemplate(new LazyConnectionDataSourceProxy(ds));
     }
 }

--- a/src/main/java/egovframework/bat/job/risk/api/RiskRemote1ToStgJobController.java
+++ b/src/main/java/egovframework/bat/job/risk/api/RiskRemote1ToStgJobController.java
@@ -1,0 +1,36 @@
+package egovframework.bat.job.risk.api;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import egovframework.bat.job.common.api.JobRunController;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 리스크 원격 시스템 데이터를 STG로 적재하는 잡 실행 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api/batch/risk")
+@RequiredArgsConstructor
+public class RiskRemote1ToStgJobController {
+
+    /** 공통 잡 실행 컨트롤러 */
+    private final JobRunController jobRunController;
+
+    /**
+     * 리스크 원격 데이터를 STG로 이관한다.
+     * @return 배치 잡 실행 결과
+     */
+    @PostMapping("/remote1-to-stg")
+    public ResponseEntity<BatchStatus> runRiskRemote1ToStgJob() {
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addLong("timestamp", System.currentTimeMillis())
+                .toJobParameters();
+        return jobRunController.execute("riskRemote1ToStgJob", jobParameters);
+    }
+}

--- a/src/main/java/egovframework/bat/job/risk/config/RiskRemote1ToStgJobConfig.java
+++ b/src/main/java/egovframework/bat/job/risk/config/RiskRemote1ToStgJobConfig.java
@@ -1,0 +1,160 @@
+package egovframework.bat.job.risk.config;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter;
+import org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import egovframework.bat.job.insa.listener.StepCountLogger;
+import egovframework.bat.job.risk.domain.RiskCategory;
+import egovframework.bat.job.risk.domain.RiskIncident;
+import egovframework.bat.job.risk.tasklet.TruncateRiskStgTablesTasklet;
+
+/**
+ * 리스크 원격 시스템 데이터를 STG로 이관하는 잡 설정.
+ */
+@Configuration
+public class RiskRemote1ToStgJobConfig {
+
+    /**
+     * 리스크 STG 테이블을 비우는 Tasklet 빈.
+     */
+    @Bean
+    public TruncateRiskStgTablesTasklet riskTruncateStgTablesTasklet(
+            @Qualifier("sqlSessionFactory-stg") SqlSessionFactory sqlSessionFactory) {
+        TruncateRiskStgTablesTasklet tasklet = new TruncateRiskStgTablesTasklet();
+        tasklet.setSqlSessionFactory(sqlSessionFactory);
+        return tasklet;
+    }
+
+    /**
+     * 원격 DB에서 리스크 카테고리를 읽어오는 리더.
+     */
+    @Bean
+    @StepScope
+    public EgovMyBatisPagingItemReader<RiskCategory> riskRemote1ToStgCategoryReader(
+            @Qualifier("risk-sqlSessionFactory-remote1") SqlSessionFactory sqlSessionFactory) {
+        EgovMyBatisPagingItemReader<RiskCategory> reader = new EgovMyBatisPagingItemReader<>();
+        reader.setSqlSessionFactory(sqlSessionFactory);
+        reader.setQueryId("riskRemToStg.selectCategoryList");
+        reader.setPageSize(100);
+        return reader;
+    }
+
+    /**
+     * STG DB에 리스크 카테고리를 기록하는 라이터.
+     */
+    @Bean
+    @StepScope
+    public EgovMyBatisBatchItemWriter<RiskCategory> riskRemote1ToStgCategoryWriter(
+            @Qualifier("sqlSessionFactory-stg") SqlSessionFactory sqlSessionFactory) {
+        EgovMyBatisBatchItemWriter<RiskCategory> writer = new EgovMyBatisBatchItemWriter<>();
+        writer.setSqlSessionFactory(sqlSessionFactory);
+        writer.setStatementId("riskRemToStg.insertCategory");
+        return writer;
+    }
+
+    /**
+     * 원격 DB에서 리스크 사건을 읽어오는 리더.
+     */
+    @Bean
+    @StepScope
+    public EgovMyBatisPagingItemReader<RiskIncident> riskRemote1ToStgIncidentReader(
+            @Qualifier("risk-sqlSessionFactory-remote1") SqlSessionFactory sqlSessionFactory) {
+        EgovMyBatisPagingItemReader<RiskIncident> reader = new EgovMyBatisPagingItemReader<>();
+        reader.setSqlSessionFactory(sqlSessionFactory);
+        reader.setQueryId("riskRemToStg.selectIncidentList");
+        reader.setPageSize(100);
+        return reader;
+    }
+
+    /**
+     * STG DB에 리스크 사건을 기록하는 라이터.
+     */
+    @Bean
+    @StepScope
+    public EgovMyBatisBatchItemWriter<RiskIncident> riskRemote1ToStgIncidentWriter(
+            @Qualifier("sqlSessionFactory-stg") SqlSessionFactory sqlSessionFactory) {
+        EgovMyBatisBatchItemWriter<RiskIncident> writer = new EgovMyBatisBatchItemWriter<>();
+        writer.setSqlSessionFactory(sqlSessionFactory);
+        writer.setStatementId("riskRemToStg.insertIncident");
+        return writer;
+    }
+
+    /**
+     * STG 테이블 초기화 스텝.
+     */
+    @Bean
+    public Step riskTruncateStgTablesStep(JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            TruncateRiskStgTablesTasklet riskTruncateStgTablesTasklet,
+            StepCountLogger stepCountLogger) {
+        return new StepBuilder("riskTruncateStgTablesStep").repository(jobRepository)
+                .tasklet(riskTruncateStgTablesTasklet)
+                .transactionManager(transactionManager)
+                .listener(stepCountLogger)
+                .build();
+    }
+
+    /**
+     * 리스크 카테고리를 이관하는 스텝.
+     */
+    @Bean
+    public Step riskRemote1ToStgCategoryStep(JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            ItemReader<RiskCategory> riskRemote1ToStgCategoryReader,
+            ItemWriter<RiskCategory> riskRemote1ToStgCategoryWriter,
+            StepCountLogger stepCountLogger) {
+        return new StepBuilder("riskRemote1ToStgCategoryStep").repository(jobRepository)
+                .<RiskCategory, RiskCategory>chunk(500)
+                .reader(riskRemote1ToStgCategoryReader)
+                .writer(riskRemote1ToStgCategoryWriter)
+                .listener(stepCountLogger)
+                .transactionManager(transactionManager)
+                .build();
+    }
+
+    /**
+     * 리스크 사건을 이관하는 스텝.
+     */
+    @Bean
+    public Step riskRemote1ToStgIncidentStep(JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            ItemReader<RiskIncident> riskRemote1ToStgIncidentReader,
+            ItemWriter<RiskIncident> riskRemote1ToStgIncidentWriter,
+            StepCountLogger stepCountLogger) {
+        return new StepBuilder("riskRemote1ToStgIncidentStep").repository(jobRepository)
+                .<RiskIncident, RiskIncident>chunk(500)
+                .reader(riskRemote1ToStgIncidentReader)
+                .writer(riskRemote1ToStgIncidentWriter)
+                .listener(stepCountLogger)
+                .transactionManager(transactionManager)
+                .build();
+    }
+
+    /**
+     * 리스크 원격 데이터를 STG로 옮기는 잡 정의.
+     */
+    @Bean
+    public Job riskRemote1ToStgJob(JobRepository jobRepository,
+            Step riskTruncateStgTablesStep,
+            Step riskRemote1ToStgCategoryStep,
+            Step riskRemote1ToStgIncidentStep) {
+        return new JobBuilder("riskRemote1ToStgJob").repository(jobRepository)
+                .start(riskTruncateStgTablesStep)
+                .next(riskRemote1ToStgCategoryStep)
+                .next(riskRemote1ToStgIncidentStep)
+                .build();
+    }
+}

--- a/src/main/java/egovframework/bat/job/risk/config/RiskStgToLocalJobConfig.java
+++ b/src/main/java/egovframework/bat/job/risk/config/RiskStgToLocalJobConfig.java
@@ -1,0 +1,114 @@
+package egovframework.bat.job.risk.config;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter;
+import org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import egovframework.bat.job.insa.listener.StepCountLogger;
+import egovframework.bat.job.risk.domain.RiskCategory;
+import egovframework.bat.job.risk.tasklet.RiskStgToLocalIncidentTasklet;
+
+/**
+ * STG에 적재된 리스크 데이터를 로컬 DB로 이관하는 잡 설정.
+ */
+@Configuration
+public class RiskStgToLocalJobConfig {
+
+    /**
+     * STG DB에서 리스크 카테고리를 읽어오는 리더.
+     */
+    @Bean
+    @StepScope
+    public EgovMyBatisPagingItemReader<RiskCategory> riskStgToLocalCategoryReader(
+            @Qualifier("sqlSessionFactory-stg") SqlSessionFactory sqlSessionFactory) {
+        EgovMyBatisPagingItemReader<RiskCategory> reader = new EgovMyBatisPagingItemReader<>();
+        reader.setSqlSessionFactory(sqlSessionFactory);
+        reader.setQueryId("riskStgToLoc.selectCategoryList");
+        reader.setPageSize(100);
+        return reader;
+    }
+
+    /**
+     * 로컬 DB에 리스크 카테고리를 적재하는 라이터.
+     */
+    @Bean
+    @StepScope
+    public EgovMyBatisBatchItemWriter<RiskCategory> riskStgToLocalCategoryWriter(
+            @Qualifier("sqlSessionFactory-local") SqlSessionFactory sqlSessionFactory) {
+        EgovMyBatisBatchItemWriter<RiskCategory> writer = new EgovMyBatisBatchItemWriter<>();
+        writer.setSqlSessionFactory(sqlSessionFactory);
+        writer.setStatementId("riskStgToLoc.insertCategory");
+        return writer;
+    }
+
+    /**
+     * 리스크 카테고리 이관 스텝 정의.
+     */
+    @Bean
+    public Step riskStgToLocalCategoryStep(JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            ItemReader<RiskCategory> riskStgToLocalCategoryReader,
+            ItemWriter<RiskCategory> riskStgToLocalCategoryWriter,
+            StepCountLogger stepCountLogger) {
+        return new StepBuilder("riskStgToLocalCategoryStep").repository(jobRepository)
+                .<RiskCategory, RiskCategory>chunk(500)
+                .reader(riskStgToLocalCategoryReader)
+                .writer(riskStgToLocalCategoryWriter)
+                .listener(stepCountLogger)
+                .transactionManager(transactionManager)
+                .build();
+    }
+
+    /**
+     * 리스크 사건 동기화 Tasklet 빈.
+     */
+    @Bean
+    public RiskStgToLocalIncidentTasklet riskStgToLocalIncidentTasklet(
+            @Qualifier("sqlSessionFactory-local") SqlSessionFactory sqlSessionFactory) {
+        RiskStgToLocalIncidentTasklet tasklet = new RiskStgToLocalIncidentTasklet();
+        tasklet.setSqlSessionFactory(sqlSessionFactory);
+        return tasklet;
+    }
+
+    /**
+     * 리스크 사건 이관 스텝 정의.
+     */
+    @Bean
+    public Step riskStgToLocalIncidentStep(JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            RiskStgToLocalIncidentTasklet riskStgToLocalIncidentTasklet,
+            StepCountLogger stepCountLogger) {
+        return new StepBuilder("riskStgToLocalIncidentStep").repository(jobRepository)
+                .tasklet(riskStgToLocalIncidentTasklet)
+                .listener(stepCountLogger)
+                .transactionManager(transactionManager)
+                .build();
+    }
+
+    /**
+     * 리스크 STG 데이터를 로컬 DB로 옮기는 잡.
+     */
+    @Bean
+    public Job riskStgToLocalJob(JobRepository jobRepository,
+            Step riskStgToLocalCategoryStep,
+            Step riskStgToLocalIncidentStep) {
+        return new JobBuilder("riskStgToLocalJob").repository(jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .start(riskStgToLocalCategoryStep)
+                .next(riskStgToLocalIncidentStep)
+                .build();
+    }
+}

--- a/src/main/java/egovframework/bat/job/risk/domain/RiskCategory.java
+++ b/src/main/java/egovframework/bat/job/risk/domain/RiskCategory.java
@@ -1,0 +1,14 @@
+package egovframework.bat.job.risk.domain;
+
+import lombok.Data;
+
+/**
+ * 위험 카테고리 정보를 담는 VO 클래스.
+ */
+@Data
+public class RiskCategory {
+
+    private String categoryId;        /** 카테고리 고유 ID */
+    private String categoryName;      /** 카테고리 명칭 */
+    private String categoryDescription; /** 카테고리 설명 */
+}

--- a/src/main/java/egovframework/bat/job/risk/domain/RiskIncident.java
+++ b/src/main/java/egovframework/bat/job/risk/domain/RiskIncident.java
@@ -1,0 +1,23 @@
+package egovframework.bat.job.risk.domain;
+
+import java.util.Date;
+
+import lombok.Data;
+
+/**
+ * 위험 사건(리스크 이슈) 정보를 담는 VO 클래스.
+ */
+@Data
+public class RiskIncident {
+
+    private String incidentId;    /** 로컬 시스템에서 사용하는 사건 ID */
+    private String incidentNo;    /** 원천 시스템의 사건 식별자 */
+    private String categoryId;    /** 소속 카테고리 ID */
+    private String title;         /** 사건 제목 */
+    private String riskLevel;     /** 위험 등급 */
+    private String status;        /** 처리 상태 */
+    private String ownerId;       /** 담당자 ID */
+    private String description;   /** 사건 상세 설명 */
+    private Date occurredAt;      /** 발생 일시 */
+    private Date updatedAt;       /** 수정 일시 */
+}

--- a/src/main/java/egovframework/bat/job/risk/tasklet/RiskStgToLocalIncidentTasklet.java
+++ b/src/main/java/egovframework/bat/job/risk/tasklet/RiskStgToLocalIncidentTasklet.java
@@ -1,0 +1,44 @@
+package egovframework.bat.job.risk.tasklet;
+
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+
+/**
+ * 스테이징과 로컬 DB의 리스크 사건 정보를 동기화하는 Tasklet.
+ */
+public class RiskStgToLocalIncidentTasklet implements Tasklet {
+
+    /** MyBatis SqlSessionFactory */
+    private SqlSessionFactory sqlSessionFactory;
+
+    /**
+     * SqlSessionFactory 주입자.
+     * @param sqlSessionFactory 로컬 DB용 SqlSessionFactory
+     */
+    public void setSqlSessionFactory(SqlSessionFactory sqlSessionFactory) {
+        this.sqlSessionFactory = sqlSessionFactory;
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        try (SqlSession session = sqlSessionFactory.openSession()) {
+            // 기존 사건 정보 갱신
+            int updateCount = session.update("riskStgToLoc.updateIncident");
+            // INCIDENT_ID 시퀀스 초기화
+            session.update("riskStgToLoc.initIncidentSeq");
+            // 신규 사건 정보 추가
+            int insertCount = session.insert("riskStgToLoc.insertIncidentIncremental");
+            session.commit();
+
+            // 처리 건수 기록
+            int total = updateCount + insertCount;
+            contribution.getStepExecution().setReadCount(total);
+            contribution.incrementWriteCount(total);
+        }
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/egovframework/bat/job/risk/tasklet/TruncateRiskStgTablesTasklet.java
+++ b/src/main/java/egovframework/bat/job/risk/tasklet/TruncateRiskStgTablesTasklet.java
@@ -1,0 +1,37 @@
+package egovframework.bat.job.risk.tasklet;
+
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+
+/**
+ * 리스크 도메인의 스테이징 테이블을 초기화하는 Tasklet.
+ */
+public class TruncateRiskStgTablesTasklet implements Tasklet {
+
+    /** MyBatis SqlSessionFactory */
+    private SqlSessionFactory sqlSessionFactory;
+
+    /**
+     * SqlSessionFactory 주입자.
+     * @param sqlSessionFactory STG용 SqlSessionFactory
+     */
+    public void setSqlSessionFactory(SqlSessionFactory sqlSessionFactory) {
+        this.sqlSessionFactory = sqlSessionFactory;
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        try (SqlSession session = sqlSessionFactory.openSession()) {
+            // 리스크 사건 테이블 비우기
+            session.update("riskRemToStg.truncateRiskIncident");
+            // 리스크 카테고리 테이블 비우기
+            session.update("riskRemToStg.truncateRiskCategory");
+            session.commit();
+        }
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/resources/application/env/dev/application.yml
+++ b/src/main/resources/application/env/dev/application.yml
@@ -49,6 +49,13 @@ spring:
       username: readuser
       password: read!1234
 
+    # 리스크 전용 원격 MySQL
+    risk-remote-mysql:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      url: jdbc:mysql://localhost:3306/riskremote1?useSSL=false&serverTimezone=Asia/Seoul
+      username: readuser
+      password: read!1234
+
   quartz:
     job-store-type: jdbc           # JDBCJobStore 사용
     jdbc:
@@ -97,7 +104,11 @@ scheduler:
     erpStgToRestJob: "0 0 * * * ?"
     # CronTrigger로 즉시 스케줄됨
     mybatisToMybatisSampleJob: "0 0 * * * ?"
+    # CronTrigger로 즉시 스케줄됨
+    riskRemote1ToStgJob: "0 0/10 * * * ?"
     # 선행 잡 종료 후 체인으로 실행됨
     insaStgToLocalJob: ""
     # 선행 잡 종료 후 체인으로 실행됨
     erpStgToLocalJob: ""
+    # 선행 잡 종료 후 체인으로 실행됨
+    riskStgToLocalJob: ""

--- a/src/main/resources/application/env/local/application.yml
+++ b/src/main/resources/application/env/local/application.yml
@@ -44,6 +44,13 @@ spring:
       username: readuser
       password: read!1234
 
+    # 리스크 전용 원격 MySQL
+    risk-remote-mysql:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      url: jdbc:mysql://localhost:3306/riskremote1?useSSL=false&serverTimezone=Asia/Seoul
+      username: readuser
+      password: read!1234
+
   quartz:
     job-store-type: jdbc           # JDBCJobStore 사용
     jdbc:
@@ -96,8 +103,12 @@ scheduler:
     erpStgToRestJob: "0 0 * * * ?"
     # CronTrigger로 즉시 스케줄됨
     mybatisToMybatisSampleJob: "0 0 * * * ?"
+    # CronTrigger로 즉시 스케줄됨
+    riskRemote1ToStgJob: "0 0/10 * * * ?"
     # 선행 잡 종료 후 체인으로 실행됨
     insaStgToLocalJob: ""
     # 선행 잡 종료 후 체인으로 실행됨
     erpStgToLocalJob: ""
+    # 선행 잡 종료 후 체인으로 실행됨
+    riskStgToLocalJob: ""
 

--- a/src/main/resources/application/env/prod/application.yml
+++ b/src/main/resources/application/env/prod/application.yml
@@ -49,6 +49,13 @@ spring:
       username: readuser
       password: read!1234
 
+    # 리스크 전용 원격 MySQL
+    risk-remote-mysql:
+      driver-class-name: com.mysql.cj.jdbc.Driver
+      url: jdbc:mysql://localhost:3306/riskremote1?useSSL=false&serverTimezone=Asia/Seoul
+      username: readuser
+      password: read!1234
+
   quartz:
     job-store-type: jdbc           # JDBCJobStore 사용
     jdbc:
@@ -97,7 +104,11 @@ scheduler:
     erpStgToRestJob: "0 0 * * * ?"
     # CronTrigger로 즉시 스케줄됨
     mybatisToMybatisSampleJob: "0 0 * * * ?"
+    # CronTrigger로 즉시 스케줄됨
+    riskRemote1ToStgJob: "0 0/10 * * * ?"
     # 선행 잡 종료 후 체인으로 실행됨
     insaStgToLocalJob: ""
     # 선행 잡 종료 후 체인으로 실행됨
     erpStgToLocalJob: ""
+    # 선행 잡 종료 후 체인으로 실행됨
+    riskStgToLocalJob: ""

--- a/src/main/resources/egovframework/batch/context-batch-mapper.xml
+++ b/src/main/resources/egovframework/batch/context-batch-mapper.xml
@@ -14,6 +14,7 @@
             <list>
                 <value>classpath:/egovframework/batch/mapper/job/insa/insa_stg_to_local.xml</value>
                 <value>classpath:/egovframework/batch/mapper/job/erp/erp_stg_to_local.xml</value>
+                <value>classpath:/egovframework/batch/mapper/job/risk/risk_stg_to_local.xml</value>
             </list>
         </property>
     </bean>
@@ -28,13 +29,15 @@
                 <value>classpath:/egovframework/batch/mapper/job/insa/insa_remote1_to_stg.xml</value>
                 <value>classpath:/egovframework/batch/mapper/job/erp/erp_stg_to_local.xml</value>
                 <value>classpath:/egovframework/batch/mapper/job/erp/erp_rest_to_stg.xml</value>
+                <value>classpath:/egovframework/batch/mapper/job/risk/risk_stg_to_local.xml</value>
+                <value>classpath:/egovframework/batch/mapper/job/risk/risk_remote1_to_stg.xml</value>
                 <value>classpath:/egovframework/batch/mapper/job/example/Egov_Example_SQL.xml</value>
                 <!-- 배치 관리 매퍼는 스테이징 환경에서만 사용됩니다. -->
                 <value>classpath:/egovframework/batch/mapper/batch/BatchManagementMapper.xml</value>
             </list>
         </property>
     </bean>
-    
+
     <!-- insa - remote1 DB용 SqlSessionFactory -->
     <bean id="insa-sqlSessionFactory-remote1" class="org.mybatis.spring.SqlSessionFactoryBean">
         <property name="dataSource" ref="dataSource-remote1"/>
@@ -42,6 +45,17 @@
         <property name="mapperLocations">
             <list>
                 <value>classpath:/egovframework/batch/mapper/job/insa/insa_remote1_to_stg.xml</value>
+            </list>
+        </property>
+    </bean>
+
+    <!-- risk - remote1 DB용 SqlSessionFactory -->
+    <bean id="risk-sqlSessionFactory-remote1" class="org.mybatis.spring.SqlSessionFactoryBean">
+        <property name="dataSource" ref="dataSource-risk-remote"/>
+        <property name="configLocation" value="classpath:/egovframework/batch/mapper/config/mapper-config.xml" />
+        <property name="mapperLocations">
+            <list>
+                <value>classpath:/egovframework/batch/mapper/job/risk/risk_remote1_to_stg.xml</value>
             </list>
         </property>
     </bean>

--- a/src/main/resources/egovframework/batch/mapper/job/risk/risk_remote1_to_stg.xml
+++ b/src/main/resources/egovframework/batch/mapper/job/risk/risk_remote1_to_stg.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="riskRemToStg">
+
+    <!-- 리스크 카테고리 목록 조회 -->
+    <select id="selectCategoryList" resultType="egovframework.bat.job.risk.domain.RiskCategory">
+        SELECT
+            CATEGORY_ID,
+            CATEGORY_NAME,
+            CATEGORY_DESC AS categoryDescription
+        FROM RISK_CATEGORY
+    </select>
+
+    <!-- 리스크 사건 목록 조회 -->
+    <select id="selectIncidentList" resultType="egovframework.bat.job.risk.domain.RiskIncident">
+        SELECT
+            INCIDENT_ID,
+            INCIDENT_NO,
+            CATEGORY_ID,
+            TITLE,
+            RISK_LEVEL,
+            STATUS,
+            OWNER_ID,
+            DESCRIPTION,
+            OCCURRED_AT,
+            UPDATED_AT
+        FROM RISK_INCIDENT
+    </select>
+
+    <!-- STG에 리스크 카테고리 저장 -->
+    <insert id="insertCategory" parameterType="egovframework.bat.job.risk.domain.RiskCategory">
+        INSERT INTO migstg.RISK_CATEGORY (CATEGORY_ID, CATEGORY_NAME, CATEGORY_DESC)
+        VALUES (#{categoryId}, #{categoryName}, #{categoryDescription})
+    </insert>
+
+    <!-- STG에 리스크 사건 저장 -->
+    <insert id="insertIncident" parameterType="egovframework.bat.job.risk.domain.RiskIncident">
+        INSERT INTO migstg.RISK_INCIDENT (
+            INCIDENT_ID,
+            INCIDENT_NO,
+            CATEGORY_ID,
+            TITLE,
+            RISK_LEVEL,
+            STATUS,
+            OWNER_ID,
+            DESCRIPTION,
+            OCCURRED_AT,
+            UPDATED_AT)
+        VALUES (
+            #{incidentId},
+            #{incidentNo},
+            #{categoryId},
+            #{title},
+            #{riskLevel},
+            #{status},
+            #{ownerId},
+            #{description},
+            #{occurredAt},
+            #{updatedAt})
+    </insert>
+
+    <!-- 스테이징 카테고리 초기화 -->
+    <update id="truncateRiskCategory">
+        TRUNCATE TABLE migstg.RISK_CATEGORY
+    </update>
+
+    <!-- 스테이징 사건 초기화 -->
+    <update id="truncateRiskIncident">
+        TRUNCATE TABLE migstg.RISK_INCIDENT
+    </update>
+
+</mapper>

--- a/src/main/resources/egovframework/batch/mapper/job/risk/risk_stg_to_local.xml
+++ b/src/main/resources/egovframework/batch/mapper/job/risk/risk_stg_to_local.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="riskStgToLoc">
+
+    <!-- STG의 리스크 카테고리 목록 조회 -->
+    <select id="selectCategoryList" resultType="egovframework.bat.job.risk.domain.RiskCategory">
+        SELECT
+            CATEGORY_ID,
+            CATEGORY_NAME,
+            CATEGORY_DESC AS categoryDescription
+        FROM migstg.RISK_CATEGORY
+    </select>
+
+    <!-- STG의 리스크 사건 목록 조회 -->
+    <select id="selectIncidentList" resultType="egovframework.bat.job.risk.domain.RiskIncident">
+        SELECT
+            INCIDENT_ID,
+            INCIDENT_NO,
+            CATEGORY_ID,
+            TITLE,
+            RISK_LEVEL,
+            STATUS,
+            OWNER_ID,
+            DESCRIPTION,
+            OCCURRED_AT,
+            UPDATED_AT
+        FROM migstg.RISK_INCIDENT
+    </select>
+
+    <!-- 기존 로컬 사건 정보 갱신 -->
+    <update id="updateIncident">
+        UPDATE egovlocal.RISK_INCIDENT u
+        JOIN migstg.RISK_INCIDENT s ON u.INCIDENT_NO = s.INCIDENT_NO
+        SET u.CATEGORY_ID = s.CATEGORY_ID,
+            u.TITLE = s.TITLE,
+            u.RISK_LEVEL = s.RISK_LEVEL,
+            u.STATUS = s.STATUS,
+            u.OWNER_ID = s.OWNER_ID,
+            u.DESCRIPTION = s.DESCRIPTION,
+            u.OCCURRED_AT = s.OCCURRED_AT,
+            u.UPDATED_AT = s.UPDATED_AT
+    </update>
+
+    <!-- INCIDENT_ID 시퀀스 초기화 -->
+    <update id="initIncidentSeq">
+        SET @riskSeq := (
+            SELECT IFNULL(MAX(CAST(SUBSTR(INCIDENT_ID, 4) AS UNSIGNED)), 0)
+            FROM egovlocal.RISK_INCIDENT
+        )
+    </update>
+
+    <!-- 신규 리스크 사건 적재 -->
+    <insert id="insertIncidentIncremental">
+        INSERT INTO egovlocal.RISK_INCIDENT (
+            INCIDENT_ID,
+            INCIDENT_NO,
+            CATEGORY_ID,
+            TITLE,
+            RISK_LEVEL,
+            STATUS,
+            OWNER_ID,
+            DESCRIPTION,
+            OCCURRED_AT,
+            UPDATED_AT)
+        SELECT CONCAT('RSK', LPAD(@riskSeq := @riskSeq + 1, 7, '0')) AS INCIDENT_ID,
+               s.INCIDENT_NO,
+               s.CATEGORY_ID,
+               s.TITLE,
+               s.RISK_LEVEL,
+               s.STATUS,
+               s.OWNER_ID,
+               s.DESCRIPTION,
+               s.OCCURRED_AT,
+               s.UPDATED_AT
+        FROM migstg.RISK_INCIDENT s
+        LEFT JOIN egovlocal.RISK_INCIDENT u ON u.INCIDENT_NO = s.INCIDENT_NO
+        WHERE u.INCIDENT_NO IS NULL
+    </insert>
+
+    <!-- 로컬 리스크 카테고리 적재 -->
+    <insert id="insertCategory" parameterType="egovframework.bat.job.risk.domain.RiskCategory">
+        INSERT INTO egovlocal.RISK_CATEGORY (CATEGORY_ID, CATEGORY_NAME, CATEGORY_DESC)
+        VALUES (#{categoryId}, #{categoryName}, #{categoryDescription})
+        ON DUPLICATE KEY UPDATE
+            CATEGORY_NAME = VALUES(CATEGORY_NAME),
+            CATEGORY_DESC = VALUES(CATEGORY_DESC)
+    </insert>
+
+    <!-- STG 데이터를 로컬 사건 테이블에 직접 적재 (필요 시 사용) -->
+    <insert id="insertIncident" parameterType="egovframework.bat.job.risk.domain.RiskIncident">
+        INSERT INTO egovlocal.RISK_INCIDENT (
+            INCIDENT_ID,
+            INCIDENT_NO,
+            CATEGORY_ID,
+            TITLE,
+            RISK_LEVEL,
+            STATUS,
+            OWNER_ID,
+            DESCRIPTION,
+            OCCURRED_AT,
+            UPDATED_AT)
+        VALUES (
+            #{incidentId},
+            #{incidentNo},
+            #{categoryId},
+            #{title},
+            #{riskLevel},
+            #{status},
+            #{ownerId},
+            #{description},
+            #{occurredAt},
+            #{updatedAt})
+    </insert>
+
+</mapper>

--- a/src/test/java/egovframework/bat/job/risk/processor/RiskStgToLocalJobIntegrationTest.java
+++ b/src/test/java/egovframework/bat/job/risk/processor/RiskStgToLocalJobIntegrationTest.java
@@ -1,0 +1,133 @@
+package egovframework.bat.job.risk.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * 리스크 STG -> 로컬 이관 잡 통합 테스트.
+ */
+@SpringBootTest
+@SpringBatchTest
+@TestPropertySource(properties = {
+    "spring.batch.job.enabled=false"
+})
+public class RiskStgToLocalJobIntegrationTest {
+
+    /** 스테이징 DB 접근용 JdbcTemplate */
+    @Autowired
+    @Qualifier("migstgJdbcTemplate")
+    private JdbcTemplate migstgJdbcTemplate;
+
+    /** 로컬 DB 접근용 JdbcTemplate */
+    @Autowired
+    @Qualifier("jdbcTemplateLocal")
+    private JdbcTemplate jdbcTemplateLocal;
+
+    /** 잡 실행 유틸리티 */
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    /** 테스트 대상 잡 */
+    @Autowired
+    @Qualifier("riskStgToLocalJob")
+    private Job riskStgToLocalJob;
+
+    @BeforeEach
+    void setUp() {
+        jobLauncherTestUtils.setJob(riskStgToLocalJob);
+
+        // STG 테이블 생성 및 초기화
+        migstgJdbcTemplate.execute("CREATE TABLE IF NOT EXISTS RISK_CATEGORY (" +
+                "CATEGORY_ID VARCHAR(20) PRIMARY KEY, " +
+                "CATEGORY_NAME VARCHAR(100), " +
+                "CATEGORY_DESC VARCHAR(255))");
+        migstgJdbcTemplate.execute("CREATE TABLE IF NOT EXISTS RISK_INCIDENT (" +
+                "INCIDENT_ID VARCHAR(20), " +
+                "INCIDENT_NO VARCHAR(30) PRIMARY KEY, " +
+                "CATEGORY_ID VARCHAR(20), " +
+                "TITLE VARCHAR(200), " +
+                "RISK_LEVEL VARCHAR(20), " +
+                "STATUS VARCHAR(20), " +
+                "OWNER_ID VARCHAR(50), " +
+                "DESCRIPTION VARCHAR(4000), " +
+                "OCCURRED_AT TIMESTAMP, " +
+                "UPDATED_AT TIMESTAMP)");
+        migstgJdbcTemplate.execute("TRUNCATE TABLE RISK_CATEGORY");
+        migstgJdbcTemplate.execute("TRUNCATE TABLE RISK_INCIDENT");
+
+        // STG 데이터 입력
+        migstgJdbcTemplate.update("INSERT INTO RISK_CATEGORY (CATEGORY_ID, CATEGORY_NAME, CATEGORY_DESC) VALUES ('C1','위험관리','핵심 카테고리')");
+        migstgJdbcTemplate.update("INSERT INTO RISK_CATEGORY (CATEGORY_ID, CATEGORY_NAME, CATEGORY_DESC) VALUES ('C2','정보보안','신규 카테고리')");
+        migstgJdbcTemplate.update("INSERT INTO RISK_INCIDENT (INCIDENT_ID, INCIDENT_NO, CATEGORY_ID, TITLE, RISK_LEVEL, STATUS, OWNER_ID, DESCRIPTION, OCCURRED_AT, UPDATED_AT) " +
+                "VALUES ('RSK0000001','INC-001','C1','중요 사고','HIGH','OPEN','manager','세부 내용',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)");
+        migstgJdbcTemplate.update("INSERT INTO RISK_INCIDENT (INCIDENT_ID, INCIDENT_NO, CATEGORY_ID, TITLE, RISK_LEVEL, STATUS, OWNER_ID, DESCRIPTION, OCCURRED_AT, UPDATED_AT) " +
+                "VALUES (NULL,'INC-002','C2','신규 이슈','MEDIUM','NEW','analyst','신규 세부 내용',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)");
+
+        // 로컬 테이블 생성 및 초기화
+        jdbcTemplateLocal.execute("CREATE TABLE IF NOT EXISTS RISK_CATEGORY (" +
+                "CATEGORY_ID VARCHAR(20) PRIMARY KEY, " +
+                "CATEGORY_NAME VARCHAR(100), " +
+                "CATEGORY_DESC VARCHAR(255))");
+        jdbcTemplateLocal.execute("CREATE TABLE IF NOT EXISTS RISK_INCIDENT (" +
+                "INCIDENT_ID VARCHAR(20) PRIMARY KEY, " +
+                "INCIDENT_NO VARCHAR(30) UNIQUE, " +
+                "CATEGORY_ID VARCHAR(20), " +
+                "TITLE VARCHAR(200), " +
+                "RISK_LEVEL VARCHAR(20), " +
+                "STATUS VARCHAR(20), " +
+                "OWNER_ID VARCHAR(50), " +
+                "DESCRIPTION VARCHAR(4000), " +
+                "OCCURRED_AT TIMESTAMP, " +
+                "UPDATED_AT TIMESTAMP)");
+        jdbcTemplateLocal.execute("TRUNCATE TABLE RISK_CATEGORY");
+        jdbcTemplateLocal.execute("TRUNCATE TABLE RISK_INCIDENT");
+
+        jdbcTemplateLocal.update("INSERT INTO RISK_CATEGORY (CATEGORY_ID, CATEGORY_NAME, CATEGORY_DESC) VALUES ('C1','구분 필요','이전 설명')");
+        jdbcTemplateLocal.update("INSERT INTO RISK_INCIDENT (INCIDENT_ID, INCIDENT_NO, CATEGORY_ID, TITLE, RISK_LEVEL, STATUS, OWNER_ID, DESCRIPTION, OCCURRED_AT, UPDATED_AT) " +
+                "VALUES ('RSK0000001','INC-001','C1','이전 제목','LOW','CLOSED','user1','과거 내용',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP)");
+    }
+
+    @Test
+    void stgToLocalJob_syncsRiskData() throws Exception {
+        JobExecution execution = jobLauncherTestUtils.launchJob();
+        assertThat(execution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+
+        // 카테고리 업데이트 확인
+        Map<String, Object> category = jdbcTemplateLocal.queryForMap(
+                "SELECT CATEGORY_NAME, CATEGORY_DESC FROM RISK_CATEGORY WHERE CATEGORY_ID='C1'");
+        assertThat(category.get("CATEGORY_NAME")).isEqualTo("위험관리");
+        assertThat(category.get("CATEGORY_DESC")).isEqualTo("핵심 카테고리");
+
+        // 신규 카테고리 삽입 확인
+        Map<String, Object> newCategory = jdbcTemplateLocal.queryForMap(
+                "SELECT CATEGORY_NAME FROM RISK_CATEGORY WHERE CATEGORY_ID='C2'");
+        assertThat(newCategory.get("CATEGORY_NAME")).isEqualTo("정보보안");
+
+        // 기존 사건 업데이트 확인
+        Map<String, Object> incident = jdbcTemplateLocal.queryForMap(
+                "SELECT TITLE, RISK_LEVEL, STATUS FROM RISK_INCIDENT WHERE INCIDENT_NO='INC-001'");
+        assertThat(incident.get("TITLE")).isEqualTo("중요 사고");
+        assertThat(incident.get("RISK_LEVEL")).isEqualTo("HIGH");
+        assertThat(incident.get("STATUS")).isEqualTo("OPEN");
+
+        // 신규 사건 삽입 및 ID 생성 확인
+        Map<String, Object> newIncident = jdbcTemplateLocal.queryForMap(
+                "SELECT INCIDENT_ID, TITLE FROM RISK_INCIDENT WHERE INCIDENT_NO='INC-002'");
+        assertThat(newIncident.get("TITLE")).isEqualTo("신규 이슈");
+        assertThat(newIncident.get("INCIDENT_ID")).isEqualTo("RSK0000002");
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -10,6 +10,11 @@ spring:
       url: jdbc:h2:mem:localdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false
       username: sa
       password:
+    risk-remote-mysql:
+      driver-class-name: org.h2.Driver
+      url: jdbc:h2:mem:riskremote;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false
+      username: sa
+      password:
   batch:
     job:
       enabled: false


### PR DESCRIPTION
## Summary
- add risk-specific batch configurations, domain objects, tasklets and REST controller for remote-to-staging and staging-to-local jobs
- register new MyBatis mappers, data sources and scheduler links for the risk pipeline across environments
- document the risk batch flow and add integration coverage for the staging-to-local job

## Testing
- mvn -Plocal test *(fails: unable to download parent POM because outbound network is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9c9a97c4832ab2d11ec0204a99fe