### PR TITLE
MyBatis Spring 의존성 교체

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,9 +112,9 @@
             <version>${org.egovframe.rte.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.mybatis.spring.batch</groupId>
-            <artifactId>mybatis-spring-batch</artifactId>
-            <version>2.0.1</version>
+            <groupId>org.mybatis</groupId>
+            <artifactId>mybatis-spring</artifactId>
+            <version>2.0.7</version>
         </dependency>
         <!-- JPA 엔티티를 사용하기 위한 의존성 추가 -->
         <dependency>


### PR DESCRIPTION
## Summary
- org.mybatis.spring.batch 의존성을 제거하고 필요한 MyBatis Spring 의존성을 명시적으로 추가했습니다.

## Testing
- mvn dependency:tree *(네트워크 연결 문제로 부모 POM 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ad8aeafc832a80d5d27813a4d9e7