### PR TITLE
Pass start/end date parameters through insa remote job

### DIFF
--- a/src/main/java/egovframework/bat/job/insa/api/Remote1ToStgJobController.java
+++ b/src/main/java/egovframework/bat/job/insa/api/Remote1ToStgJobController.java
@@ -6,6 +6,7 @@ import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import egovframework.bat.job.common.api.JobRunController;
@@ -26,13 +27,23 @@ public class Remote1ToStgJobController {
      * Remote1 데이터를 STG로 적재한다.
      *
      * @param startDate 시작날짜 (선택)
-     * @param endDate 시작날짜 (선택)
+     * @param endDate 종료날짜 (선택)
      * @return 배치 잡 실행 결과 상태
      */
     @PostMapping("/remote1-to-stg")
-    public ResponseEntity<BatchStatus> runRemote1ToStgJob() {
+    public ResponseEntity<BatchStatus> runRemote1ToStgJob(
+            @RequestParam(value = "startDate", required = false) String startDate,
+            @RequestParam(value = "endDate", required = false) String endDate) {
         JobParametersBuilder builder = new JobParametersBuilder()
-            .addLong("timestamp", System.currentTimeMillis());	//add를 여러개 연결해서 추가할수 있음. ExampleJobController참고
+                .addLong("timestamp", System.currentTimeMillis());  //add를 여러개 연결해서 추가할수 있음. ExampleJobController참고
+
+        if (startDate != null && !startDate.isBlank()) {
+            builder.addString("startDate", startDate.trim());
+        }
+        if (endDate != null && !endDate.isBlank()) {
+            builder.addString("endDate", endDate.trim());
+        }
+
         JobParameters jobParameters = builder.toJobParameters();
         return jobRunController.execute("insaRemote1ToStgJob", jobParameters);
     }

--- a/src/main/resources/egovframework/batch/mapper/job/insa/insa_remote1_to_stg.xml
+++ b/src/main/resources/egovframework/batch/mapper/job/insa/insa_remote1_to_stg.xml
@@ -13,7 +13,7 @@
         </select>
 
         <!-- remote1 DB에서 STG 이관 시 ESNTL_ID와 SOURCE_SYSTEM을 제외하여 조회 -->
-        <select id="selectEmployeeList" resultType="egovframework.bat.job.insa.domain.EmployeeInfo">
+        <select id="selectEmployeeList" parameterType="map" resultType="egovframework.bat.job.insa.domain.EmployeeInfo">
                 SELECT
                          EMPLYR_ID,
                          ORGNZT_ID,
@@ -27,6 +27,20 @@
                          REG_DTTM,
                          MOD_DTTM
                 FROM COMTNEMPLYRINFO
+                <where>
+                        <if test="startDate != null">
+                                AND (
+                                        (REG_DTTM <![CDATA[>=]]> STR_TO_DATE(#{startDate}, '%Y%m%d%H%i%s'))
+                                        OR (MOD_DTTM <![CDATA[>=]]> STR_TO_DATE(#{startDate}, '%Y%m%d%H%i%s'))
+                                )
+                        </if>
+                        <if test="endDate != null">
+                                AND (
+                                        (REG_DTTM <![CDATA[<=]]> STR_TO_DATE(#{endDate}, '%Y%m%d%H%i%s'))
+                                        OR (MOD_DTTM <![CDATA[<=]]> STR_TO_DATE(#{endDate}, '%Y%m%d%H%i%s'))
+                                )
+                        </if>
+                </where>
                 ORDER BY EMPLYR_ID ASC
                 LIMIT #{_skiprows}, #{_pagesize}
         </select>


### PR DESCRIPTION
## Summary
- allow the Remote1-to-STG API to accept optional start/end date request parameters and include them in the job parameters
- normalize job parameters inside the job configuration and apply them to the MyBatis reader so the XML mapper filters employees by the supplied date range

## Testing
- `mvn -q -DskipTests package` *(fails: cannot resolve Spring Boot parent POM because the Maven central repository is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d37de2b818832abe30c43533a3506a