### PR TITLE
feat: apply start/end date parameters to INSA staging job

### DIFF
--- a/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
+++ b/src/main/java/egovframework/bat/config/BatchSchedulerConfig.java
@@ -28,6 +28,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.quartz.CronTriggerFactoryBean;
 import org.springframework.scheduling.quartz.JobDetailFactoryBean;
 import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+import org.springframework.util.StringUtils;
 
 import egovframework.bat.common.Constant;
 import egovframework.bat.repository.dto.SchedulerJobDto;
@@ -50,8 +51,8 @@ public class BatchSchedulerConfig {
     /** application.yml에서 읽어 온 scheduler 정보 */
     private final SchedulerProps schedulerProps;
 
-    @Value("${startDate}") private String startDate;
-    @Value("${endDate}") private String endDate;
+    @Value("${startDate:}") private String startDate;
+    @Value("${endDate:}") private String endDate;
 
     /**
      * 공통 JobDetail 생성 메서드
@@ -211,9 +212,13 @@ public class BatchSchedulerConfig {
     	// 추가 데이터 넣는 예시
         if ("insaStgToLocalJob".equals(jobName)) {
             Map<String, Object> extra = new HashMap<>();
-            extra.put("startDate", startDate);	//java -jar MyApp.jar -DstartDate=20250101 -DendDate=20250131
-            extra.put("endDate", endDate);		//java -jar MyApp.jar -DstartDate=20250101 -DendDate=20250131
-            return extra;
+            if (StringUtils.hasText(startDate)) {
+                extra.put("startDate", startDate);	//java -jar MyApp.jar -DstartDate=20250101 -DendDate=20250131
+            }
+            if (StringUtils.hasText(endDate)) {
+                extra.put("endDate", endDate);		//java -jar MyApp.jar -DstartDate=20250101 -DendDate=20250131
+            }
+            return extra.isEmpty() ? null : extra;
         }
         
         return null;

--- a/src/main/java/egovframework/bat/job/insa/config/InsaStgToLocalJobConfig.java
+++ b/src/main/java/egovframework/bat/job/insa/config/InsaStgToLocalJobConfig.java
@@ -13,6 +13,7 @@ import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -76,10 +77,15 @@ public class InsaStgToLocalJobConfig {
      * 사원 정보를 동기화하는 Tasklet 빈.
      */
     @Bean
+    @StepScope
     public StgToLocalEmployeeTasklet stgToLocalEmployeeTasklet(
-            @Qualifier("sqlSessionFactory-local") SqlSessionFactory sqlSessionFactory) {
+            @Qualifier("sqlSessionFactory-local") SqlSessionFactory sqlSessionFactory,
+            @Value("#{jobParameters['startDate']}") String startDate,
+            @Value("#{jobParameters['endDate']}") String endDate) {
         StgToLocalEmployeeTasklet tasklet = new StgToLocalEmployeeTasklet();
         tasklet.setSqlSessionFactory(sqlSessionFactory);
+        tasklet.setStartDate(startDate);
+        tasklet.setEndDate(endDate);
         return tasklet;
     }
 

--- a/src/main/java/egovframework/bat/job/insa/tasklet/StgToLocalEmployeeTasklet.java
+++ b/src/main/java/egovframework/bat/job/insa/tasklet/StgToLocalEmployeeTasklet.java
@@ -1,11 +1,15 @@
 package egovframework.bat.job.insa.tasklet;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.util.StringUtils;
 
 /**
  * 스테이징 DB와 로컬 DB의 사원 정보를 동기화하는 Tasklet.
@@ -16,6 +20,12 @@ public class StgToLocalEmployeeTasklet implements Tasklet {
     /** MyBatis SqlSessionFactory */
     private SqlSessionFactory sqlSessionFactory;
 
+    /** 배치 실행 파라미터: 시작일자(yyyyMMdd) */
+    private String startDate;
+
+    /** 배치 실행 파라미터: 종료일자(yyyyMMdd) */
+    private String endDate;
+
     /**
      * SqlSessionFactory 주입
      * @param sqlSessionFactory 로컬 DB용 SqlSessionFactory
@@ -24,15 +34,34 @@ public class StgToLocalEmployeeTasklet implements Tasklet {
         this.sqlSessionFactory = sqlSessionFactory;
     }
 
+    /**
+     * 시작일자 파라미터 주입
+     *
+     * @param startDate 시작일자(yyyyMMdd)
+     */
+    public void setStartDate(String startDate) {
+        this.startDate = startDate;
+    }
+
+    /**
+     * 종료일자 파라미터 주입
+     *
+     * @param endDate 종료일자(yyyyMMdd)
+     */
+    public void setEndDate(String endDate) {
+        this.endDate = endDate;
+    }
+
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
         try (SqlSession session = sqlSessionFactory.openSession()) {
+            Map<String, Object> params = buildParameterMap();
             // 기존 사원 정보 갱신
-            int updateCount = session.update("insaStgToLoc.updateEmployee");
+            int updateCount = session.update("insaStgToLoc.updateEmployee", params);
             // ESNTL_ID 시퀀스 초기화
             session.update("insaStgToLoc.initEmployeeSeq");
             // 신규 사원 정보 추가
-            int insertCount = session.insert("insaStgToLoc.insertEmployeeIncremental");
+            int insertCount = session.insert("insaStgToLoc.insertEmployeeIncremental", params);
             session.commit();
 
             // 처리 건수를 스텝 컨트리뷰션에 반영
@@ -42,5 +71,21 @@ public class StgToLocalEmployeeTasklet implements Tasklet {
             contribution.incrementWriteCount(total);
         }
         return RepeatStatus.FINISHED;
+    }
+
+    /**
+     * 잡 파라미터(startDate, endDate)를 MyBatis에 전달할 Map으로 구성한다.
+     *
+     * @return MyBatis 파라미터 맵
+     */
+    private Map<String, Object> buildParameterMap() {
+        Map<String, Object> params = new HashMap<>();
+        if (StringUtils.hasText(startDate)) {
+            params.put("startDate", startDate);
+        }
+        if (StringUtils.hasText(endDate)) {
+            params.put("endDate", endDate);
+        }
+        return params;
     }
 }

--- a/src/main/resources/egovframework/batch/mapper/job/insa/insa_stg_to_local.xml
+++ b/src/main/resources/egovframework/batch/mapper/job/insa/insa_stg_to_local.xml
@@ -28,6 +28,13 @@
                          REG_DTTM,
                          MOD_DTTM
                 FROM migstg.COMTNEMPLYRINFO
+                WHERE 1 = 1
+                <if test="startDate != null and startDate != ''">
+                        AND COALESCE(MOD_DTTM, REG_DTTM) <![CDATA[>=]]> STR_TO_DATE(#{startDate}, '%Y%m%d')
+                </if>
+                <if test="endDate != null and endDate != ''">
+                        AND COALESCE(MOD_DTTM, REG_DTTM) <![CDATA[<]]> DATE_ADD(STR_TO_DATE(#{endDate}, '%Y%m%d'), INTERVAL 1 DAY)
+                </if>
         </select>
 
         <!-- EMPLYR_ID를 기준으로 기존 사원 정보를 갱신 -->
@@ -45,6 +52,13 @@
                     u.EMPLYR_STTUS_CODE = s.EMPLYR_STTUS_CODE,
                     u.REG_DTTM = s.REG_DTTM,
                     u.MOD_DTTM = s.MOD_DTTM
+                WHERE 1 = 1
+                <if test="startDate != null and startDate != ''">
+                        AND COALESCE(s.MOD_DTTM, s.REG_DTTM) <![CDATA[>=]]> STR_TO_DATE(#{startDate}, '%Y%m%d')
+                </if>
+                <if test="endDate != null and endDate != ''">
+                        AND COALESCE(s.MOD_DTTM, s.REG_DTTM) <![CDATA[<]]> DATE_ADD(STR_TO_DATE(#{endDate}, '%Y%m%d'), INTERVAL 1 DAY)
+                </if>
         </update>
 
        <!-- 신규 사원 추가 전에 ESNTL_ID 시퀀스 초기화 -->
@@ -63,6 +77,12 @@
                FROM migstg.COMTNEMPLYRINFO s
                LEFT JOIN egovlocal.COMTNEMPLYRINFO u ON u.EMPLYR_ID = s.EMPLYR_ID
                WHERE u.EMPLYR_ID IS NULL
+               <if test="startDate != null and startDate != ''">
+                       AND COALESCE(s.MOD_DTTM, s.REG_DTTM) <![CDATA[>=]]> STR_TO_DATE(#{startDate}, '%Y%m%d')
+               </if>
+               <if test="endDate != null and endDate != ''">
+                       AND COALESCE(s.MOD_DTTM, s.REG_DTTM) <![CDATA[<]]> DATE_ADD(STR_TO_DATE(#{endDate}, '%Y%m%d'), INTERVAL 1 DAY)
+               </if>
        </insert>
 
         <!-- 로컬 DB에 조직 정보 적재 -->


### PR DESCRIPTION
## Summary
- propagate optional `startDate`/`endDate` parameters from the Quartz scheduler to the INSA STG→Local job
- inject the job parameters into the STG→Local employee tasklet and forward them to MyBatis statements
- update the INSA STG→Local mapper to filter updates/inserts with the provided date range

## Testing
- `mvn -q test` *(fails: Maven cannot download the parent POM because external network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d377b44228832a903953b6d267c73d