### PR TITLE
Add MyBatis Spring Batch dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,12 @@
             <artifactId>spring-batch-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- MyBatis 기반 배치 작업 지원을 위한 의존성 추가 -->
+        <dependency>
+            <groupId>org.mybatis</groupId>
+            <artifactId>mybatis-spring-batch</artifactId>
+            <version>2.0.0</version>
+        </dependency>
     </dependencies>
        
     <!-- 환경별 프로필 설정 -->


### PR DESCRIPTION
## Summary
- add the mybatis-spring-batch dependency to support MyBatis-based batch processing

## Testing
- `mvn -q dependency:tree` *(fails: unable to resolve parent POM because the Maven Central repository is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b68c9828832a981a8d10b45dbd33