### PR TITLE
feat: chain jobs only on completed status

### DIFF
--- a/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
@@ -11,7 +11,6 @@ import javax.sql.DataSource;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
 import org.quartz.Trigger;
-import org.quartz.listeners.JobChainingJobListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.Job;
@@ -30,6 +29,7 @@ import org.springframework.scheduling.quartz.SchedulerFactoryBean;
 
 import egovframework.bat.common.Constant;
 import egovframework.bat.repository.dto.SchedulerJobDto;
+import egovframework.bat.scheduler.ConditionalJobChainingListener;
 import egovframework.bat.scheduler.EgovQuartzJobLauncher;
 import lombok.RequiredArgsConstructor;
 
@@ -90,8 +90,8 @@ public class BatchSchedulerConfig {
      * 잡 체이닝 리스너
      */
     @Bean
-    public JobChainingJobListener jobChainingJobListener() {
-        JobChainingJobListener listener = new JobChainingJobListener("jobChainingListener");
+    public ConditionalJobChainingListener jobChainingJobListener() {
+        ConditionalJobChainingListener listener = new ConditionalJobChainingListener("jobChainingListener");
         listener.addJobChainLink(new JobKey("insaRemote1ToStgJobDetail", Constant.QUARTZ_BATCH_GROUP),
                 new JobKey("insaStgToLocalJobDetail", Constant.QUARTZ_BATCH_GROUP));
         listener.addJobChainLink(new JobKey("erpRestToStgJobDetail", Constant.QUARTZ_BATCH_GROUP),
@@ -104,12 +104,12 @@ public class BatchSchedulerConfig {
      *
      * <p>application.yml의 {@code scheduler.jobs} 값을 읽어 크론이 있는 잡은
      * {@code CronTrigger}로 등록하고, 크론이 비어 있는 잡은 {@code JobDetail}만 생성한 뒤
-     * {@code JobChainingJobListener}로 체인 처리한다.</p>
+     * {@link ConditionalJobChainingListener}로 체인 처리한다.</p>
      */
     @Bean
     @DependsOn("jobRegistryBeanPostProcessor") // 잡 등록이 완료된 후 스케줄러 생성
     public SchedulerFactoryBean schedulerFactoryBean(JobRegistry jobRegistry,
-            JobChainingJobListener jobChainingJobListener,
+            ConditionalJobChainingListener jobChainingJobListener,
             List<Job> jobBeans,
             @Qualifier("dataSource-stg") DataSource quartzDataSource,
             AutowiringJobFactory autowiringJobFactory,

--- a/src/main/java/egovframework/bat/scheduler/ConditionalJobChainingListener.java
+++ b/src/main/java/egovframework/bat/scheduler/ConditionalJobChainingListener.java
@@ -1,0 +1,63 @@
+package egovframework.bat.scheduler;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.listeners.JobChainingJobListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+
+/**
+ * 배치 잡의 종료 상태를 확인해 성공한 경우에만 후행 Quartz 잡을 기동하는 리스너.
+ */
+public class ConditionalJobChainingListener extends JobChainingJobListener implements JobExecutionListener {
+
+    /** 로그 기록용 로거 */
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConditionalJobChainingListener.class);
+
+    /** 잡별 종료 상태 저장소 (JobDetail 이름 기준) */
+    private final Map<String, ExitStatus> jobExitStatuses = new ConcurrentHashMap<>();
+
+    public ConditionalJobChainingListener(String name) {
+        super(name);
+    }
+
+    @Override
+    public void beforeJob(JobExecution jobExecution) {
+        // 별도의 전처리가 필요하지 않으므로 구현하지 않음
+    }
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        String jobDetailName = jobExecution.getJobInstance().getJobName() + "Detail";
+        ExitStatus exitStatus = jobExecution.getExitStatus();
+        jobExitStatuses.put(jobDetailName, exitStatus);
+        LOGGER.info("잡 '{}' 종료 상태 기록: {}", jobDetailName, exitStatus);
+    }
+
+    @Override
+    public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
+        String jobDetailName = context.getJobDetail().getKey().getName();
+        ExitStatus exitStatus = jobExitStatuses.get(jobDetailName);
+
+        if (ExitStatus.COMPLETED.equals(exitStatus)) {
+            LOGGER.info("잡 '{}'이(가) 성공적으로 완료되어 후행 잡을 기동합니다.", jobDetailName);
+            super.jobWasExecuted(context, jobException);
+        } else {
+            if (exitStatus == null) {
+                LOGGER.warn("잡 '{}'의 종료 상태 정보를 찾을 수 없어 후행 잡을 기동하지 않습니다.", jobDetailName);
+            } else {
+                LOGGER.warn("잡 '{}'의 종료 상태가 '{}'이므로 후행 잡을 기동하지 않습니다.", jobDetailName, exitStatus);
+            }
+        }
+
+        if (jobDetailName != null) {
+            jobExitStatuses.remove(jobDetailName);
+        }
+    }
+}

--- a/src/main/java/egovframework/bat/scheduler/EgovQuartzJobLauncher.java
+++ b/src/main/java/egovframework/bat/scheduler/EgovQuartzJobLauncher.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.quartz.QuartzJobBean;
 
 import egovframework.bat.management.batch.service.JobProgressService;
+import egovframework.bat.scheduler.ConditionalJobChainingListener;
 import egovframework.bat.service.JobLockService;
 
 /**
@@ -75,6 +76,10 @@ public class EgovQuartzJobLauncher extends QuartzJobBean {
         @Autowired
         private JobRegistry jobRegistry;
 
+        /** 잡 체이닝 상태를 관리하는 리스너 */
+        @Autowired
+        private ConditionalJobChainingListener conditionalJobChainingListener;
+
 	@Override
 	@SuppressWarnings("unchecked")
 	protected void executeInternal(JobExecutionContext context) {
@@ -115,6 +120,7 @@ public class EgovQuartzJobLauncher extends QuartzJobBean {
         try {
             LOGGER.info("{} 작업 시작", jobName); // 작업 시작 로그
             JobExecution jobExecution = jobLauncher.run(job, jobParameters);
+            conditionalJobChainingListener.afterJob(jobExecution);
             LOGGER.info("{} 작업 종료, 상태: {}", jobName, jobExecution.getStatus()); // 작업 종료 로그
             jobProgressService.send(jobName, jobExecution.getStatus().toString());
         } catch (JobExecutionException e) {


### PR DESCRIPTION
## Summary
- add ConditionalJobChainingListener to store batch exit status per Quartz job
- update scheduler configuration and launcher to use the new listener when chaining jobs
- log skips so downstream jobs do not start after failures

## Testing
- mvn -q -DskipTests compile *(fails: Non-resolvable parent POM because repo1.maven.org is unreachable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0a7e75800832abeb389bb2017a100