### PR TITLE
Replace Egov MyBatis paging reader with MyBatis implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,11 @@
             <artifactId>org.egovframe.rte.fdl.property</artifactId>
             <version>${org.egovframe.rte.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.mybatis.spring.batch</groupId>
+            <artifactId>mybatis-spring-batch</artifactId>
+            <version>2.0.1</version>
+        </dependency>
         <!-- JPA 엔티티를 사용하기 위한 의존성 추가 -->
         <dependency>
             <groupId>javax.persistence</groupId>

--- a/src/main/java/egovframework/bat/job/erp/config/ErpStgToLocalJobConfig.java
+++ b/src/main/java/egovframework/bat/job/erp/config/ErpStgToLocalJobConfig.java
@@ -2,7 +2,7 @@ package egovframework.bat.job.erp.config;
 
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter;
-import org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -34,9 +34,9 @@ public class ErpStgToLocalJobConfig {
      */
     @Bean
     @StepScope
-    public EgovMyBatisPagingItemReader<VehicleInfo> erpStgToLocalVehicleReader(
+    public MyBatisPagingItemReader<VehicleInfo> erpStgToLocalVehicleReader(
             @Qualifier("sqlSessionFactory-stg") SqlSessionFactory sqlSessionFactory) {
-        EgovMyBatisPagingItemReader<VehicleInfo> reader = new EgovMyBatisPagingItemReader<>();
+        MyBatisPagingItemReader<VehicleInfo> reader = new MyBatisPagingItemReader<>();
         reader.setSqlSessionFactory(sqlSessionFactory);
         reader.setQueryId("Vehicle.selectVehicleList");
         reader.setPageSize(100);

--- a/src/main/java/egovframework/bat/job/example/config/MybatisToMybatisJobConfig.java
+++ b/src/main/java/egovframework/bat/job/example/config/MybatisToMybatisJobConfig.java
@@ -1,7 +1,7 @@
 package egovframework.bat.job.example.config;
 
 import org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter;
-import org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -32,9 +32,9 @@ public class MybatisToMybatisJobConfig {
      */
     @Bean
     @StepScope
-    public EgovMyBatisPagingItemReader<CustomerCredit> mybatisItemReader(
+    public MyBatisPagingItemReader<CustomerCredit> mybatisItemReader(
             @Qualifier("example-sqlSessionFactory-remote1") SqlSessionFactory sqlSessionFactory) {
-        EgovMyBatisPagingItemReader<CustomerCredit> reader = new EgovMyBatisPagingItemReader<>();
+        MyBatisPagingItemReader<CustomerCredit> reader = new MyBatisPagingItemReader<>();
         reader.setSqlSessionFactory(sqlSessionFactory);
         reader.setQueryId("Customer.getAllCustomerCredits");
         reader.setPageSize(100);

--- a/src/main/java/egovframework/bat/job/insa/config/InsaRemote1ToStgJobConfig.java
+++ b/src/main/java/egovframework/bat/job/insa/config/InsaRemote1ToStgJobConfig.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter;
-import org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -50,9 +50,9 @@ public class InsaRemote1ToStgJobConfig {
      */
     @Bean
     @StepScope
-    public EgovMyBatisPagingItemReader<Orgnztinfo> remote1ToStgOrgnztReader(
+    public MyBatisPagingItemReader<Orgnztinfo> remote1ToStgOrgnztReader(
             @Qualifier("insa-sqlSessionFactory-remote1") SqlSessionFactory sqlSessionFactory) {
-        EgovMyBatisPagingItemReader<Orgnztinfo> reader = new EgovMyBatisPagingItemReader<>();
+        MyBatisPagingItemReader<Orgnztinfo> reader = new MyBatisPagingItemReader<>();
         reader.setSqlSessionFactory(sqlSessionFactory);
         reader.setQueryId("insaRemToStg.selectOrgnztList");
         reader.setPageSize(100);
@@ -77,10 +77,10 @@ public class InsaRemote1ToStgJobConfig {
      */
     @Bean
     @StepScope
-    public EgovMyBatisPagingItemReader<EmployeeInfo> remote1ToStgEmpReader(
+    public MyBatisPagingItemReader<EmployeeInfo> remote1ToStgEmpReader(
             @Qualifier("insa-sqlSessionFactory-remote1") SqlSessionFactory sqlSessionFactory,
             @Value("#{jobParameters['lastEmplyrId']}") Long lastEmplyrId) {
-        EgovMyBatisPagingItemReader<EmployeeInfo> reader = new EgovMyBatisPagingItemReader<>();
+        MyBatisPagingItemReader<EmployeeInfo> reader = new MyBatisPagingItemReader<>();
         reader.setSqlSessionFactory(sqlSessionFactory);
         reader.setQueryId("insaRemToStg.selectEmployeeList");
         if (lastEmplyrId != null) {

--- a/src/main/java/egovframework/bat/job/insa/config/InsaStgToLocalJobConfig.java
+++ b/src/main/java/egovframework/bat/job/insa/config/InsaStgToLocalJobConfig.java
@@ -2,7 +2,7 @@ package egovframework.bat.job.insa.config;
 
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter;
-import org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -32,9 +32,9 @@ public class InsaStgToLocalJobConfig {
      */
     @Bean
     @StepScope
-    public EgovMyBatisPagingItemReader<Orgnztinfo> stgToLocalOrgnztReader(
+    public MyBatisPagingItemReader<Orgnztinfo> stgToLocalOrgnztReader(
             @Qualifier("sqlSessionFactory-stg") SqlSessionFactory sqlSessionFactory) {
-        EgovMyBatisPagingItemReader<Orgnztinfo> reader = new EgovMyBatisPagingItemReader<>();
+        MyBatisPagingItemReader<Orgnztinfo> reader = new MyBatisPagingItemReader<>();
         reader.setSqlSessionFactory(sqlSessionFactory);
         reader.setQueryId("insaStgToLoc.selectOrgnztList");
         reader.setPageSize(100);


### PR DESCRIPTION
## Summary
- add the mybatis-spring-batch dependency so Spring Batch jobs can use MyBatis readers
- replace usages of EgovMyBatisPagingItemReader with MyBatisPagingItemReader in batch job configs

## Testing
- `mvn -q -DskipTests package` *(실패: 외부 Maven 저장소에 접근할 수 없어 부모 POM을 내려받지 못했습니다)*

------
https://chatgpt.com/codex/tasks/task_e_68d0aad50104832ab4e0efed6bf14102