### PR TITLE
Replace Egov paging reader with MyBatisPagingItemReader

### DIFF
--- a/src/main/java/egovframework/bat/job/erp/config/ErpStgToLocalJobConfig.java
+++ b/src/main/java/egovframework/bat/job/erp/config/ErpStgToLocalJobConfig.java
@@ -2,7 +2,7 @@ package egovframework.bat.job.erp.config;
 
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter;
-import org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -34,9 +34,9 @@ public class ErpStgToLocalJobConfig {
      */
     @Bean
     @StepScope
-    public EgovMyBatisPagingItemReader<VehicleInfo> erpStgToLocalVehicleReader(
+    public MyBatisPagingItemReader<VehicleInfo> erpStgToLocalVehicleReader(
             @Qualifier("sqlSessionFactory-stg") SqlSessionFactory sqlSessionFactory) {
-        EgovMyBatisPagingItemReader<VehicleInfo> reader = new EgovMyBatisPagingItemReader<>();
+        MyBatisPagingItemReader<VehicleInfo> reader = new MyBatisPagingItemReader<>();
         reader.setSqlSessionFactory(sqlSessionFactory);
         reader.setQueryId("Vehicle.selectVehicleList");
         reader.setPageSize(100);

--- a/src/main/java/egovframework/bat/job/example/config/MybatisToMybatisJobConfig.java
+++ b/src/main/java/egovframework/bat/job/example/config/MybatisToMybatisJobConfig.java
@@ -1,7 +1,7 @@
 package egovframework.bat.job.example.config;
 
 import org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter;
-import org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -32,9 +32,9 @@ public class MybatisToMybatisJobConfig {
      */
     @Bean
     @StepScope
-    public EgovMyBatisPagingItemReader<CustomerCredit> mybatisItemReader(
+    public MyBatisPagingItemReader<CustomerCredit> mybatisItemReader(
             @Qualifier("example-sqlSessionFactory-remote1") SqlSessionFactory sqlSessionFactory) {
-        EgovMyBatisPagingItemReader<CustomerCredit> reader = new EgovMyBatisPagingItemReader<>();
+        MyBatisPagingItemReader<CustomerCredit> reader = new MyBatisPagingItemReader<>();
         reader.setSqlSessionFactory(sqlSessionFactory);
         reader.setQueryId("Customer.getAllCustomerCredits");
         reader.setPageSize(100);

--- a/src/main/java/egovframework/bat/job/insa/config/InsaRemote1ToStgJobConfig.java
+++ b/src/main/java/egovframework/bat/job/insa/config/InsaRemote1ToStgJobConfig.java
@@ -2,7 +2,7 @@ package egovframework.bat.job.insa.config;
 
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter;
-import org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -46,9 +46,9 @@ public class InsaRemote1ToStgJobConfig {
      */
     @Bean
     @StepScope
-    public EgovMyBatisPagingItemReader<Orgnztinfo> remote1ToStgOrgnztReader(
+    public MyBatisPagingItemReader<Orgnztinfo> remote1ToStgOrgnztReader(
             @Qualifier("insa-sqlSessionFactory-remote1") SqlSessionFactory sqlSessionFactory) {
-        EgovMyBatisPagingItemReader<Orgnztinfo> reader = new EgovMyBatisPagingItemReader<>();
+        MyBatisPagingItemReader<Orgnztinfo> reader = new MyBatisPagingItemReader<>();
         reader.setSqlSessionFactory(sqlSessionFactory);
         reader.setQueryId("insaRemToStg.selectOrgnztList");
         reader.setPageSize(100);
@@ -73,9 +73,9 @@ public class InsaRemote1ToStgJobConfig {
      */
     @Bean
     @StepScope
-    public EgovMyBatisPagingItemReader<EmployeeInfo> remote1ToStgEmpReader(
+    public MyBatisPagingItemReader<EmployeeInfo> remote1ToStgEmpReader(
             @Qualifier("insa-sqlSessionFactory-remote1") SqlSessionFactory sqlSessionFactory) {
-        EgovMyBatisPagingItemReader<EmployeeInfo> reader = new EgovMyBatisPagingItemReader<>();
+        MyBatisPagingItemReader<EmployeeInfo> reader = new MyBatisPagingItemReader<>();
         reader.setSqlSessionFactory(sqlSessionFactory);
         reader.setQueryId("insaRemToStg.selectEmployeeList");
         reader.setPageSize(100);

--- a/src/main/java/egovframework/bat/job/insa/config/InsaStgToLocalJobConfig.java
+++ b/src/main/java/egovframework/bat/job/insa/config/InsaStgToLocalJobConfig.java
@@ -2,7 +2,7 @@ package egovframework.bat.job.insa.config;
 
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.egovframe.rte.bat.core.item.database.EgovMyBatisBatchItemWriter;
-import org.egovframe.rte.bat.core.item.database.EgovMyBatisPagingItemReader;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -32,9 +32,9 @@ public class InsaStgToLocalJobConfig {
      */
     @Bean
     @StepScope
-    public EgovMyBatisPagingItemReader<Orgnztinfo> stgToLocalOrgnztReader(
+    public MyBatisPagingItemReader<Orgnztinfo> stgToLocalOrgnztReader(
             @Qualifier("sqlSessionFactory-stg") SqlSessionFactory sqlSessionFactory) {
-        EgovMyBatisPagingItemReader<Orgnztinfo> reader = new EgovMyBatisPagingItemReader<>();
+        MyBatisPagingItemReader<Orgnztinfo> reader = new MyBatisPagingItemReader<>();
         reader.setSqlSessionFactory(sqlSessionFactory);
         reader.setQueryId("insaStgToLoc.selectOrgnztList");
         reader.setPageSize(100);


### PR DESCRIPTION
## Summary
- eGovFrame의 페이징 리더 사용 구간을 org.mybatis.spring.batch.MyBatisPagingItemReader로 교체했습니다.
- 각 리더 빈에서 MyBatisPagingItemReader를 생성하도록 수정했습니다.

## Testing
- mvn clean compile *(네트워크 차단으로 부모 POM을 받을 수 없어 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68d0b84dac38832a81dc86ae5f505155