### PR TITLE
feat: rerun truncate step when job restarts

### DIFF
--- a/src/main/java/egovframework/bat/job/insa/config/InsaRemote1ToStgJobConfig.java
+++ b/src/main/java/egovframework/bat/job/insa/config/InsaRemote1ToStgJobConfig.java
@@ -115,6 +115,7 @@ public class InsaRemote1ToStgJobConfig {
             StepCountLogger stepCountLogger) {
         return new StepBuilder("truncateStgTablesStep").repository(jobRepository)
                 .tasklet(truncateStgTablesTasklet)
+                .allowStartIfComplete(true)
                 .transactionManager(transactionManager)
                 .listener(stepCountLogger)
                 .build();


### PR DESCRIPTION
## Summary
- ensure the truncate step permits re-execution after completion by enabling allowStartIfComplete

## Testing
- `mvn -B -DskipTests package` *(fails: cannot download parent POM because external repositories are unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b627f8a4832aa7e1378c529379ef