### PR TITLE
정렬 기준 및 커서 페이징 파라미터 추가

### DIFF
--- a/src/main/java/egovframework/bat/job/insa/config/InsaRemote1ToStgJobConfig.java
+++ b/src/main/java/egovframework/bat/job/insa/config/InsaRemote1ToStgJobConfig.java
@@ -1,5 +1,8 @@
 package egovframework.bat.job.insa.config;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter;
 import org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader;
@@ -12,6 +15,7 @@ import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -74,10 +78,16 @@ public class InsaRemote1ToStgJobConfig {
     @Bean
     @StepScope
     public EgovMyBatisPagingItemReader<EmployeeInfo> remote1ToStgEmpReader(
-            @Qualifier("insa-sqlSessionFactory-remote1") SqlSessionFactory sqlSessionFactory) {
+            @Qualifier("insa-sqlSessionFactory-remote1") SqlSessionFactory sqlSessionFactory,
+            @Value("#{jobParameters['lastEmplyrId']}") Long lastEmplyrId) {
         EgovMyBatisPagingItemReader<EmployeeInfo> reader = new EgovMyBatisPagingItemReader<>();
         reader.setSqlSessionFactory(sqlSessionFactory);
         reader.setQueryId("insaRemToStg.selectEmployeeList");
+        if (lastEmplyrId != null) {
+            Map<String, Object> parameterValues = new HashMap<>();
+            parameterValues.put("lastEmplyrId", lastEmplyrId);
+            reader.setParameterValues(parameterValues);
+        }
         reader.setPageSize(100);
         return reader;
     }

--- a/src/main/resources/egovframework/batch/mapper/job/insa/insa_remote1_to_stg.xml
+++ b/src/main/resources/egovframework/batch/mapper/job/insa/insa_remote1_to_stg.xml
@@ -27,6 +27,12 @@
                          REG_DTTM,
                          MOD_DTTM
                 FROM COMTNEMPLYRINFO
+                <where>
+                        <if test="lastEmplyrId != null">
+                                EMPLYR_ID &gt; #{lastEmplyrId}
+                        </if>
+                </where>
+                ORDER BY EMPLYR_ID
         </select>
 
        <!-- STG DB에 조직 정보 적재 (STG 대상 테이블이 사전 TRUNCATE되므로 중복 갱신 없음) -->


### PR DESCRIPTION
## Summary
- 사원 조회 쿼리에 EMPLYR_ID 기준 정렬과 lastEmplyrId 조건을 추가해 안정적인 페이지 처리를 지원
- Remote1 사원 리더에서 잡 파라미터를 전달해 커서 기반 페이징을 활용할 수 있도록 개선

## Testing
- `mvn -q -DskipTests compile` *(네트워크 단절로 부모 POM을 받을 수 없어 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a1e6c9c0832aaa56695b03ba0d14